### PR TITLE
chore: make extreme_rate a sequential test

### DIFF
--- a/src/network/simulated/core.rs
+++ b/src/network/simulated/core.rs
@@ -255,6 +255,8 @@ mod tests {
     // test simulated latency accuracy to within +/-5%
     const ACCURACY: f64 = 0.05;
 
+    // When run concurrently with other tests on github, then the test fails.
+    // Running sequentially seems to help.
     #[tokio::test]
     #[ignore]
     async fn symmetric() {
@@ -290,6 +292,8 @@ mod tests {
         assert!(latency < max);
     }
 
+    // When run concurrently with other tests on github, then the test fails.
+    // Running sequentially seems to help.
     #[tokio::test]
     #[ignore]
     async fn asymmetric() {

--- a/src/network/simulated/token_bucket.rs
+++ b/src/network/simulated/token_bucket.rs
@@ -91,7 +91,10 @@ mod tests {
         token_bucket_experiment(100 * 1024 * 1024, 500_000, 1500).await;
     }
 
+    // When run concurrently with other tests on github, then the test fails.
+    // Running sequentially seems to help.
     #[tokio::test]
+    #[ignore]
     async fn extreme_rate() {
         // 1 GiB/s : 5M packets a 1500 bytes
         token_bucket_experiment(1024 * 1024 * 1024, 5_000_000, 1500).await;

--- a/test.sh
+++ b/test.sh
@@ -33,7 +33,8 @@ sequential_tests () {
 	sleep 1
 	RUST_BACKTRACE=1 cargo test -- test-threads=1 --ignored \
 		network::simulated::core::tests::asymmetric \
-		network::simulated::core::tests::symmetric
+		network::simulated::core::tests::symmetric \
+		network::simulated::core::tests::extreme_rate
 }
 
 if [ $# -gt 0 ] && [ $1 == "slow" ]; then


### PR DESCRIPTION
This test is starting to fail on github some times.  Making is sequential might help.

Also adds minor comments to other sequential tests.