### PR TITLE
fix: do not hold blockstore lock while holding the pool lock

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -369,11 +369,9 @@ where
             for s in shreds {
                 self.disseminator.send(&s).await?;
                 // PERF: move expensive add_shred() call out of block production
-                let mut blockstore = self.blockstore.write().await;
-                let block = blockstore.add_shred(s, true).await;
+                let block = self.blockstore.write().await.add_shred(s, true).await;
                 if let Some((slot, block_info)) = block {
-                    let mut pool = self.pool.write().await;
-                    pool.add_block(slot, block_info).await;
+                    self.pool.write().await.add_block(slot, block_info).await;
                 }
             }
 


### PR DESCRIPTION
I haven't done a proper investigation if this is dangerous but it seems like we do not need need to hold the two locks at the same time so minor refactoring.