### PR TITLE
refactor: bubble up `clone`

### DIFF
--- a/benches/disseminator.rs
+++ b/benches/disseminator.rs
@@ -36,7 +36,7 @@ fn turbine_tree(bencher: divan::Bencher) {
                 data: slice_data,
             };
             let sk = SecretKey::new(&mut rng);
-            let mut shreds = RegularShredder::shred(&slice, &sk).unwrap();
+            let mut shreds = RegularShredder::shred(slice, &sk).unwrap();
             let shred = shreds.pop().unwrap();
 
             (shred, turbine1, turbine2)

--- a/benches/network.rs
+++ b/benches/network.rs
@@ -60,7 +60,7 @@ fn serialize_slice(bencher: divan::Bencher) {
                 data: slice_data,
             };
             let sk = signature::SecretKey::new(&mut rng);
-            let shreds = RegularShredder::shred(&slice, &sk).unwrap();
+            let shreds = RegularShredder::shred(slice, &sk).unwrap();
             shreds.into_iter().map(NetworkMessage::Shred).collect()
         })
         .bench_values(|msgs: Vec<NetworkMessage>| {
@@ -87,7 +87,7 @@ fn serialize_slice_into(bencher: divan::Bencher) {
                 data: slice_data,
             };
             let sk = signature::SecretKey::new(&mut rng);
-            let shreds = RegularShredder::shred(&slice, &sk).unwrap();
+            let shreds = RegularShredder::shred(slice, &sk).unwrap();
             let buf = vec![0; 1500];
             let msgs = shreds.into_iter().map(NetworkMessage::Shred).collect();
             (buf, msgs)
@@ -118,7 +118,7 @@ fn deserialize_slice(bencher: divan::Bencher) {
                 data: slice_data,
             };
             let sk = signature::SecretKey::new(&mut rng);
-            let shreds = RegularShredder::shred(&slice, &sk).unwrap();
+            let shreds = RegularShredder::shred(slice, &sk).unwrap();
             let msgs: Vec<_> = shreds.into_iter().map(NetworkMessage::Shred).collect();
             let mut serialized = Vec::new();
             for msg in msgs {

--- a/benches/shredder.rs
+++ b/benches/shredder.rs
@@ -35,7 +35,7 @@ fn shred<S: Shredder>(bencher: divan::Bencher) {
             (slice, sk)
         })
         .bench_values(|(slice, sk): (Slice, SecretKey)| {
-            let _ = S::shred(&slice, &sk).unwrap();
+            let _ = S::shred(slice, &sk).unwrap();
         });
 }
 
@@ -57,7 +57,7 @@ fn deshred<S: Shredder>(bencher: divan::Bencher) {
                 data: slice_data,
             };
             let sk = SecretKey::new(&mut rng);
-            S::shred(&slice, &sk).unwrap()
+            S::shred(slice, &sk).unwrap()
         })
         .bench_values(|shreds: Vec<Shred>| {
             let _ = S::deshred(&shreds[DATA_SHREDS..]).unwrap();

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -286,14 +286,14 @@ mod tests {
         let slices = create_random_block(Slot::new(0), 2);
 
         // first slice is not enough
-        let shreds = RegularShredder::shred(&slices[0], &sk)?;
+        let shreds = RegularShredder::shred(slices[0].clone(), &sk)?;
         for shred in shreds {
             blockstore.add_shred_from_disseminator(shred).await?;
         }
         assert!(blockstore.canonical_block_hash(Slot::new(0)).is_none());
 
         // after second slice we should have the block
-        let shreds = RegularShredder::shred(&slices[1], &sk)?;
+        let shreds = RegularShredder::shred(slices[1].clone(), &sk)?;
         for shred in shreds {
             blockstore.add_shred_from_disseminator(shred).await?;
         }
@@ -313,7 +313,7 @@ mod tests {
         let slices = create_random_block(Slot::new(0), 1);
 
         // insert shreds in reverse order
-        let shreds = RegularShredder::shred(&slices[0], &sk)?;
+        let shreds = RegularShredder::shred(slices[0].clone(), &sk)?;
         for shred in shreds.into_iter().rev() {
             blockstore.add_shred_from_disseminator(shred).await?;
         }
@@ -334,28 +334,28 @@ mod tests {
         assert_eq!(blockstore.stored_slices_for_slot(Slot::new(0)), 0);
 
         // insert just enough shreds to reconstruct slice 0 (from beginning)
-        let shreds = RegularShredder::shred(&slices[0], &sk)?;
+        let shreds = RegularShredder::shred(slices[0].clone(), &sk)?;
         for shred in shreds.into_iter().take(DATA_SHREDS) {
             blockstore.add_shred_from_disseminator(shred).await?;
         }
         assert_eq!(blockstore.stored_slices_for_slot(Slot::new(0)), 1);
 
         // insert just enough shreds to reconstruct slice 1 (from end)
-        let shreds = RegularShredder::shred(&slices[1], &sk)?;
+        let shreds = RegularShredder::shred(slices[1].clone(), &sk)?;
         for shred in shreds.into_iter().skip(TOTAL_SHREDS - DATA_SHREDS) {
             blockstore.add_shred_from_disseminator(shred).await?;
         }
         assert_eq!(blockstore.stored_slices_for_slot(Slot::new(0)), 2);
 
         // insert just enough shreds to reconstruct slice 2 (from middle)
-        let shreds = RegularShredder::shred(&slices[2], &sk)?;
+        let shreds = RegularShredder::shred(slices[2].clone(), &sk)?;
         for shred in shreds.into_iter().skip(DATA_SHREDS / 2) {
             blockstore.add_shred_from_disseminator(shred).await?;
         }
         assert_eq!(blockstore.stored_slices_for_slot(Slot::new(0)), 3);
 
         // insert just enough shreds to reconstruct slice 3 (split)
-        let shreds = RegularShredder::shred(&slices[3], &sk)?;
+        let shreds = RegularShredder::shred(slices[3].clone(), &sk)?;
         for (_, shred) in shreds
             .into_iter()
             .enumerate()
@@ -382,7 +382,7 @@ mod tests {
         let slices = create_random_block(Slot::new(0), 2);
 
         // second slice alone is not enough
-        let shreds = RegularShredder::shred(&slices[0], &sk)?;
+        let shreds = RegularShredder::shred(slices[0].clone(), &sk)?;
         for shred in shreds {
             blockstore.add_shred_from_disseminator(shred).await?;
         }
@@ -395,7 +395,7 @@ mod tests {
         );
 
         // after also also inserting first slice we should have the block
-        let shreds = RegularShredder::shred(&slices[1], &sk)?;
+        let shreds = RegularShredder::shred(slices[1].clone(), &sk)?;
         for shred in shreds {
             blockstore.add_shred_from_disseminator(shred).await?;
         }
@@ -418,7 +418,7 @@ mod tests {
         let slices = create_random_block(Slot::new(0), 1);
 
         // insert many duplicate shreds
-        let shreds = RegularShredder::shred(&slices[0], &sk)?;
+        let shreds = RegularShredder::shred(slices[0].clone(), &sk)?;
         for shred in vec![shreds[0].clone(); 1024] {
             // ignore errors
             let _ = blockstore.add_shred_from_disseminator(shred).await;
@@ -438,7 +438,7 @@ mod tests {
         let slices = create_random_block(Slot::new(0), 1);
 
         // insert shreds with wrong Merkle root
-        let shreds = RegularShredder::shred(&slices[0], &sk)?;
+        let shreds = RegularShredder::shred(slices[0].clone(), &sk)?;
         for mut shred in shreds {
             shred.merkle_root = Hash::default();
             let res = blockstore.add_shred_from_disseminator(shred).await;
@@ -459,9 +459,9 @@ mod tests {
         let block2 = create_random_block(Slot::new(2), 1);
 
         // insert shreds
-        let mut shreds = RegularShredder::shred(&block0[0], &sk)?;
-        shreds.extend(RegularShredder::shred(&block1[0], &sk)?);
-        shreds.extend(RegularShredder::shred(&block2[0], &sk)?);
+        let mut shreds = RegularShredder::shred(block0[0].clone(), &sk)?;
+        shreds.extend(RegularShredder::shred(block1[0].clone(), &sk)?);
+        shreds.extend(RegularShredder::shred(block2[0].clone(), &sk)?);
         for shred in shreds {
             blockstore.add_shred_from_disseminator(shred).await?;
         }

--- a/src/consensus/produce_block.rs
+++ b/src/consensus/produce_block.rs
@@ -126,7 +126,7 @@ where
             let (slice, cont_prod) =
                 produce_slice(&self.txs_receiver, slot, slice_index, sleep_duration).await;
             // shred and disseminate slice
-            let shreds = RegularShredder::shred(&slice, &self.secret_key).unwrap();
+            let shreds = RegularShredder::shred(slice, &self.secret_key).unwrap();
             for s in shreds {
                 self.disseminator.send(&s).await?;
                 // PERF: move expensive add_shred() call out of block production

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -188,7 +188,7 @@ mod tests {
             merkle_root: None,
             data: vec![42; MAX_DATA_PER_SLICE],
         };
-        let shreds = RegularShredder::shred(&slice, &sks[0]).unwrap();
+        let shreds = RegularShredder::shred(slice, &sks[0]).unwrap();
 
         let data_shreds_received = Arc::new(Mutex::new(HashSet::new()));
         let code_shreds_received = Arc::new(Mutex::new(HashSet::new()));
@@ -259,7 +259,7 @@ mod tests {
             merkle_root: None,
             data: vec![42; MAX_DATA_PER_SLICE],
         };
-        let shreds = RegularShredder::shred(&slice, &sks[0]).unwrap();
+        let shreds = RegularShredder::shred(slice, &sks[0]).unwrap();
 
         let mut data_shreds_received = Vec::with_capacity(rotors.len());
         (0..rotors.len())

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -102,7 +102,7 @@ mod tests {
             merkle_root: None,
             data: vec![42; MAX_DATA_PER_SLICE],
         };
-        let shreds = RegularShredder::shred(&slice, &sks[0]).unwrap();
+        let shreds = RegularShredder::shred(slice, &sks[0]).unwrap();
 
         let shreds_received = Arc::new(Mutex::new(0_usize));
         let mut tasks = Vec::new();

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -341,7 +341,7 @@ mod tests {
             merkle_root: None,
             data: vec![42; MAX_DATA_PER_SLICE],
         };
-        let shreds = RegularShredder::shred(&slice, &sks[0]).unwrap();
+        let shreds = RegularShredder::shred(slice, &sks[0]).unwrap();
 
         let shreds_received = Arc::new(Mutex::new(0_usize));
         let mut tasks = Vec::new();

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -158,7 +158,7 @@ mod tests {
                 merkle_root: None,
                 data,
             };
-            let slice_shreds = RegularShredder::shred(&slice, &sk).unwrap();
+            let slice_shreds = RegularShredder::shred(slice, &sk).unwrap();
             shreds.extend(slice_shreds);
         }
 
@@ -219,7 +219,7 @@ mod tests {
                 merkle_root: None,
                 data,
             };
-            let slice_shreds = RegularShredder::shred(&slice, &sk).unwrap();
+            let slice_shreds = RegularShredder::shred(slice, &sk).unwrap();
             shreds.extend(slice_shreds);
         }
 
@@ -280,7 +280,7 @@ mod tests {
                 merkle_root: None,
                 data,
             };
-            let slice_shreds = RegularShredder::shred(&slice, &sk).unwrap();
+            let slice_shreds = RegularShredder::shred(slice, &sk).unwrap();
             shreds.extend(slice_shreds);
         }
 

--- a/src/shredder/reed_solomon.rs
+++ b/src/shredder/reed_solomon.rs
@@ -25,7 +25,7 @@ pub(super) enum ReedSolomonDeshredError {
 /// Splits the given slice into `num_data` data shreds, then generates
 /// `num_coding` additional Reed-Solomon coding shreds.
 pub(super) fn reed_solomon_shred(
-    slice: &Slice,
+    slice: Slice,
     num_data: usize,
     num_coding: usize,
 ) -> Result<(Vec<DataShred>, Vec<CodingShred>), ReedSolomonShredError> {
@@ -36,7 +36,7 @@ pub(super) fn reed_solomon_shred(
         merkle_root: _,
         data,
     } = slice;
-    reed_solomon_shred_raw(*slot, *slice_index, *is_last, data, num_data, num_coding)
+    reed_solomon_shred_raw(slot, slice_index, is_last, data, num_data, num_coding)
 }
 
 /// Splits the given data into `num_data` data shreds, then generates
@@ -47,7 +47,7 @@ pub(super) fn reed_solomon_shred_raw(
     slot: Slot,
     slice_index: usize,
     is_last_slice: bool,
-    data: &[u8],
+    data: Vec<u8>,
     num_data: usize,
     num_coding: usize,
 ) -> Result<(Vec<DataShred>, Vec<CodingShred>), ReedSolomonShredError> {


### PR DESCRIPTION
Shredding a slice currently ends up cloning the slice.  So passing a reference to the slice to the function in effect hides this information at the type level.  Changing the API to consume the slice so that the callers know that this is an expensive operation.