### PR TITLE
refactor: Introduce a Slot type

### DIFF
--- a/benches/disseminator.rs
+++ b/benches/disseminator.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use alpenglow::Slot;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Turbine;
 use alpenglow::network::UdpNetwork;
@@ -28,7 +29,7 @@ fn turbine_tree(bencher: divan::Bencher) {
             let mut slice_data = vec![0; MAX_DATA_PER_SLICE];
             rng.fill_bytes(&mut slice_data);
             let slice = Slice {
-                slot: 0,
+                slot: Slot::new(0),
                 slice_index: 0,
                 is_last: true,
                 merkle_root: None,

--- a/benches/network.rs
+++ b/benches/network.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use alpenglow::Slot;
 use alpenglow::consensus::Vote;
 use alpenglow::crypto::{Hash, aggsig, signature};
 use alpenglow::network::NetworkMessage;
@@ -22,7 +23,7 @@ fn serialize_vote(bencher: divan::Bencher) {
             let mut hash = Hash::default();
             rng.fill_bytes(&mut hash);
             let sk = aggsig::SecretKey::new(&mut rng);
-            NetworkMessage::Vote(Vote::new_notar(0, hash, &sk, 0))
+            NetworkMessage::Vote(Vote::new_notar(Slot::new(0), hash, &sk, 0))
         })
         .bench_values(|msg: NetworkMessage| msg.to_bytes());
 }
@@ -36,7 +37,7 @@ fn deserialize_vote(bencher: divan::Bencher) {
             let mut hash = Hash::default();
             rng.fill_bytes(&mut hash);
             let sk = aggsig::SecretKey::new(&mut rng);
-            let msg = NetworkMessage::Vote(Vote::new_notar(0, hash, &sk, 0));
+            let msg = NetworkMessage::Vote(Vote::new_notar(Slot::new(0), hash, &sk, 0));
             msg.to_bytes()
         })
         .bench_values(|bytes: Vec<u8>| NetworkMessage::from_bytes(&bytes));
