### PR TITLE
Refactored `Transaction` out of `NetworkMessage`

### DIFF
--- a/src/all2all/robust.rs
+++ b/src/all2all/robust.rs
@@ -45,7 +45,7 @@ impl<N: Network> All2All for RobustAll2All<N> {
     }
 
     async fn receive(&self) -> Result<NetworkMessage, NetworkError> {
-        self.network.receive().await
+        self.network.receive::<NetworkMessage>().await
         // loop {
         //     let msg = self.network.receive().await;
         //     match msg {

--- a/src/all2all/trivial.rs
+++ b/src/all2all/trivial.rs
@@ -40,7 +40,7 @@ impl<N: Network> All2All for TrivialAll2All<N> {
     }
 
     async fn receive(&self) -> Result<NetworkMessage, NetworkError> {
-        self.network.receive().await
+        self.network.receive::<NetworkMessage>().await
     }
 }
 

--- a/src/consensus/produce_block.rs
+++ b/src/consensus/produce_block.rs
@@ -5,7 +5,6 @@ use color_eyre::Result;
 use either::Either;
 use fastrace::Span;
 use log::{info, warn};
-use serde::{Deserialize, Serialize};
 use static_assertions::const_assert;
 
 use crate::MAX_TRANSACTION_SIZE;

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -10,7 +10,7 @@ use rand::prelude::*;
 use sampling_strategy::PartitionSampler;
 
 use crate::consensus::EpochInfo;
-use crate::network::{Network, NetworkError, NetworkMessage};
+use crate::network::{Network, NetworkError, NetworkMessage, SerializableMessage};
 use crate::shredder::Shred;
 use crate::{Slot, ValidatorId};
 
@@ -115,7 +115,7 @@ impl<N: Network, S: SamplingStrategy + Sync + Send + 'static> Disseminator for R
 
     async fn receive(&self) -> Result<Shred, NetworkError> {
         loop {
-            match self.network.receive().await? {
+            match self.network.receive::<NetworkMessage>().await? {
                 NetworkMessage::Shred(s) => return Ok(s),
                 m => warn!("unexpected message type for Rotor: {m:?}"),
             }

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -41,7 +41,7 @@ impl<N: Network> Disseminator for TrivialDisseminator<N> {
 
     async fn receive(&self) -> Result<Shred, NetworkError> {
         loop {
-            match self.network.receive().await? {
+            match self.network.receive::<NetworkMessage>().await? {
                 NetworkMessage::Shred(s) => return Ok(s),
                 m => warn!("unexpected message type for disseminator: {m:?}"),
             }

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -141,7 +141,7 @@ impl<N: Network> Disseminator for Turbine<N> {
 
     async fn receive(&self) -> Result<Shred, NetworkError> {
         loop {
-            match self.network.receive().await? {
+            match self.network.receive::<NetworkMessage>().await? {
                 NetworkMessage::Shred(s) => return Ok(s),
                 m => warn!("unexpected message type for Turbine: {m:?}"),
             }

--- a/src/network.rs
+++ b/src/network.rs
@@ -162,8 +162,9 @@ pub trait Network: Send + Sync {
 
     // TODO: implement brodcast at `Network` level?
 
-    fn receive<SM: SerializableMessage>(&self) -> 
-        impl Future<Output = Result<SM, NetworkError>> + Send;
+    fn receive<SM: SerializableMessage>(
+        &self,
+    ) -> impl Future<Output = Result<SM, NetworkError>> + Send;
 
     fn parse_addr(str: impl AsRef<str>) -> Result<Self::Address, NetworkError>
     where

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -103,6 +103,7 @@ mod tests {
     use super::*;
 
     use crate::crypto::signature::SecretKey;
+    use crate::network::NetworkMessage;
     use crate::shredder::{
         DATA_SHREDS, MAX_DATA_PER_SLICE, RegularShredder, Shredder, Slice, TOTAL_SHREDS,
     };

--- a/src/network/simulated/core.rs
+++ b/src/network/simulated/core.rs
@@ -275,7 +275,7 @@ mod tests {
         // one direction
         net1.send(&msg, "1").await.unwrap();
         let now = Instant::now();
-        let _ = net2.receive().await.unwrap();
+        let _: NetworkMessage = net2.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
         let min = (10_000.0 * (1.0 - ACCURACY)) as u128;
         let max = (10_000.0 * (1.0 + ACCURACY)) as u128;
@@ -285,7 +285,7 @@ mod tests {
         // other direction
         net2.send(&msg, "0").await.unwrap();
         let now = Instant::now();
-        let _ = net1.receive().await.unwrap();
+        let _: NetworkMessage = net1.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
         let min = (10_000.0 * (1.0 - ACCURACY)) as u128;
         let max = (10_000.0 * (1.0 + ACCURACY)) as u128;
@@ -315,7 +315,7 @@ mod tests {
         // one direction
         net1.send(&msg, "1").await.unwrap();
         let now = Instant::now();
-        let _ = net2.receive().await.unwrap();
+        let _: NetworkMessage = net2.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
         let min = (10_000.0 * (1.0 - ACCURACY)) as u128;
         let max = (10_000.0 * (1.0 + ACCURACY)) as u128;
@@ -331,7 +331,7 @@ mod tests {
         // other direction
         net2.send(&msg, "0").await.unwrap();
         let now = Instant::now();
-        let _ = net1.receive().await.unwrap();
+        let _: NetworkMessage = net1.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
         let min = (100_000.0 * (1.0 - ACCURACY)) as u128;
         let max = (100_000.0 * (1.0 + ACCURACY)) as u128;

--- a/src/network/udp.rs
+++ b/src/network/udp.rs
@@ -88,6 +88,7 @@ impl Network for UdpNetwork {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::network::NetworkMessage;
 
     #[tokio::test]
     async fn ping() {

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -207,7 +207,7 @@ impl<N: Network> Repair<N> {
     /// Returns [`NetworkError`] if the underlying network fails.
     pub async fn receive(&self) -> Result<RepairMessage, NetworkError> {
         loop {
-            match self.network.receive().await? {
+            match self.network.receive::<NetworkMessage>().await? {
                 NetworkMessage::Repair(r) => return Ok(r),
                 m => warn!("unexpected message type for repair: {m:?}"),
             }


### PR DESCRIPTION
 - Transaction is now its own type
 - I tried to follow conventional naming, and least amount of changes possible for this
 - not sure also whether I put those new elements in the right files, but the imports seem to be cleaner
 - implicit typing doesn't seem to be an option in this case