### PR TITLE
fix: apply a bandage to help with some flaky tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,8 +38,13 @@ jobs:
           profile: minimal
           override: true
 
+      - name: Install tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: Build
         run: cargo build --all-targets --verbose
 
       - name: Run tests
-        run: cargo test --verbose
+        run: ./test.sh ci

--- a/src/network/simulated/core.rs
+++ b/src/network/simulated/core.rs
@@ -256,6 +256,7 @@ mod tests {
     const ACCURACY: f64 = 0.05;
 
     #[tokio::test]
+    #[ignore]
     async fn symmetric() {
         // set up network with two nodes
         let msg = NetworkMessage::Ping;
@@ -290,6 +291,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore]
     async fn asymmetric() {
         // set up network with two nodes
         let msg = NetworkMessage::Ping;

--- a/test.sh
+++ b/test.sh
@@ -31,7 +31,7 @@ fast_tests () {
 sequential_tests () {
 	echo "Running sequential tests!"
 	sleep 1
-	RUST_BACKTRACE=1 cargo test --release -- test-threads=1 --ignored \
+	RUST_BACKTRACE=1 cargo test -- test-threads=1 --ignored \
 		network::simulated::core::tests::asymmetric \
 		network::simulated::core::tests::symmetric
 }

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ $# -gt 0 ] && [ $1 == "slow" ]; then
+slow_tests () {
 	echo "🐌 Running slow tests can take up to 10 minutes!"
 	echo "Starting in 3 seconds..."
 	sleep 3
@@ -20,8 +20,29 @@ if [ $# -gt 0 ] && [ $1 == "slow" ]; then
 		three_nodes \
 		three_nodes_crash && \
 	RUST_BACKTRACE=1 cargo test
-else
-	echo "🚀 Running fast tests only!"
+}
+
+fast_tests () {
+	echo "🚀 Running fast tests!"
 	sleep 1
 	RUST_BACKTRACE=1 cargo nextest run
+}
+
+sequential_tests () {
+	echo "Running sequential tests!"
+	sleep 1
+	RUST_BACKTRACE=1 cargo test --release -- test-threads=1 --ignored \
+		network::simulated::core::tests::asymmetric \
+		network::simulated::core::tests::symmetric
+}
+
+if [ $# -gt 0 ] && [ $1 == "slow" ]; then
+	slow_tests
+elif [ $# -gt 0 ] && [ $1 == "ci" ]; then
+	fast_tests && \
+		sequential_tests
+elif [ $# -gt 0 ] && [ $1 == "sequential" ]; then
+	sequential_tests
+else
+	fast_tests
 fi


### PR DESCRIPTION
`symmetric` and `asymmetric` are doing latency measurements and require in essence a dedicated core to have a high chance of succeeding.  This PR sets things up so that on CI, they run separately from the rest of the tests and while running, they have a high chance of not getting interrupted by other tests.  

The PR also refactors some of the code into functions to help with code reuse.