@@ -52,7 +53,7 @@ fn serialize_slice(bencher: divan::Bencher) {
             let mut slice_data = vec![0; MAX_DATA_PER_SLICE];
             rng.fill_bytes(&mut slice_data);
             let slice = Slice {
-                slot: 0,
+                slot: Slot::new(0),
                 slice_index: 0,
                 is_last: true,
                 merkle_root: None,
@@ -79,7 +80,7 @@ fn serialize_slice_into(bencher: divan::Bencher) {
             let mut slice_data = vec![0; MAX_DATA_PER_SLICE];
             rng.fill_bytes(&mut slice_data);
             let slice = Slice {
-                slot: 0,
+                slot: Slot::new(0),
                 slice_index: 0,
                 is_last: true,
                 merkle_root: None,
@@ -110,7 +111,7 @@ fn deserialize_slice(bencher: divan::Bencher) {
             let mut slice_data = vec![0; MAX_DATA_PER_SLICE];
             rng.fill_bytes(&mut slice_data);
             let slice = Slice {
-                slot: 0,
+                slot: Slot::new(0),
                 slice_index: 0,
                 is_last: true,
                 merkle_root: None,

--- a/benches/shredder.rs
+++ b/benches/shredder.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use alpenglow::Slot;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::shredder::{
     AontShredder, CodingOnlyShredder, DATA_SHREDS, PetsShredder, RegularShredder, Shred, Shredder,
@@ -24,7 +25,7 @@ fn shred<S: Shredder>(bencher: divan::Bencher) {
             let mut slice_data = vec![0; size];
             rng.fill_bytes(&mut slice_data);
             let slice = Slice {
-                slot: 0,
+                slot: Slot::new(0),
                 slice_index: 0,
                 is_last: true,
                 merkle_root: None,
@@ -49,7 +50,7 @@ fn deshred<S: Shredder>(bencher: divan::Bencher) {
             let mut slice_data = vec![0; size];
             rng.fill_bytes(&mut slice_data);
             let slice = Slice {
-                slot: 0,
+                slot: Slot::new(0),
                 slice_index: 0,
                 is_last: true,
                 merkle_root: None,

--- a/src/bin/performance_test.rs
+++ b/src/bin/performance_test.rs
@@ -13,7 +13,7 @@ use alpenglow::disseminator::Rotor;
 use alpenglow::disseminator::rotor::StakeWeightedSampler;
 use alpenglow::network::simulated::SimulatedNetworkCore;
 use alpenglow::network::{SimulatedNetwork, UdpNetwork};
-use alpenglow::{Alpenglow, ValidatorInfo, logging};
+use alpenglow::{Alpenglow, Slot, ValidatorInfo, logging};
 use color_eyre::Result;
 use log::info;
 
@@ -127,7 +127,7 @@ async fn latency_test(num_nodes: usize) {
     // spawn a thread checking pool for progress
     let cancel_tokens = node_cancel_tokens.clone();
     let liveness_tester = tokio::spawn(async move {
-        let mut finalized = vec![0; pools.len()];
+        let mut finalized = vec![Slot::new(0); pools.len()];
         let mut times = vec![Instant::now(); pools.len()];
         loop {
             tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -51,8 +51,6 @@ pub use pool::{AddVoteError, Pool};
 pub use vote::Vote;
 use votor::Votor;
 
-/// Number of slots in each epoch.
-pub const SLOTS_PER_EPOCH: u64 = 18_000;
 /// Time bound assumed on network transmission delays during periods of synchrony.
 const DELTA: Duration = Duration::from_millis(400);
 /// Time the leader has for producing and sending the block.

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -135,7 +135,7 @@ async fn wait_for_first_slot(
             let handle = tokio::spawn(async move {
                 // PERF: These are burning a CPU. Can we use async here?
                 loop {
-                    let last_slot_in_prev_window = first_slot_in_window.last_slot_in_prev_window();
+                    let last_slot_in_prev_window = first_slot_in_window.prev();
                     if let Some(hash) = blockstore
                         .read()
                         .await

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -106,15 +106,13 @@ pub struct Alpenglow<A: All2All, D: Disseminator, R: Network, T: Network> {
 async fn wait_for_first_slot(
     pool: Arc<RwLock<Pool>>,
     blockstore: Arc<RwLock<Blockstore>>,
-    window: Slot,
+    first_slot_in_window: Slot,
 ) -> Option<(Slot, Hash, bool)> {
-    // genesis
-    if window == 0 {
-        return Some((0, Hash::default(), false));
+    if first_slot_in_window.is_genesis_window() {
+        return Some((Slot::new(0), Hash::default(), false));
     }
 
-    let first_slot_in_window = window * SLOTS_PER_WINDOW;
-    let last_slot_in_window = (window + 1) * SLOTS_PER_WINDOW - 1;
+    let last_slot_in_window = first_slot_in_window.last_slot_in_window();
 
     // if already have parent ready, return it, otherwise get a channel to await on
     let rx = {
@@ -141,18 +139,18 @@ async fn wait_for_first_slot(
             let handle = tokio::spawn(async move {
                 // PERF: These are burning a CPU. Can we use async here?
                 loop {
+                    let last_slot_in_prev_window = first_slot_in_window.last_slot_in_prev_window();
                     if let Some(hash) = blockstore
                         .read()
                         .await
-                        .canonical_block_hash(first_slot_in_window - 1)
+                        .canonical_block_hash(last_slot_in_prev_window)
                     {
-                        let slot = first_slot_in_window - 1;
                         debug!(
                             "optimistically building block on parent {} in slot {}",
                             &hex::encode(hash)[..8],
-                            slot
+                            last_slot_in_prev_window,
                         );
-                        return Some((slot, hash, false));
+                        return Some((last_slot_in_prev_window, hash, false));
                     }
                     if pool.read().await.finalized_slot() >= last_slot_in_window {
                         warn!(
@@ -313,7 +311,7 @@ where
     /// Keeps track of when consensus progresses, i.e., [`Pool`] finalizes new blocks.
     /// Triggers standstill recovery if no progress was detected for a long time.
     async fn standstill_loop(self: &Arc<Self>) -> Result<()> {
-        let mut finalized_slot = 0;
+        let mut finalized_slot = Slot::new(0);
         let mut last_progress = Instant::now();
         loop {
             let slot = self.pool.read().await.finalized_slot();
@@ -333,13 +331,13 @@ where
     /// Once all previous blocks have been notarized or skipped and the next
     /// slot belongs to our leader window, we will produce a block.
     async fn block_production_loop(&self) -> Result<()> {
-        for window in 0.. {
+        let mut first_slot_in_window = Slot::new(0);
+        loop {
             if self.cancel_token.is_cancelled() {
                 break;
             }
 
-            let first_slot_in_window = window * SLOTS_PER_WINDOW;
-            let last_slot_in_window = (window + 1) * SLOTS_PER_WINDOW - 1;
+            let last_slot_in_window = first_slot_in_window.last_slot_in_window();
 
             // don't do anything if we are not the leader
             let leader = self.epoch_info.leader(first_slot_in_window);
@@ -354,17 +352,21 @@ where
                 continue;
             }
 
-            let (parent, parent_hash, parent_ready) =
-                match wait_for_first_slot(self.pool.clone(), self.blockstore.clone(), window).await
-                {
-                    Some(res) => res,
-                    None => continue,
-                };
+            let (parent, parent_hash, parent_ready) = match wait_for_first_slot(
+                self.pool.clone(),
+                self.blockstore.clone(),
+                first_slot_in_window,
+            )
+            .await
+            {
+                Some(res) => res,
+                None => continue,
+            };
 
             // produce blocks for all slots in window
             let mut block = parent;
             let mut block_hash = parent_hash;
-            for slot in first_slot_in_window..=last_slot_in_window {
+            for slot in first_slot_in_window.slots_in_window() {
                 self.produce_block(slot, (block, block_hash), parent_ready)
                     .await?;
 
@@ -377,6 +379,7 @@ where
                     .canonical_block_hash(slot)
                     .unwrap();
             }
+            first_slot_in_window = first_slot_in_window.first_slot_in_next_window();
         }
 
         Ok(())

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -51,8 +51,6 @@ pub use pool::{AddVoteError, Pool};
 pub use vote::Vote;
 use votor::Votor;
 
-/// Number of slots in each leader window.
-pub const SLOTS_PER_WINDOW: u64 = 4;
 /// Number of slots in each epoch.
 pub const SLOTS_PER_EPOCH: u64 = 18_000;
 /// Time bound assumed on network transmission delays during periods of synchrony.
@@ -331,8 +329,7 @@ where
     /// Once all previous blocks have been notarized or skipped and the next
     /// slot belongs to our leader window, we will produce a block.
     async fn block_production_loop(&self) -> Result<()> {
-        let mut first_slot_in_window = Slot::new(0);
-        loop {
+        for first_slot_in_window in Slot::windows() {
             if self.cancel_token.is_cancelled() {
                 break;
             }
@@ -379,7 +376,6 @@ where
                     .canonical_block_hash(slot)
                     .unwrap();
             }
-            first_slot_in_window = first_slot_in_window.first_slot_in_next_window();
         }
 
         Ok(())

--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -253,7 +253,9 @@ impl BlockData {
 
         // reconstruct block header
         let first_slice = self.slices.get(&0).unwrap();
-        let parent_slot = u64::from_be_bytes(first_slice.data[0..8].try_into().unwrap());
+        let parent_slot = Slot::new(u64::from_be_bytes(
+            first_slice.data[0..8].try_into().unwrap(),
+        ));
         let parent_hash = first_slice.data[8..40].try_into().unwrap();
         // TODO: reconstruct actual block content
         let block = Block {

--- a/src/consensus/cert.rs
+++ b/src/consensus/cert.rs
@@ -597,36 +597,35 @@ mod tests {
         let (sks, info) = create_signers(100);
 
         // notar cert
-        let votes: Vec<Vote> = create_votes(VoteKind::Notar(Slot::new(0), Hash::default()), &sks);
+        let votes = create_votes(VoteKind::Notar(Slot::new(0), Hash::default()), &sks);
         let res = NotarCert::try_new(&votes, &info);
         assert!(res.is_ok());
         let cert = Cert::Notar(res.unwrap());
         check_full_cert(cert, &info);
 
         // notar-fallback cert
-        let votes: Vec<Vote> =
-            create_votes(VoteKind::NotarFallback(Slot::new(0), Hash::default()), &sks);
+        let votes = create_votes(VoteKind::NotarFallback(Slot::new(0), Hash::default()), &sks);
         let res = NotarFallbackCert::try_new(&votes, &info);
         assert!(res.is_ok());
         let cert = Cert::NotarFallback(res.unwrap());
         check_full_cert(cert, &info);
 
         // skip cert
-        let votes: Vec<Vote> = create_votes(VoteKind::Skip(Slot::new(0)), &sks);
+        let votes = create_votes(VoteKind::Skip(Slot::new(0)), &sks);
         let res = SkipCert::try_new(&votes, &info);
         assert!(res.is_ok());
         let cert = Cert::Skip(res.unwrap());
         check_full_cert(cert, &info);
 
         // fast finalization cert
-        let votes: Vec<Vote> = create_votes(VoteKind::Notar(Slot::new(0), Hash::default()), &sks);
+        let votes = create_votes(VoteKind::Notar(Slot::new(0), Hash::default()), &sks);
         let res = FastFinalCert::try_new(&votes, &info);
         assert!(res.is_ok());
         let cert = Cert::FastFinal(res.unwrap());
         check_full_cert(cert, &info);
 
         // finalization cert
-        let votes: Vec<Vote> = create_votes(VoteKind::Final(Slot::new(0)), &sks);
+        let votes = create_votes(VoteKind::Final(Slot::new(0)), &sks);
         let res = FinalCert::try_new(&votes, &info);
         assert!(res.is_ok());
         let cert = Cert::Final(res.unwrap());

--- a/src/consensus/cert.rs
+++ b/src/consensus/cert.rs
@@ -597,35 +597,36 @@ mod tests {
         let (sks, info) = create_signers(100);
 
         // notar cert
-        let votes: Vec<Vote> = create_votes(VoteKind::Notar(0, Hash::default()), &sks);
+        let votes: Vec<Vote> = create_votes(VoteKind::Notar(Slot::new(0), Hash::default()), &sks);
         let res = NotarCert::try_new(&votes, &info);
         assert!(res.is_ok());
         let cert = Cert::Notar(res.unwrap());
         check_full_cert(cert, &info);
 
         // notar-fallback cert
-        let votes: Vec<Vote> = create_votes(VoteKind::NotarFallback(0, Hash::default()), &sks);
+        let votes: Vec<Vote> =
+            create_votes(VoteKind::NotarFallback(Slot::new(0), Hash::default()), &sks);
         let res = NotarFallbackCert::try_new(&votes, &info);
         assert!(res.is_ok());
         let cert = Cert::NotarFallback(res.unwrap());
         check_full_cert(cert, &info);
 
         // skip cert
-        let votes: Vec<Vote> = create_votes(VoteKind::Skip(0), &sks);
+        let votes: Vec<Vote> = create_votes(VoteKind::Skip(Slot::new(0)), &sks);
         let res = SkipCert::try_new(&votes, &info);
         assert!(res.is_ok());
         let cert = Cert::Skip(res.unwrap());
         check_full_cert(cert, &info);
 
         // fast finalization cert
-        let votes: Vec<Vote> = create_votes(VoteKind::Notar(0, Hash::default()), &sks);
+        let votes: Vec<Vote> = create_votes(VoteKind::Notar(Slot::new(0), Hash::default()), &sks);
         let res = FastFinalCert::try_new(&votes, &info);
         assert!(res.is_ok());
         let cert = Cert::FastFinal(res.unwrap());
         check_full_cert(cert, &info);
 
         // finalization cert
-        let votes: Vec<Vote> = create_votes(VoteKind::Final(0), &sks);
+        let votes: Vec<Vote> = create_votes(VoteKind::Final(Slot::new(0)), &sks);
         let res = FinalCert::try_new(&votes, &info);
         assert!(res.is_ok());
         let cert = Cert::Final(res.unwrap());
@@ -637,16 +638,16 @@ mod tests {
         let (sks, info) = create_signers(2);
 
         // notar + notar-fallback
-        let vote1 = Vote::new_notar(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar_fallback(0, Hash::default(), &sks[1], 1);
+        let vote1 = Vote::new_notar(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar_fallback(Slot::new(0), Hash::default(), &sks[1], 1);
         let res = NotarFallbackCert::try_new(&[vote1, vote2], &info);
         assert!(res.is_ok());
         let cert = Cert::NotarFallback(res.unwrap());
         check_full_cert(cert, &info);
 
         // notar-fallback + notar
-        let vote1 = Vote::new_notar_fallback(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar(0, Hash::default(), &sks[1], 1);
+        let vote1 = Vote::new_notar_fallback(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar(Slot::new(0), Hash::default(), &sks[1], 1);
         let res = NotarFallbackCert::try_new(&[vote1, vote2], &info);
         assert!(res.is_ok());
         let cert = Cert::NotarFallback(res.unwrap());
@@ -658,16 +659,16 @@ mod tests {
         let (sks, info) = create_signers(2);
 
         // skip + skip-fallback
-        let vote1 = Vote::new_skip(0, &sks[0], 0);
-        let vote2 = Vote::new_skip_fallback(0, &sks[1], 1);
+        let vote1 = Vote::new_skip(Slot::new(0), &sks[0], 0);
+        let vote2 = Vote::new_skip_fallback(Slot::new(0), &sks[1], 1);
         let res = SkipCert::try_new(&[vote1, vote2], &info);
         assert!(res.is_ok());
         let cert = Cert::Skip(res.unwrap());
         check_full_cert(cert, &info);
 
         // skip-fallback + skip
-        let vote1 = Vote::new_skip_fallback(0, &sks[0], 0);
-        let vote2 = Vote::new_skip(0, &sks[1], 1);
+        let vote1 = Vote::new_skip_fallback(Slot::new(0), &sks[0], 0);
+        let vote2 = Vote::new_skip(Slot::new(0), &sks[1], 1);
         let res = SkipCert::try_new(&[vote1, vote2], &info);
         assert!(res.is_ok());
         let cert = Cert::Skip(res.unwrap());
@@ -679,26 +680,26 @@ mod tests {
         let (sks, info) = create_signers(2);
 
         // slot mismatch
-        let vote1 = Vote::new_notar(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar(1, Hash::default(), &sks[1], 1);
+        let vote1 = Vote::new_notar(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar(Slot::new(1), Hash::default(), &sks[1], 1);
         let res = NotarCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::SlotMismatch));
 
         // block hash mismatch
-        let vote1 = Vote::new_notar(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar(0, [42; 32], &sks[1], 1);
+        let vote1 = Vote::new_notar(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar(Slot::new(0), [42; 32], &sks[1], 1);
         let res = NotarCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::BlockHashMismatch));
 
         // different vote types
-        let vote1 = Vote::new_notar(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar_fallback(0, Hash::default(), &sks[1], 1);
+        let vote1 = Vote::new_notar(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar_fallback(Slot::new(0), Hash::default(), &sks[1], 1);
         let res = NotarCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::WrongVoteType));
 
         // wrong vote type for cert
-        let vote1 = Vote::new_notar_fallback(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar_fallback(0, Hash::default(), &sks[1], 1);
+        let vote1 = Vote::new_notar_fallback(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar_fallback(Slot::new(0), Hash::default(), &sks[1], 1);
         let res = NotarCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::WrongVoteType));
     }
@@ -708,26 +709,26 @@ mod tests {
         let (sks, info) = create_signers(2);
 
         // slot mismatch
-        let vote1 = Vote::new_notar_fallback(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar_fallback(1, Hash::default(), &sks[1], 1);
+        let vote1 = Vote::new_notar_fallback(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar_fallback(Slot::new(1), Hash::default(), &sks[1], 1);
         let res = NotarFallbackCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::SlotMismatch));
 
         // block hash mismatch
-        let vote1 = Vote::new_notar_fallback(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar_fallback(0, [42; 32], &sks[1], 1);
+        let vote1 = Vote::new_notar_fallback(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar_fallback(Slot::new(0), [42; 32], &sks[1], 1);
         let res = NotarFallbackCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::BlockHashMismatch));
 
         // wrong vote types for cert
-        let vote1 = Vote::new_notar(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_final(0, &sks[1], 1);
+        let vote1 = Vote::new_notar(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_final(Slot::new(0), &sks[1], 1);
         let res = NotarFallbackCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::WrongVoteType));
 
         // wrong vote type for cert
-        let vote1 = Vote::new_final(0, &sks[0], 0);
-        let vote2 = Vote::new_final(0, &sks[1], 1);
+        let vote1 = Vote::new_final(Slot::new(0), &sks[0], 0);
+        let vote2 = Vote::new_final(Slot::new(0), &sks[1], 1);
         let res = NotarFallbackCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::WrongVoteType));
     }
@@ -737,20 +738,20 @@ mod tests {
         let (sks, info) = create_signers(2);
 
         // slot mismatch
-        let vote1 = Vote::new_skip(0, &sks[0], 0);
-        let vote2 = Vote::new_skip(1, &sks[1], 1);
+        let vote1 = Vote::new_skip(Slot::new(0), &sks[0], 0);
+        let vote2 = Vote::new_skip(Slot::new(1), &sks[1], 1);
         let res = SkipCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::SlotMismatch));
 
         // wrong vote type for cert
-        let vote1 = Vote::new_skip(0, &sks[0], 0);
-        let vote2 = Vote::new_final(0, &sks[1], 1);
+        let vote1 = Vote::new_skip(Slot::new(0), &sks[0], 0);
+        let vote2 = Vote::new_final(Slot::new(0), &sks[1], 1);
         let res = SkipCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::WrongVoteType));
 
         // wrong vote type for cert
-        let vote1 = Vote::new_final(0, &sks[0], 0);
-        let vote2 = Vote::new_final(0, &sks[1], 1);
+        let vote1 = Vote::new_final(Slot::new(0), &sks[0], 0);
+        let vote2 = Vote::new_final(Slot::new(0), &sks[1], 1);
         let res = SkipCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::WrongVoteType));
     }
@@ -760,26 +761,26 @@ mod tests {
         let (sks, info) = create_signers(2);
 
         // slot mismatch
-        let vote1 = Vote::new_notar(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar(1, Hash::default(), &sks[1], 1);
+        let vote1 = Vote::new_notar(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar(Slot::new(1), Hash::default(), &sks[1], 1);
         let res = FastFinalCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::SlotMismatch));
 
         // block hash mismatch
-        let vote1 = Vote::new_notar(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar(0, [42; 32], &sks[1], 1);
+        let vote1 = Vote::new_notar(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar(Slot::new(0), [42; 32], &sks[1], 1);
         let res = FastFinalCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::BlockHashMismatch));
 
         // wrong vote type for cert
-        let vote1 = Vote::new_notar(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar_fallback(0, Hash::default(), &sks[1], 1);
+        let vote1 = Vote::new_notar(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar_fallback(Slot::new(0), Hash::default(), &sks[1], 1);
         let res = FastFinalCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::WrongVoteType));
 
         // wrong vote type for cert
-        let vote1 = Vote::new_notar_fallback(0, Hash::default(), &sks[0], 0);
-        let vote2 = Vote::new_notar_fallback(0, Hash::default(), &sks[1], 1);
+        let vote1 = Vote::new_notar_fallback(Slot::new(0), Hash::default(), &sks[0], 0);
+        let vote2 = Vote::new_notar_fallback(Slot::new(0), Hash::default(), &sks[1], 1);
         let res = FastFinalCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::WrongVoteType));
     }
@@ -789,20 +790,20 @@ mod tests {
         let (sks, info) = create_signers(2);
 
         // slot mismatch
-        let vote1 = Vote::new_final(0, &sks[0], 0);
-        let vote2 = Vote::new_final(1, &sks[1], 1);
+        let vote1 = Vote::new_final(Slot::new(0), &sks[0], 0);
+        let vote2 = Vote::new_final(Slot::new(1), &sks[1], 1);
         let res = FinalCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::SlotMismatch));
 
         // wrong vote type for cert
-        let vote1 = Vote::new_final(0, &sks[0], 0);
-        let vote2 = Vote::new_skip(0, &sks[1], 1);
+        let vote1 = Vote::new_final(Slot::new(0), &sks[0], 0);
+        let vote2 = Vote::new_skip(Slot::new(0), &sks[1], 1);
         let res = FinalCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::WrongVoteType));
 
         // wrong vote type for cert
-        let vote1 = Vote::new_skip(0, &sks[0], 0);
-        let vote2 = Vote::new_skip(0, &sks[1], 1);
+        let vote1 = Vote::new_skip(Slot::new(0), &sks[0], 0);
+        let vote2 = Vote::new_skip(Slot::new(0), &sks[1], 1);
         let res = FinalCert::try_new(&[vote1, vote2], &info);
         assert_eq!(res.err(), Some(CertError::WrongVoteType));
     }

--- a/src/consensus/epoch_info.rs
+++ b/src/consensus/epoch_info.rs
@@ -3,8 +3,6 @@
 
 use crate::{Slot, Stake, ValidatorId, ValidatorInfo};
 
-use super::SLOTS_PER_WINDOW;
-
 /// Epoch-specfic validator information.
 #[derive(Clone, Debug)]
 pub struct EpochInfo {
@@ -32,9 +30,7 @@ impl EpochInfo {
     // TODO: actual stake-based pseudorandom leader schedule
     #[must_use]
     pub fn leader(&self, slot: Slot) -> &ValidatorInfo {
-        let window = slot / SLOTS_PER_WINDOW;
-        let leader_id = window % (self.validators.len() as u64);
-        self.validator(leader_id)
+        slot.leader(&self.validators)
     }
 
     /// Gives the total stake over all validators.

--- a/src/consensus/epoch_info.rs
+++ b/src/consensus/epoch_info.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Slot, Stake, ValidatorId, ValidatorInfo};
+use crate::{Slot, Stake, ValidatorId, ValidatorInfo, slot::SLOTS_PER_WINDOW};
 
 /// Epoch-specfic validator information.
 #[derive(Clone, Debug)]
@@ -30,7 +30,9 @@ impl EpochInfo {
     // TODO: actual stake-based pseudorandom leader schedule
     #[must_use]
     pub fn leader(&self, slot: Slot) -> &ValidatorInfo {
-        slot.leader(&self.validators)
+        let window = slot.inner() / SLOTS_PER_WINDOW;
+        let leader_id = window % (self.validators.len() as u64);
+        self.validator(leader_id)
     }
 
     /// Gives the total stake over all validators.

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -116,7 +116,7 @@ impl Pool {
         // TODO: set bounds exactly correctly,
         //       use correct validator set & stake distribution
         let slot_far_in_future =
-            Slot::new(self.highest_finalized_slot.take() + 2 * SLOTS_PER_EPOCH);
+            Slot::new(self.highest_finalized_slot.inner() + 2 * SLOTS_PER_EPOCH);
         if slot < self.highest_finalized_slot || slot >= slot_far_in_future {
             return Err(AddCertError::SlotOutOfBounds);
         }
@@ -243,7 +243,7 @@ impl Pool {
         // TODO: set bounds exactly correctly,
         //       use correct validator set & stake distribution
         let slot_far_in_future =
-            Slot::new(self.highest_finalized_slot.take() + 2 * SLOTS_PER_EPOCH);
+            Slot::new(self.highest_finalized_slot.inner() + 2 * SLOTS_PER_EPOCH);
         if slot < self.highest_finalized_slot || slot >= slot_far_in_future {
             return Err(AddVoteError::SlotOutOfBounds);
         }
@@ -462,9 +462,9 @@ impl Pool {
 mod tests {
     use super::*;
 
-    use crate::consensus::SLOTS_PER_WINDOW;
     use crate::consensus::cert::NotarCert;
     use crate::crypto::aggsig::SecretKey;
+    use crate::slot::SLOTS_PER_WINDOW;
     use crate::test_utils::generate_validators;
 
     use static_assertions::const_assert;
@@ -478,7 +478,7 @@ mod tests {
         let mut pool = Pool::new(epoch_info, votor_tx, repair_tx);
 
         let wrong_sk = SecretKey::new(&mut rand::rng());
-        let vote = Vote::new_notar(0, Hash::default(), &wrong_sk, 0);
+        let vote = Vote::new_notar(Slot::new(0), Hash::default(), &wrong_sk, 0);
         assert_eq!(
             pool.add_vote(vote).await,
             Err(AddVoteError::InvalidSignature)
@@ -495,28 +495,28 @@ mod tests {
         let mut pool = Pool::new(epoch_info, votor_tx, repair_tx);
 
         // all nodes notarize block in slot 0
-        assert!(!pool.is_notarized(0));
+        assert!(!pool.is_notarized(Slot::new(0)));
         for v in 0..11 {
-            let vote = Vote::new_notar(0, Hash::default(), &sks[v as usize], v);
+            let vote = Vote::new_notar(Slot::new(0), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_notarized(0));
+        assert!(pool.is_notarized(Slot::new(0)));
 
         // just enough nodes notarize block in slot 1
-        assert!(!pool.is_notarized(1));
+        assert!(!pool.is_notarized(Slot::new(1)));
         for v in 0..7 {
-            let vote = Vote::new_notar(1, Hash::default(), &sks[v as usize], v);
+            let vote = Vote::new_notar(Slot::new(1), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_notarized(1));
+        assert!(pool.is_notarized(Slot::new(1)));
 
         // just NOT enough nodes notarize block in slot 2
-        assert!(!pool.is_notarized(2));
+        assert!(!pool.is_notarized(Slot::new(2)));
         for v in 0..6 {
-            let vote = Vote::new_notar(2, Hash::default(), &sks[v as usize], v);
+            let vote = Vote::new_notar(Slot::new(2), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(!pool.is_notarized(2));
+        assert!(!pool.is_notarized(Slot::new(2)));
         drop(votor_rx);
         drop(repair_rx);
     }
@@ -529,28 +529,28 @@ mod tests {
         let mut pool = Pool::new(epoch_info, votor_tx, repair_tx);
 
         // all nodes vote skip on slot 0
-        assert!(!pool.is_skip_certified(0));
+        assert!(!pool.is_skip_certified(Slot::new(0)));
         for v in 0..11 {
-            let vote = Vote::new_skip(0, &sks[v as usize], v);
+            let vote = Vote::new_skip(Slot::new(0), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_skip_certified(0));
+        assert!(pool.is_skip_certified(Slot::new(0)));
 
         // just enough nodes vote skip on slot 1
-        assert!(!pool.is_skip_certified(1));
+        assert!(!pool.is_skip_certified(Slot::new(1)));
         for v in 0..7 {
-            let vote = Vote::new_skip(1, &sks[v as usize], v);
+            let vote = Vote::new_skip(Slot::new(1), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_skip_certified(1));
+        assert!(pool.is_skip_certified(Slot::new(1)));
 
         // just NOT enough nodes notarize block in slot 2
-        assert!(!pool.is_skip_certified(2));
+        assert!(!pool.is_skip_certified(Slot::new(2)));
         for v in 0..6 {
-            let vote = Vote::new_skip(2, &sks[v as usize], v);
+            let vote = Vote::new_skip(Slot::new(2), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(!pool.is_skip_certified(2));
+        assert!(!pool.is_skip_certified(Slot::new(2)));
         drop(votor_rx);
         drop(repair_rx);
     }
@@ -563,31 +563,31 @@ mod tests {
         let mut pool = Pool::new(epoch_info, votor_tx, repair_tx);
 
         // all nodes vote finalize on slot 0
-        assert!(!pool.is_finalized(0));
+        assert!(!pool.is_finalized(Slot::new(0)));
         for v in 0..11 {
-            let vote = Vote::new_final(0, &sks[v as usize], v);
+            let vote = Vote::new_final(Slot::new(0), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_finalized(0));
-        assert!(pool.highest_finalized_slot == 0);
+        assert!(pool.is_finalized(Slot::new(0)));
+        assert!(pool.highest_finalized_slot == Slot::new(0));
 
         // just enough nodes vote finalize on slot 1
-        assert!(!pool.is_finalized(1));
+        assert!(!pool.is_finalized(Slot::new(1)));
         for v in 0..7 {
-            let vote = Vote::new_final(1, &sks[v as usize], v);
+            let vote = Vote::new_final(Slot::new(1), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_finalized(1));
-        assert!(pool.highest_finalized_slot == 1);
+        assert!(pool.is_finalized(Slot::new(1)));
+        assert!(pool.highest_finalized_slot == Slot::new(1));
 
         // just NOT enough nodes vote finalize on slot 2
-        assert!(!pool.is_finalized(2));
+        assert!(!pool.is_finalized(Slot::new(2)));
         for v in 0..6 {
-            let vote = Vote::new_final(2, &sks[v as usize], v);
+            let vote = Vote::new_final(Slot::new(2), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(!pool.is_finalized(2));
-        assert!(pool.highest_finalized_slot == 1);
+        assert!(!pool.is_finalized(Slot::new(2)));
+        assert!(pool.highest_finalized_slot == Slot::new(1));
         drop(votor_rx);
         drop(repair_rx);
     }
@@ -600,31 +600,31 @@ mod tests {
         let mut pool = Pool::new(epoch_info, votor_tx, repair_tx);
 
         // all nodes vote notarize on slot 0
-        assert!(!pool.is_finalized(0));
+        assert!(!pool.is_finalized(Slot::new(0)));
         for v in 0..11 {
-            let vote = Vote::new_notar(0, Hash::default(), &sks[v as usize], v);
+            let vote = Vote::new_notar(Slot::new(0), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_finalized(0));
-        assert!(pool.highest_finalized_slot == 0);
+        assert!(pool.is_finalized(Slot::new(0)));
+        assert!(pool.highest_finalized_slot == Slot::new(0));
 
         // just enough nodes to fast finalize slot 1
-        assert!(!pool.is_finalized(1));
+        assert!(!pool.is_finalized(Slot::new(1)));
         for v in 0..9 {
-            let vote = Vote::new_notar(1, Hash::default(), &sks[v as usize], v);
+            let vote = Vote::new_notar(Slot::new(1), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_finalized(1));
-        assert!(pool.highest_finalized_slot == 1);
+        assert!(pool.is_finalized(Slot::new(1)));
+        assert!(pool.highest_finalized_slot == Slot::new(1));
 
         // just NOT enough nodes to fast finalize slot 2
-        assert!(!pool.is_finalized(2));
+        assert!(!pool.is_finalized(Slot::new(2)));
         for v in 0..8 {
-            let vote = Vote::new_notar(2, Hash::default(), &sks[v as usize], v);
+            let vote = Vote::new_notar(Slot::new(2), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(!pool.is_finalized(2));
-        assert!(pool.highest_finalized_slot == 1);
+        assert!(!pool.is_finalized(Slot::new(2)));
+        assert!(pool.highest_finalized_slot == Slot::new(1));
         drop(votor_rx);
         drop(repair_rx);
     }
@@ -638,13 +638,17 @@ mod tests {
 
         for slot in 0..SLOTS_PER_WINDOW {
             for v in 0..7 {
-                let vote = Vote::new_notar(slot, [slot as u8; 32], &sks[v as usize], v);
+                let vote = Vote::new_notar(Slot::new(slot), [slot as u8; 32], &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
         }
+
         assert!(pool.is_parent_ready(
-            SLOTS_PER_WINDOW,
-            (SLOTS_PER_WINDOW - 1, [SLOTS_PER_WINDOW as u8 - 1; 32])
+            Slot::new(SLOTS_PER_WINDOW),
+            (
+                Slot::new(SLOTS_PER_WINDOW - 1),
+                [SLOTS_PER_WINDOW as u8 - 1; 32]
+            )
         ));
         drop(votor_rx);
         drop(repair_rx);
@@ -658,20 +662,24 @@ mod tests {
         let mut pool = Pool::new(epoch_info, votor_tx, repair_tx);
 
         // receive mixed notar & notar-fallback votes
-        for slot in 0..SLOTS_PER_WINDOW {
-            assert!(!pool.is_parent_ready(slot + 1, (slot, [slot as u8; 32])));
+        for slot in Slot::new(0).slots_in_window() {
+            assert!(!pool.is_parent_ready(slot.next(), (slot, [slot.inner() as u8; 32])));
             for v in 0..4 {
-                let vote = Vote::new_notar(slot, [slot as u8; 32], &sks[v as usize], v);
+                let vote = Vote::new_notar(slot, [slot.inner() as u8; 32], &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
             for v in 4..7 {
-                let vote = Vote::new_notar_fallback(slot, [slot as u8; 32], &sks[v as usize], v);
+                let vote =
+                    Vote::new_notar_fallback(slot, [slot.inner() as u8; 32], &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
         }
         assert!(pool.is_parent_ready(
-            SLOTS_PER_WINDOW,
-            (SLOTS_PER_WINDOW - 1, [SLOTS_PER_WINDOW as u8 - 1; 32])
+            Slot::new(SLOTS_PER_WINDOW),
+            (
+                Slot::new(SLOTS_PER_WINDOW - 1),
+                [SLOTS_PER_WINDOW as u8 - 1; 32]
+            )
         ));
         drop(votor_rx);
         drop(repair_rx);
@@ -688,23 +696,23 @@ mod tests {
         const_assert!(SLOTS_PER_WINDOW > 2);
         for slot in 2..SLOTS_PER_WINDOW {
             for v in 0..7 {
-                let vote = Vote::new_skip(slot, &sks[v as usize], v);
+                let vote = Vote::new_skip(Slot::new(slot), &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
         }
         // no blocks are valid parents yet
-        assert!(pool.parents_ready(SLOTS_PER_WINDOW).is_empty());
+        assert!(pool.parents_ready(Slot::new(SLOTS_PER_WINDOW)).is_empty());
 
         // then see notarization votes for slot 1
         for v in 0..7 {
-            let vote = Vote::new_notar(1, [1; 32], &sks[v as usize], v);
+            let vote = Vote::new_notar(Slot::new(1), [1; 32], &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
 
         // branch can only be certified once we saw votes other slots in window
-        assert!(pool.is_parent_ready(SLOTS_PER_WINDOW, (1, [1; 32])));
+        assert!(pool.is_parent_ready(Slot::new(SLOTS_PER_WINDOW), (Slot::new(1), [1; 32])));
         // no other blocks are valid parents
-        assert_eq!(pool.parents_ready(SLOTS_PER_WINDOW).len(), 1);
+        assert_eq!(pool.parents_ready(Slot::new(SLOTS_PER_WINDOW)).len(), 1);
         drop(votor_rx);
         drop(repair_rx);
     }
@@ -718,24 +726,25 @@ mod tests {
 
         // first see skip votes for later slots
         for slot in 2..SLOTS_PER_WINDOW {
+            let slot = Slot::new(slot);
             for v in 0..7 {
                 let vote = Vote::new_skip(slot, &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
         }
         // no blocks are valid parents yet
-        assert!(pool.parents_ready(SLOTS_PER_WINDOW).is_empty());
+        assert!(pool.parents_ready(Slot::new(SLOTS_PER_WINDOW)).is_empty());
 
         // then receive notarization cert for slot 1
         let mut votes = Vec::new();
         for v in 0..7 {
-            votes.push(Vote::new_notar(1, [1; 32], &sks[v as usize], v));
+            votes.push(Vote::new_notar(Slot::new(1), [1; 32], &sks[v as usize], v));
         }
         let cert = NotarCert::try_new(&votes, &epoch_info.validators).unwrap();
         pool.add_cert(Cert::Notar(cert)).await.unwrap();
 
         // branch can only be certified once we saw votes for parent
-        assert!(pool.is_parent_ready(SLOTS_PER_WINDOW, (1, [1; 32])));
+        assert!(pool.is_parent_ready(Slot::new(SLOTS_PER_WINDOW), (Slot::new(1), [1; 32])));
         drop(votor_rx);
         drop(repair_rx);
     }
@@ -750,14 +759,17 @@ mod tests {
         // notarize all slots of first window
         for slot in 0..SLOTS_PER_WINDOW {
             for v in 0..7 {
-                let vote = Vote::new_notar(slot, [slot as u8; 32], &sks[v as usize], v);
+                let vote = Vote::new_notar(Slot::new(slot), [slot as u8; 32], &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
         }
 
         assert!(pool.is_parent_ready(
-            SLOTS_PER_WINDOW,
-            (SLOTS_PER_WINDOW - 1, [(SLOTS_PER_WINDOW - 1) as u8; 32])
+            Slot::new(SLOTS_PER_WINDOW),
+            (
+                Slot::new(SLOTS_PER_WINDOW - 1),
+                [(SLOTS_PER_WINDOW - 1) as u8; 32]
+            )
         ));
         drop(votor_rx);
         drop(repair_rx);
@@ -773,20 +785,23 @@ mod tests {
         // notarize all slots but last one
         for slot in 0..SLOTS_PER_WINDOW - 1 {
             for v in 0..7 {
-                let vote = Vote::new_notar(slot, [slot as u8; 32], &sks[v as usize], v);
+                let vote = Vote::new_notar(Slot::new(slot), [slot as u8; 32], &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
         }
 
         // skip last slot
         for v in 0..7 {
-            let vote = Vote::new_skip(SLOTS_PER_WINDOW - 1, &sks[v as usize], v);
+            let vote = Vote::new_skip(Slot::new(SLOTS_PER_WINDOW - 1), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
 
         assert!(pool.is_parent_ready(
-            SLOTS_PER_WINDOW,
-            (SLOTS_PER_WINDOW - 2, [(SLOTS_PER_WINDOW - 2) as u8; 32])
+            Slot::new(SLOTS_PER_WINDOW),
+            (
+                Slot::new(SLOTS_PER_WINDOW - 2),
+                [(SLOTS_PER_WINDOW - 2) as u8; 32]
+            )
         ));
         drop(votor_rx);
         drop(repair_rx);
@@ -802,24 +817,27 @@ mod tests {
         // notarize all slots but last two
         for slot in 0..SLOTS_PER_WINDOW - 2 {
             for v in 0..7 {
-                let vote = Vote::new_notar(slot, [slot as u8; 32], &sks[v as usize], v);
+                let vote = Vote::new_notar(Slot::new(slot), [slot as u8; 32], &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
         }
 
         // skip last 2 slots
         for v in 0..7 {
-            let vote = Vote::new_skip(SLOTS_PER_WINDOW - 2, &sks[v as usize], v);
+            let vote = Vote::new_skip(Slot::new(SLOTS_PER_WINDOW - 2), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
         for v in 0..7 {
-            let vote = Vote::new_skip(SLOTS_PER_WINDOW - 1, &sks[v as usize], v);
+            let vote = Vote::new_skip(Slot::new(SLOTS_PER_WINDOW - 1), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
 
         assert!(pool.is_parent_ready(
-            SLOTS_PER_WINDOW,
-            (SLOTS_PER_WINDOW - 3, [(SLOTS_PER_WINDOW - 3) as u8; 32])
+            Slot::new(SLOTS_PER_WINDOW),
+            (
+                Slot::new(SLOTS_PER_WINDOW - 3),
+                [(SLOTS_PER_WINDOW - 3) as u8; 32]
+            )
         ));
         drop(votor_rx);
         drop(repair_rx);
@@ -835,7 +853,7 @@ mod tests {
         // notarize all slots in first window
         for slot in 0..SLOTS_PER_WINDOW {
             for v in 0..7 {
-                let vote = Vote::new_notar(slot, [slot as u8; 32], &sks[v as usize], v);
+                let vote = Vote::new_notar(Slot::new(slot), [slot as u8; 32], &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
         }
@@ -843,14 +861,17 @@ mod tests {
         // skip all slots in second window
         for slot in 0..SLOTS_PER_WINDOW {
             for v in 0..7 {
-                let vote = Vote::new_skip(SLOTS_PER_WINDOW + slot, &sks[v as usize], v);
+                let vote = Vote::new_skip(Slot::new(SLOTS_PER_WINDOW + slot), &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
         }
 
         assert!(pool.is_parent_ready(
-            2 * SLOTS_PER_WINDOW,
-            (SLOTS_PER_WINDOW - 1, [(SLOTS_PER_WINDOW - 1) as u8; 32])
+            Slot::new(2 * SLOTS_PER_WINDOW),
+            (
+                Slot::new(SLOTS_PER_WINDOW - 1),
+                [(SLOTS_PER_WINDOW - 1) as u8; 32]
+            )
         ));
         drop(votor_rx);
         drop(repair_rx);
@@ -865,6 +886,7 @@ mod tests {
 
         // all nodes vote finalize on 100 leader windows
         for slot in 0..3 * SLOTS_PER_WINDOW {
+            let slot = Slot::new(slot);
             assert!(!pool.is_finalized(slot));
             for v in 0..11 {
                 let vote = Vote::new_final(slot, &sks[v as usize], v);
@@ -872,18 +894,19 @@ mod tests {
             }
             assert!(pool.is_finalized(slot));
         }
-        let last_slot = 3 * SLOTS_PER_WINDOW - 1;
+        let last_slot = Slot::new(3 * SLOTS_PER_WINDOW - 1);
         assert_eq!(pool.highest_finalized_slot, last_slot);
 
         // finalization triggers pruning, only last slot should be there
-        for slot in 0..last_slot {
+        for slot in 0..last_slot.inner() {
+            let slot = Slot::new(slot);
             assert!(!pool.slot_states.contains_key(&slot));
         }
         assert!(pool.slot_states.contains_key(&(last_slot)));
 
         // NOT enough nodes vote finalize on next 10 slots
         for s in 1..=10 {
-            let slot = last_slot + s;
+            let slot = Slot::new(last_slot.inner() + s);
             for v in 0..6 {
                 let vote = Vote::new_final(slot, &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
@@ -894,25 +917,28 @@ mod tests {
 
         // these slots should still be there
         for s in 0..=10 {
-            let slot = last_slot + s;
+            let slot = Slot::new(last_slot.inner() + s);
             assert!(pool.slot_states.contains_key(&slot));
         }
 
         // add one more vote each to finalize next 10 slots
         for s in 1..=10 {
-            let slot = last_slot + s;
+            let slot = Slot::new(last_slot.inner() + s);
             let vote = Vote::new_final(slot, &sks[6], 6);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
             assert!(pool.is_finalized(slot));
         }
-        assert_eq!(pool.highest_finalized_slot, last_slot + 10);
+        assert_eq!(pool.highest_finalized_slot.inner(), last_slot.inner() + 10);
 
         // NOW first 10 slots should be gone
         for s in 0..10 {
-            let slot = last_slot + s;
+            let slot = Slot::new(last_slot.inner() + s);
             assert!(!pool.slot_states.contains_key(&slot));
         }
-        assert!(pool.slot_states.contains_key(&(last_slot + 10)));
+        assert!(
+            pool.slot_states
+                .contains_key(&Slot::new(last_slot.inner() + 10))
+        );
 
         drop(votor_rx);
         drop(repair_rx);

--- a/src/consensus/pool/parent_ready_tracker.rs
+++ b/src/consensus/pool/parent_ready_tracker.rs
@@ -96,12 +96,7 @@ impl ParentReadyTracker {
         // find possible parents for future windows
         let mut potential_parents = SmallVec::<[BlockId; 1]>::new();
 
-        let mut slots = slot
-            .slots_in_window()
-            .filter(|s| *s <= slot)
-            .collect::<Vec<_>>();
-        slots.reverse();
-        for s in slots {
+        for s in slot.slots_in_window().filter(|s| *s <= slot).rev() {
             let state = self.0.entry(s).or_default();
             if s < slot {
                 for nf in &state.notar_fallbacks {

--- a/src/consensus/pool/parent_ready_tracker/parent_ready_state.rs
+++ b/src/consensus/pool/parent_ready_tracker/parent_ready_state.rs
@@ -104,13 +104,15 @@ impl ParentReadyState {
 
 #[cfg(test)]
 mod tests {
+    use crate::Slot;
+
     use super::*;
 
     #[test]
     fn wait_for_parent_ready_no_blocking() {
         let mut state = ParentReadyState::default();
         assert_eq!(state.ready_block_ids().len(), 0);
-        let block_id = (0, [1; 32]);
+        let block_id = (Slot::new(0), [1; 32]);
         state.add_to_ready(block_id);
         let res = state.wait_for_parent_ready();
         let Either::Left(received_block_id) = res else {
@@ -128,7 +130,7 @@ mod tests {
         let Either::Right(rx) = res else {
             panic!("Unexpected result {res:?}");
         };
-        let block_id = (0, [1; 32]);
+        let block_id = (Slot::new(0), [1; 32]);
         state.add_to_ready(block_id);
         let received_block_id = rx.await.unwrap();
         assert_eq!(received_block_id, block_id);

--- a/src/consensus/produce_block.rs
+++ b/src/consensus/produce_block.rs
@@ -175,7 +175,7 @@ mod tests {
     async fn produce_slice_empty_slices() {
         let txs_receiver = UdpNetwork::new_with_any_port();
         let sleep_duration = Duration::from_micros(1);
-        let slot = 1;
+        let slot = Slot::new(1);
         // setting != 0 so that parent info is not included in slice
         let slice_index = 123;
         let (slice, cont) = produce_slice(
@@ -206,7 +206,7 @@ mod tests {
         let (slice, cont) = produce_slice(
             &txs_receiver,
             slot,
-            Either::Left((slot - 1, Hash::default(), 0)),
+            Either::Left((slot.prev(), Hash::default(), 0)),
             sleep_duration,
         )
         .await;
@@ -236,7 +236,7 @@ mod tests {
         let txs_sender = UdpNetwork::new_with_any_port();
         // long enough duration so hopefully doesn't fire while collecting txs
         let sleep_duration = Duration::from_secs(100);
-        let slot = 1;
+        let slot = Slot::new(1);
         let slice_index = 123;
 
         tokio::spawn(async move {

--- a/src/consensus/produce_block.rs
+++ b/src/consensus/produce_block.rs
@@ -37,7 +37,7 @@ where
         Either::Left((parent_slot, parent_hash, slice_index)) => {
             let mut data = Vec::with_capacity(MAX_DATA_PER_SLICE);
             // pack parent information in first slice
-            data.extend_from_slice(&parent_slot.to_be_bytes());
+            data.extend_from_slice(&parent_slot.inner().to_be_bytes());
             data.extend_from_slice(&parent_hash);
             let slice_capacity_left = MAX_DATA_PER_SLICE.checked_sub(data.len()).unwrap();
             assert!(slice_capacity_left >= MAX_TRANSACTION_SIZE);

--- a/src/consensus/vote.rs
+++ b/src/consensus/vote.rs
@@ -203,23 +203,23 @@ mod tests {
         let sk = SecretKey::new(&mut rand::rng());
         let pk = sk.to_pk();
 
-        let vote = Vote::new_notar(0, Hash::default(), &sk, 0);
+        let vote = Vote::new_notar(Slot::new(0), Hash::default(), &sk, 0);
         assert!(vote.is_notar());
         assert!(vote.check_sig(&pk));
 
-        let vote = Vote::new_notar_fallback(0, Hash::default(), &sk, 0);
+        let vote = Vote::new_notar_fallback(Slot::new(0), Hash::default(), &sk, 0);
         assert!(vote.is_notar_fallback());
         assert!(vote.check_sig(&pk));
 
-        let vote = Vote::new_skip(0, &sk, 0);
+        let vote = Vote::new_skip(Slot::new(0), &sk, 0);
         assert!(vote.is_skip());
         assert!(vote.check_sig(&pk));
 
-        let vote = Vote::new_skip_fallback(0, &sk, 0);
+        let vote = Vote::new_skip_fallback(Slot::new(0), &sk, 0);
         assert!(vote.is_skip_fallback());
         assert!(vote.check_sig(&pk));
 
-        let vote = Vote::new_final(0, &sk, 0);
+        let vote = Vote::new_final(Slot::new(0), &sk, 0);
         assert!(vote.is_final());
         assert!(vote.check_sig(&pk));
     }

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -98,7 +98,13 @@ impl<N: Network, S: SamplingStrategy> Rotor<N, S> {
     }
 
     fn sample_relay(&self, slot: Slot, shred: usize) -> ValidatorId {
-        let seed = [slot.to_be_bytes(), shred.to_be_bytes(), [0; 8], [0; 8]].concat();
+        let seed = [
+            slot.inner().to_be_bytes(),
+            shred.to_be_bytes(),
+            [0; 8],
+            [0; 8],
+        ]
+        .concat();
         let mut rng = StdRng::from_seed(seed.try_into().unwrap());
         self.sampler.sample(&mut rng)
     }

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -176,7 +176,7 @@ mod tests {
     async fn two_instances() {
         let (sks, mut rotors) = create_rotor_instances(2, 3000);
         let slice = Slice {
-            slot: 0,
+            slot: Slot::new(0),
             slice_index: 0,
             is_last: true,
             merkle_root: None,
@@ -247,7 +247,7 @@ mod tests {
     async fn many_instances() {
         let (sks, mut rotors) = create_rotor_instances(10, 3100);
         let slice = Slice {
-            slot: 0,
+            slot: Slot::new(0),
             slice_index: 0,
             is_last: true,
             merkle_root: None,

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -95,7 +95,7 @@ mod tests {
     async fn dissemination() {
         let (sks, mut disseminators) = create_disseminator_instances(20, 5000);
         let slice = Slice {
-            slot: 0,
+            slot: Slot::new(0),
             slice_index: 0,
             is_last: true,
             merkle_root: None,

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -53,6 +53,7 @@ impl<N: Network> Disseminator for TrivialDisseminator<N> {
 mod tests {
     use super::*;
 
+    use crate::Slot;
     use crate::crypto::aggsig;
     use crate::crypto::signature::SecretKey;
     use crate::network::UdpNetwork;

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -164,7 +164,7 @@ impl TurbineTree {
         // seed the RNG
         let seed = [
             b"ALPENGLOWTURBINE",
-            &slot.to_be_bytes()[..],
+            &slot.inner().to_be_bytes()[..],
             &shred.to_be_bytes()[..],
         ]
         .concat();

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -281,7 +281,7 @@ mod tests {
         let mut trees = Vec::new();
         for v in 0..validators.len() {
             let v = v as ValidatorId;
-            let tree = TurbineTree::new(&validators, 200, v, 0, 0);
+            let tree = TurbineTree::new(&validators, 200, v, Slot::new(0), 0);
             trees.push((v, tree));
         }
 
@@ -317,15 +317,15 @@ mod tests {
         let (_, validators) = create_validator_info(500);
         for v in 0..validators.len() {
             let v = v as ValidatorId;
-            let tree = TurbineTree::new(&validators, 200, v, 0, 0);
+            let tree = TurbineTree::new(&validators, 200, v, Slot::new(0), 0);
             assert!(tree.get_children().len() <= 200);
-            let tree = TurbineTree::new(&validators, 1, v, 0, 0);
+            let tree = TurbineTree::new(&validators, 1, v, Slot::new(0), 0);
             assert!(tree.get_children().len() <= 1);
-            let tree = TurbineTree::new(&validators, 2, v, 0, 0);
+            let tree = TurbineTree::new(&validators, 2, v, Slot::new(0), 0);
             assert!(tree.get_children().len() <= 2);
-            let tree = TurbineTree::new(&validators, 400, v, 0, 0);
+            let tree = TurbineTree::new(&validators, 400, v, Slot::new(0), 0);
             assert!(tree.get_children().len() <= 400);
-            let tree = TurbineTree::new(&validators, 1000, v, 0, 0);
+            let tree = TurbineTree::new(&validators, 1000, v, Slot::new(0), 0);
             assert!(tree.get_children().len() <= 500);
         }
     }
@@ -335,7 +335,7 @@ mod tests {
         let (sks, mut validators) = create_validator_info(10);
         let mut disseminators = create_turbine_instances(&mut validators).await;
         let slice = Slice {
-            slot: 0,
+            slot: Slot::new(0),
             slice_index: 0,
             is_last: true,
             merkle_root: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod logging;
 pub mod network;
 pub mod repair;
 pub mod shredder;
+pub mod slot;
 #[cfg(test)]
 pub mod test_utils;
 pub mod validator;
@@ -23,10 +24,9 @@ pub use all2all::All2All;
 pub use consensus::Alpenglow;
 use crypto::{Hash, aggsig, signature};
 pub use disseminator::Disseminator;
+pub use slot::Slot;
 pub use validator::Validator;
 
-/// Slot number type.
-pub type Slot = u64;
 /// Validator ID number type.
 pub type ValidatorId = u64;
 /// Validator stake type.

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -151,7 +151,7 @@ mod tests {
             let mut data = vec![0; MAX_DATA_PER_SLICE];
             rng.fill_bytes(&mut data);
             let slice = Slice {
-                slot: 0,
+                slot: Slot::new(0),
                 slice_index: i,
                 is_last: i == 4,
                 merkle_root: None,
@@ -212,7 +212,7 @@ mod tests {
             let mut data = vec![0; MAX_DATA_PER_SLICE];
             rng.fill_bytes(&mut data);
             let slice = Slice {
-                slot: 0,
+                slot: Slot::new(0),
                 slice_index: i,
                 is_last: i == 999,
                 merkle_root: None,
@@ -273,7 +273,7 @@ mod tests {
             let mut data = vec![0; MAX_DATA_PER_SLICE];
             rng.fill_bytes(&mut data);
             let slice = Slice {
-                slot: 0,
+                slot: Slot::new(0),
                 slice_index: i,
                 is_last: i == 9999,
                 merkle_root: None,

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -102,6 +102,7 @@ impl Network for SimulatedNetwork {
 mod tests {
     use super::*;
 
+    use crate::Slot;
     use crate::crypto::signature::SecretKey;
     use crate::shredder::{
         DATA_SHREDS, MAX_DATA_PER_SLICE, RegularShredder, Shredder, Slice, TOTAL_SHREDS,

--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -514,7 +514,7 @@ mod tests {
         let mut buf = vec![0u8; MAX_DATA_PER_SLICE - padding];
         rng.fill_bytes(&mut buf);
         Slice {
-            slot: 0,
+            slot: Slot::new(0),
             slice_index: 0,
             is_last: true,
             merkle_root: None,

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -31,7 +31,7 @@ impl Slot {
         (0..).map(Self)
     }
 
-    /// Returns a double ended iterator that yields all the slots in the
+    /// Returns a double-ended iterator that yields all the slots in the
     /// window `self` is in.
     pub fn slots_in_window(self) -> impl DoubleEndedIterator<Item = Slot> {
         let start = self.first_slot_in_window();

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -1,0 +1,90 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ValidatorInfo, consensus::SLOTS_PER_WINDOW};
+
+/// Slot number type.
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct Slot(u64);
+
+impl Slot {
+    pub fn new(slot: u64) -> Self {
+        Self(slot)
+    }
+
+    pub fn take(&self) -> u64 {
+        self.0
+    }
+
+    pub fn to_be_bytes(&self) -> [u8; 8] {
+        self.0.to_be_bytes()
+    }
+
+    pub fn slots_in_window(&self) -> Vec<Slot> {
+        let start = self.first_slot_in_window();
+        (start.0..start.0 + SLOTS_PER_WINDOW)
+            .map(|s| Self::new(s))
+            .collect()
+    }
+
+    pub fn future_slots(&self) -> impl Iterator<Item = Self> {
+        (self.0 + 1..).map(|s| Self(s))
+    }
+
+    /// Returns the first slot in the window this slot belongs to.
+    pub fn first_slot_in_window(&self) -> Slot {
+        let window = self.0 / SLOTS_PER_WINDOW;
+        Self(window * SLOTS_PER_WINDOW)
+    }
+
+    /// Returns the last slow in the window this slot belongs to.
+    pub fn last_slot_in_window(&self) -> Slot {
+        let window = self.0 / SLOTS_PER_WINDOW;
+        let next_window = window + 1;
+        Self(next_window * SLOTS_PER_WINDOW - 1)
+    }
+
+    pub fn first_slot_in_next_window(&self) -> Self {
+        let window = self.0 / SLOTS_PER_WINDOW;
+        let next_window = window + 1;
+        Self(next_window * SLOTS_PER_WINDOW)
+    }
+
+    pub fn last_slot_in_prev_window(&self) -> Self {
+        let window = self.0 / SLOTS_PER_WINDOW;
+        Self(window * SLOTS_PER_WINDOW - 1)
+    }
+
+    pub fn is_start_of_window(&self) -> bool {
+        self.0 % SLOTS_PER_WINDOW == 0
+    }
+
+    pub fn next(&self) -> Self {
+        Self(self.0 + 1)
+    }
+
+    pub fn prev(&self) -> Self {
+        Self(self.0 - 1)
+    }
+
+    /// Returns which validator should be the leader for the window this slot is in.
+    pub fn leader<'a>(&self, validators: &'a [ValidatorInfo]) -> &'a ValidatorInfo {
+        let slot = self.0;
+        let window = (slot / SLOTS_PER_WINDOW) as usize;
+        let ind = window % validators.len();
+        &validators[ind]
+    }
+
+    /// Returns true if this slot is part of the genesis window.
+    pub fn is_genesis_window(&self) -> bool {
+        let window = self.0 / SLOTS_PER_WINDOW;
+        window == 0
+    }
+}
+
+impl Display for Slot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -9,6 +9,10 @@ use crate::ValidatorInfo;
 /// NOTE: this is public to support testing and one function additional function.
 /// Consider hiding it.
 pub const SLOTS_PER_WINDOW: u64 = 4;
+/// Number of slots in each epoch.
+///
+/// NOTE: consider hiding this definition.
+pub const SLOTS_PER_EPOCH: u64 = 18_000;
 
 /// Slot number type.
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -31,8 +31,9 @@ impl Slot {
         (0..).map(Self)
     }
 
-    /// Returns an iterator that yields all the slots in the window `self` is in.
-    pub fn slots_in_window(self) -> impl Iterator<Item = Slot> {
+    /// Returns a double ended iterator that yields all the slots in the
+    /// window `self` is in.
+    pub fn slots_in_window(self) -> impl DoubleEndedIterator<Item = Slot> {
         let start = self.first_slot_in_window();
         (start.0..start.0 + SLOTS_PER_WINDOW).map(Self)
     }

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -31,11 +31,6 @@ impl Slot {
         (0..).map(Self)
     }
 
-    /// Returns the representation in big endian.
-    pub fn to_be_bytes(&self) -> [u8; 8] {
-        self.0.to_be_bytes()
-    }
-
     /// Returns an iterator that yields all the slots in the window `self` is in.
     pub fn slots_in_window(self) -> impl Iterator<Item = Slot> {
         let start = self.first_slot_in_window();

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -24,7 +24,7 @@ impl Slot {
     }
 
     pub fn windows() -> impl Iterator<Item = Self> {
-        (0..).map(|i| Self(i * SLOTS_PER_WINDOW))
+        (0..).map(Self)
     }
 
     pub fn to_be_bytes(&self) -> [u8; 8] {
@@ -33,11 +33,11 @@ impl Slot {
 
     pub fn slots_in_window(self) -> impl Iterator<Item = Slot> {
         let start = self.first_slot_in_window();
-        (start.0..start.0 + SLOTS_PER_WINDOW).map(|s| Self::new(s))
+        (start.0..start.0 + SLOTS_PER_WINDOW).map(Self)
     }
 
     pub fn future_slots(&self) -> impl Iterator<Item = Self> {
-        (self.0 + 1..).map(|s| Self(s))
+        (self.0 + 1..).map(Self)
     }
 
     /// Returns the first slot in the window this slot belongs to.

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -2,8 +2,6 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ValidatorInfo;
-
 /// Number of slots in each leader window.
 ///
 /// NOTE: this is public to support testing and one function additional function.
@@ -23,23 +21,28 @@ impl Slot {
         Self(slot)
     }
 
+    /// Returns the inner u64.
     pub fn inner(self) -> u64 {
         self.0
     }
 
+    /// Returns an infinite iterator that yields the first slot in each window.
     pub fn windows() -> impl Iterator<Item = Self> {
         (0..).map(Self)
     }
 
+    /// Returns the representation in big endian.
     pub fn to_be_bytes(&self) -> [u8; 8] {
         self.0.to_be_bytes()
     }
 
+    /// Returns an iterator that yields all the slots in the window `self` is in.
     pub fn slots_in_window(self) -> impl Iterator<Item = Slot> {
         let start = self.first_slot_in_window();
         (start.0..start.0 + SLOTS_PER_WINDOW).map(Self)
     }
 
+    /// Returns an infinite iterator that yields all the slots after `self`.
     pub fn future_slots(&self) -> impl Iterator<Item = Self> {
         (self.0 + 1..).map(Self)
     }
@@ -57,30 +60,19 @@ impl Slot {
         Self(next_window * SLOTS_PER_WINDOW - 1)
     }
 
-    pub fn first_slot_in_next_window(&self) -> Self {
-        let window = self.0 / SLOTS_PER_WINDOW;
-        let next_window = window + 1;
-        Self(next_window * SLOTS_PER_WINDOW)
-    }
-
+    /// Returns true if `self` is the first slot in the window.
     pub fn is_start_of_window(&self) -> bool {
         self.0 % SLOTS_PER_WINDOW == 0
     }
 
+    /// Returns the next slot after `self`.
     pub fn next(&self) -> Self {
         Self(self.0 + 1)
     }
 
+    /// Returns the previous slot before `self`.
     pub fn prev(&self) -> Self {
         Self(self.0 - 1)
-    }
-
-    /// Returns which validator should be the leader for the window this slot is in.
-    pub fn leader<'a>(&self, validators: &'a [ValidatorInfo]) -> &'a ValidatorInfo {
-        let slot = self.0;
-        let window = (slot / SLOTS_PER_WINDOW) as usize;
-        let ind = window % validators.len();
-        &validators[ind]
     }
 
     /// Returns true if this slot is part of the genesis window.

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -63,11 +63,6 @@ impl Slot {
         Self(next_window * SLOTS_PER_WINDOW)
     }
 
-    pub fn last_slot_in_prev_window(&self) -> Self {
-        let window = self.0 / SLOTS_PER_WINDOW;
-        Self(window * SLOTS_PER_WINDOW - 1)
-    }
-
     pub fn is_start_of_window(&self) -> bool {
         self.0 % SLOTS_PER_WINDOW == 0
     }

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -2,7 +2,13 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ValidatorInfo, consensus::SLOTS_PER_WINDOW};
+use crate::ValidatorInfo;
+
+/// Number of slots in each leader window.
+///
+/// NOTE: this is public to support testing and one function additional function.
+/// Consider hiding it.
+pub const SLOTS_PER_WINDOW: u64 = 4;
 
 /// Slot number type.
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -13,19 +19,21 @@ impl Slot {
         Self(slot)
     }
 
-    pub fn take(&self) -> u64 {
+    pub fn inner(self) -> u64 {
         self.0
+    }
+
+    pub fn windows() -> impl Iterator<Item = Self> {
+        (0..).map(|i| Self(i * SLOTS_PER_WINDOW))
     }
 
     pub fn to_be_bytes(&self) -> [u8; 8] {
         self.0.to_be_bytes()
     }
 
-    pub fn slots_in_window(&self) -> Vec<Slot> {
+    pub fn slots_in_window(self) -> impl Iterator<Item = Slot> {
         let start = self.first_slot_in_window();
-        (start.0..start.0 + SLOTS_PER_WINDOW)
-            .map(|s| Self::new(s))
-            .collect()
+        (start.0..start.0 + SLOTS_PER_WINDOW).map(|s| Self::new(s))
     }
 
     pub fn future_slots(&self) -> impl Iterator<Item = Self> {

--- a/tests/liveness.rs
+++ b/tests/liveness.rs
@@ -11,7 +11,7 @@ use alpenglow::crypto::aggsig;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::{Rotor, rotor::StakeWeightedSampler};
 use alpenglow::network::UdpNetwork;
-use alpenglow::{Alpenglow, ValidatorInfo};
+use alpenglow::{Alpenglow, Slot, ValidatorInfo};
 use rand::prelude::*;
 
 #[tokio::test]
@@ -139,7 +139,7 @@ async fn liveness_test_internal(num_nodes: usize, num_crashes: usize, should_suc
     // spawn a thread checking pool for progress
     let cancel_tokens = node_cancel_tokens.clone();
     let liveness_tester = tokio::spawn(async move {
-        let mut finalized = vec![0; pools.len()];
+        let mut finalized = vec![Slot::new(0); pools.len()];
         for t in 1.. {
             tokio::time::sleep(Duration::from_secs(10)).await;
             for (i, pool) in pools.iter().enumerate() {


### PR DESCRIPTION
Before, we stored the slot as a simple `u64` which is dangerous as it can be mixed up with other unrelated types.  This PR defines `Slot` as a `struct(u64)` to provide us with some type safety.

In general, I am not happy with the use of `SLOTS_PER_WINDOW` in so many tests.  But I am not sure if it makes sense to update them at this point in time.  We can discuss if we want to refactor them in this PR or a subsequent PR.