### PR TITLE
feat: track parent separately in `Slice`

### DIFF
--- a/benches/disseminator.rs
+++ b/benches/disseminator.rs
@@ -1,14 +1,12 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use alpenglow::Slot;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Turbine;
 use alpenglow::network::UdpNetwork;
 use alpenglow::shredder::{MAX_DATA_PER_SLICE, RegularShredder, Shredder};
-use alpenglow::slice::Slice;
+use alpenglow::slice::create_random_slice;
 use divan::counter::ItemsCount;
-use rand::RngCore;
 
 fn main() {
     // run registered benchmarks.
@@ -26,16 +24,8 @@ fn turbine_tree(bencher: divan::Bencher) {
             let turbine1 = Turbine::new(0, Vec::new(), net1);
             let turbine2 = Turbine::new(1, Vec::new(), net2);
 
+            let slice = create_random_slice(MAX_DATA_PER_SLICE);
             let mut rng = rand::rng();
-            let mut slice_data = vec![0; MAX_DATA_PER_SLICE];
-            rng.fill_bytes(&mut slice_data);
-            let slice = Slice {
-                slot: Slot::new(0),
-                slice_index: 0,
-                is_last: true,
-                merkle_root: None,
-                data: slice_data,
-            };
             let sk = SecretKey::new(&mut rng);
             let mut shreds = RegularShredder::shred(slice, &sk).unwrap();
             let shred = shreds.pop().unwrap();

--- a/benches/network.rs
+++ b/benches/network.rs
@@ -6,7 +6,7 @@ use alpenglow::consensus::Vote;
 use alpenglow::crypto::{Hash, aggsig, signature};
 use alpenglow::network::NetworkMessage;
 use alpenglow::shredder::{MAX_DATA_PER_SLICE, RegularShredder, Shredder};
-use alpenglow::slice::Slice;
+use alpenglow::slice::create_random_slice;
 use divan::counter::{BytesCount, ItemsCount};
 use rand::RngCore;
 
@@ -50,16 +50,8 @@ fn serialize_slice(bencher: divan::Bencher) {
         .counter(ItemsCount::new(1_usize))
         .counter(BytesCount::new(MAX_DATA_PER_SLICE))
         .with_inputs(|| {
+            let slice = create_random_slice(MAX_DATA_PER_SLICE);
             let mut rng = rand::rng();
-            let mut slice_data = vec![0; MAX_DATA_PER_SLICE];
-            rng.fill_bytes(&mut slice_data);
-            let slice = Slice {
-                slot: Slot::new(0),
-                slice_index: 0,
-                is_last: true,
-                merkle_root: None,
-                data: slice_data,
-            };
             let sk = signature::SecretKey::new(&mut rng);
             let shreds = RegularShredder::shred(slice, &sk).unwrap();
             shreds.into_iter().map(NetworkMessage::Shred).collect()
@@ -78,15 +70,7 @@ fn serialize_slice_into(bencher: divan::Bencher) {
         .counter(BytesCount::new(MAX_DATA_PER_SLICE))
         .with_inputs(|| {
             let mut rng = rand::rng();
-            let mut slice_data = vec![0; MAX_DATA_PER_SLICE];
-            rng.fill_bytes(&mut slice_data);
-            let slice = Slice {
-                slot: Slot::new(0),
-                slice_index: 0,
-                is_last: true,
-                merkle_root: None,
-                data: slice_data,
-            };
+            let slice = create_random_slice(MAX_DATA_PER_SLICE);
             let sk = signature::SecretKey::new(&mut rng);
             let shreds = RegularShredder::shred(slice, &sk).unwrap();
             let buf = vec![0; 1500];
@@ -109,15 +93,7 @@ fn deserialize_slice(bencher: divan::Bencher) {
         .counter(BytesCount::new(MAX_DATA_PER_SLICE))
         .with_inputs(|| {
             let mut rng = rand::rng();
-            let mut slice_data = vec![0; MAX_DATA_PER_SLICE];
-            rng.fill_bytes(&mut slice_data);
-            let slice = Slice {
-                slot: Slot::new(0),
-                slice_index: 0,
-                is_last: true,
-                merkle_root: None,
-                data: slice_data,
-            };
+            let slice = create_random_slice(MAX_DATA_PER_SLICE);
             let sk = signature::SecretKey::new(&mut rng);
             let shreds = RegularShredder::shred(slice, &sk).unwrap();
             let msgs: Vec<_> = shreds.into_iter().map(NetworkMessage::Shred).collect();

--- a/benches/shredder.rs
+++ b/benches/shredder.rs
@@ -1,14 +1,12 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use alpenglow::Slot;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::shredder::{
     AontShredder, CodingOnlyShredder, DATA_SHREDS, PetsShredder, RegularShredder, Shred, Shredder,
 };
-use alpenglow::slice::Slice;
+use alpenglow::slice::{Slice, create_random_slice};
 use divan::counter::BytesCount;
-use rand::prelude::*;
 
 fn main() {
     divan::main();
@@ -21,16 +19,8 @@ fn shred<S: Shredder>(bencher: divan::Bencher) {
     bencher
         .counter(BytesCount::new(size))
         .with_inputs(|| {
+            let slice = create_random_slice(size);
             let mut rng = rand::rng();
-            let mut slice_data = vec![0; size];
-            rng.fill_bytes(&mut slice_data);
-            let slice = Slice {
-                slot: Slot::new(0),
-                slice_index: 0,
-                is_last: true,
-                merkle_root: None,
-                data: slice_data,
-            };
             let sk = SecretKey::new(&mut rng);
             (slice, sk)
         })
@@ -46,16 +36,8 @@ fn deshred<S: Shredder>(bencher: divan::Bencher) {
     bencher
         .counter(BytesCount::new(size))
         .with_inputs(|| {
+            let slice = create_random_slice(size);
             let mut rng = rand::rng();
-            let mut slice_data = vec![0; size];
-            rng.fill_bytes(&mut slice_data);
-            let slice = Slice {
-                slot: Slot::new(0),
-                slice_index: 0,
-                is_last: true,
-                merkle_root: None,
-                data: slice_data,
-            };
             let sk = SecretKey::new(&mut rng);
             S::shred(slice, &sk).unwrap()
         })

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -263,7 +263,12 @@ mod tests {
     fn create_random_block(slot: Slot, num_slices: usize) -> Vec<Slice> {
         let mut slices = Vec::new();
         for slice_index in 0..num_slices {
-            let payload = create_random_slice_payload(MAX_DATA_PER_SLICE);
+            let parent = if slice_index == 0 {
+                Some((Slot::new(0), Hash::default()))
+            } else {
+                None
+            };
+            let payload = create_random_slice_payload(parent, MAX_DATA_PER_SLICE);
             let header = SliceHeader {
                 slot,
                 slice_index,

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -238,9 +238,9 @@ mod tests {
     use crate::shredder::{
         DATA_SHREDS, MAX_DATA_PER_SLICE, RegularShredder, Shredder, TOTAL_SHREDS,
     };
+    use crate::slice::{SliceHeader, create_random_slice_payload};
 
     use color_eyre::Result;
-    use rand::RngCore;
     use tokio::sync::mpsc;
 
     fn test_setup(tx: Sender<VotorEvent>) -> (SecretKey, Blockstore) {
@@ -262,17 +262,14 @@ mod tests {
 
     fn create_random_block(slot: Slot, num_slices: usize) -> Vec<Slice> {
         let mut slices = Vec::new();
-        let mut rng = rand::rng();
         for slice_index in 0..num_slices {
-            let mut buf = vec![0u8; MAX_DATA_PER_SLICE];
-            rng.fill_bytes(&mut buf);
-            slices.push(Slice {
+            let payload = create_random_slice_payload(MAX_DATA_PER_SLICE);
+            let header = SliceHeader {
                 slot,
                 slice_index,
                 is_last: slice_index == num_slices - 1,
-                merkle_root: None,
-                data: buf,
-            });
+            };
+            slices.push(Slice::from_parts(header, payload, None));
         }
         slices
     }

--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -254,10 +254,8 @@ impl BlockData {
 
         // reconstruct block header
         let first_slice = self.slices.get(&0).unwrap();
-        let parent_slot = Slot::new(u64::from_be_bytes(
-            first_slice.data[0..8].try_into().unwrap(),
-        ));
-        let parent_hash = first_slice.data[8..40].try_into().unwrap();
+        // TODO: maybe return an error if first slice does not have parent info?
+        let (parent_slot, parent_hash) = first_slice.parent.unwrap();
         // TODO: reconstruct actual block content
         let block = Block {
             slot: self.slot,

--- a/src/consensus/produce_block.rs
+++ b/src/consensus/produce_block.rs
@@ -71,6 +71,8 @@ where
                                 .expect("serialization should not panic");
                             slice_capacity_left = slice_capacity_left.checked_sub(tx.len()).unwrap();
                             txs.push(tx);
+                            // subtract from time left should be the final action to ensure it accounts for all work done in the loop.
+                            time_left = time_left.saturating_sub(Instant::now() - start_time);
                             if slice_capacity_left < MAX_TRANSACTION_SIZE {
                                 break Continue::Continue { left: time_left };
                             }
@@ -80,7 +82,6 @@ where
                         }
                     },
                 }
-                time_left = time_left.saturating_sub(Instant::now() - start_time);
             }
         }
     };

--- a/src/consensus/produce_block.rs
+++ b/src/consensus/produce_block.rs
@@ -86,6 +86,7 @@ where
         }
     };
 
+    // TODO: not accounting for this potentially operation in block production time above.
     let txs = bincode::serde::encode_to_vec(&txs, bincode::config::standard())
         .expect("serialization should not panic");
 

--- a/src/consensus/produce_block.rs
+++ b/src/consensus/produce_block.rs
@@ -48,7 +48,11 @@ where
     // Super hacky!!!  As long as the size of the txs vec fits in a single byte,
     // bincode encoding seems to take a single byte so account for that here.
     assert_eq!(highest_non_zero_byte(MAX_TRANSACTIONS_PER_SLICE), 1);
-    let mut slice_capacity_left = MAX_DATA_PER_SLICE - parent_encoded_len - 1;
+    let mut slice_capacity_left = MAX_DATA_PER_SLICE
+        .checked_sub(parent_encoded_len)
+        .unwrap()
+        .checked_sub(1)
+        .unwrap();
     let mut txs = Vec::new();
 
     let cont_prod = loop {

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -140,7 +140,7 @@ mod tests {
     use crate::shredder::{
         MAX_DATA_PER_SLICE, RegularShredder, ShredPayloadType, Shredder, TOTAL_SHREDS,
     };
-    use crate::slice::Slice;
+    use crate::slice::create_random_slice;
 
     use tokio::sync::Mutex;
     use tokio::task;
@@ -182,13 +182,7 @@ mod tests {
     #[tokio::test]
     async fn two_instances() {
         let (sks, mut rotors) = create_rotor_instances(2, 3000);
-        let slice = Slice {
-            slot: Slot::new(0),
-            slice_index: 0,
-            is_last: true,
-            merkle_root: None,
-            data: vec![42; MAX_DATA_PER_SLICE],
-        };
+        let slice = create_random_slice(MAX_DATA_PER_SLICE);
         let shreds = RegularShredder::shred(slice, &sks[0]).unwrap();
 
         let data_shreds_received = Arc::new(Mutex::new(HashSet::new()));
@@ -253,13 +247,7 @@ mod tests {
     #[tokio::test]
     async fn many_instances() {
         let (sks, mut rotors) = create_rotor_instances(10, 3100);
-        let slice = Slice {
-            slot: Slot::new(0),
-            slice_index: 0,
-            is_last: true,
-            merkle_root: None,
-            data: vec![42; MAX_DATA_PER_SLICE],
-        };
+        let slice = create_random_slice(MAX_DATA_PER_SLICE);
         let shreds = RegularShredder::shred(slice, &sks[0]).unwrap();
 
         let mut data_shreds_received = Vec::with_capacity(rotors.len());

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -53,12 +53,11 @@ impl<N: Network> Disseminator for TrivialDisseminator<N> {
 mod tests {
     use super::*;
 
-    use crate::Slot;
     use crate::crypto::aggsig;
     use crate::crypto::signature::SecretKey;
     use crate::network::UdpNetwork;
     use crate::shredder::{MAX_DATA_PER_SLICE, RegularShredder, Shredder, TOTAL_SHREDS};
-    use crate::slice::Slice;
+    use crate::slice::create_random_slice;
 
     use tokio::{sync::Mutex, task};
 
@@ -96,13 +95,7 @@ mod tests {
     #[tokio::test]
     async fn dissemination() {
         let (sks, mut disseminators) = create_disseminator_instances(20, 5000);
-        let slice = Slice {
-            slot: Slot::new(0),
-            slice_index: 0,
-            is_last: true,
-            merkle_root: None,
-            data: vec![42; MAX_DATA_PER_SLICE],
-        };
+        let slice = create_random_slice(MAX_DATA_PER_SLICE);
         let shreds = RegularShredder::shred(slice, &sks[0]).unwrap();
 
         let shreds_received = Arc::new(Mutex::new(0_usize));

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -230,7 +230,7 @@ mod tests {
     use crate::network::SimulatedNetwork;
     use crate::network::simulated::SimulatedNetworkCore;
     use crate::shredder::{MAX_DATA_PER_SLICE, RegularShredder, Shredder, TOTAL_SHREDS};
-    use crate::slice::Slice;
+    use crate::slice::create_random_slice;
 
     use tokio::{sync::Mutex, task};
 
@@ -335,13 +335,7 @@ mod tests {
     async fn dissemination() {
         let (sks, mut validators) = create_validator_info(10);
         let mut disseminators = create_turbine_instances(&mut validators).await;
-        let slice = Slice {
-            slot: Slot::new(0),
-            slice_index: 0,
-            is_last: true,
-            merkle_root: None,
-            data: vec![42; MAX_DATA_PER_SLICE],
-        };
+        let slice = create_random_slice(MAX_DATA_PER_SLICE);
         let shreds = RegularShredder::shred(slice, &sks[0]).unwrap();
 
         let shreds_received = Arc::new(Mutex::new(0_usize));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ pub type BlockId = (Slot, Hash);
 
 const MAX_TRANSACTION_SIZE: usize = 512;
 
+const MAX_TRANSACTIONS_PER_SLICE: usize = 255;
+
 /// Parsed block with information about parent and transactions as payload.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Block {
@@ -64,4 +66,14 @@ pub struct ValidatorInfo {
     pub all2all_address: String,
     pub disseminator_address: String,
     pub repair_address: String,
+}
+
+/// Returns the highest non-zero byte in `val`.
+pub(crate) fn highest_non_zero_byte(mut val: usize) -> usize {
+    let mut cnt = 0;
+    while val != 0 {
+        val /= 256;
+        cnt += 1;
+    }
+    cnt
 }

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -152,7 +152,7 @@ mod tests {
             let header = SliceHeader {
                 slot: Slot::new(0),
                 slice_index: i,
-                is_last: i == 4,
+                is_last: i == 1,
             };
             let slice = Slice::from_parts(header, payload, None);
             let slice_shreds = RegularShredder::shred(slice, &sk).unwrap();

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -107,9 +107,7 @@ mod tests {
     use crate::shredder::{
         DATA_SHREDS, MAX_DATA_PER_SLICE, RegularShredder, Shredder, TOTAL_SHREDS,
     };
-    use crate::slice::Slice;
-
-    use rand::RngCore;
+    use crate::slice::{Slice, SliceHeader, create_random_slice_payload};
 
     use std::time::Instant;
 
@@ -150,15 +148,13 @@ mod tests {
         let sk = SecretKey::new(&mut rng);
         let mut shreds = Vec::new();
         for i in 0..2 {
-            let mut data = vec![0; MAX_DATA_PER_SLICE];
-            rng.fill_bytes(&mut data);
-            let slice = Slice {
+            let payload = create_random_slice_payload(MAX_DATA_PER_SLICE);
+            let header = SliceHeader {
                 slot: Slot::new(0),
                 slice_index: i,
                 is_last: i == 4,
-                merkle_root: None,
-                data,
             };
+            let slice = Slice::from_parts(header, payload, None);
             let slice_shreds = RegularShredder::shred(slice, &sk).unwrap();
             shreds.extend(slice_shreds);
         }
@@ -211,15 +207,13 @@ mod tests {
         let sk = SecretKey::new(&mut rng);
         let mut shreds = Vec::new();
         for i in 0..1000 {
-            let mut data = vec![0; MAX_DATA_PER_SLICE];
-            rng.fill_bytes(&mut data);
-            let slice = Slice {
+            let payload = create_random_slice_payload(MAX_DATA_PER_SLICE);
+            let header = SliceHeader {
                 slot: Slot::new(0),
                 slice_index: i,
                 is_last: i == 999,
-                merkle_root: None,
-                data,
             };
+            let slice = Slice::from_parts(header, payload, None);
             let slice_shreds = RegularShredder::shred(slice, &sk).unwrap();
             shreds.extend(slice_shreds);
         }
@@ -272,15 +266,13 @@ mod tests {
         let sk = SecretKey::new(&mut rng);
         let mut shreds = Vec::new();
         for i in 0..10_000 {
-            let mut data = vec![0; MAX_DATA_PER_SLICE];
-            rng.fill_bytes(&mut data);
-            let slice = Slice {
+            let payload = create_random_slice_payload(MAX_DATA_PER_SLICE);
+            let header = SliceHeader {
                 slot: Slot::new(0),
                 slice_index: i,
                 is_last: i == 9999,
-                merkle_root: None,
-                data,
             };
+            let slice = Slice::from_parts(header, payload, None);
             let slice_shreds = RegularShredder::shred(slice, &sk).unwrap();
             shreds.extend(slice_shreds);
         }

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -148,7 +148,7 @@ mod tests {
         let sk = SecretKey::new(&mut rng);
         let mut shreds = Vec::new();
         for i in 0..2 {
-            let payload = create_random_slice_payload(MAX_DATA_PER_SLICE);
+            let payload = create_random_slice_payload(None, MAX_DATA_PER_SLICE);
             let header = SliceHeader {
                 slot: Slot::new(0),
                 slice_index: i,
@@ -207,7 +207,7 @@ mod tests {
         let sk = SecretKey::new(&mut rng);
         let mut shreds = Vec::new();
         for i in 0..1000 {
-            let payload = create_random_slice_payload(MAX_DATA_PER_SLICE);
+            let payload = create_random_slice_payload(None, MAX_DATA_PER_SLICE);
             let header = SliceHeader {
                 slot: Slot::new(0),
                 slice_index: i,
@@ -266,7 +266,7 @@ mod tests {
         let sk = SecretKey::new(&mut rng);
         let mut shreds = Vec::new();
         for i in 0..10_000 {
-            let payload = create_random_slice_payload(MAX_DATA_PER_SLICE);
+            let payload = create_random_slice_payload(None, MAX_DATA_PER_SLICE);
             let header = SliceHeader {
                 slot: Slot::new(0),
                 slice_index: i,

--- a/src/shredder/reed_solomon.rs
+++ b/src/shredder/reed_solomon.rs
@@ -144,8 +144,17 @@ mod tests {
 
     #[test]
     fn restore_empty() {
-        let (header, payload) = create_random_slice(0).deconstruct();
-        shred_deshred_restore(header, payload);
+        let header = SliceHeader {
+            slot: Slot::new(0),
+            slice_index: 0,
+            is_last: true,
+        };
+        let payload = vec![0];
+        let (data, coding) =
+            reed_solomon_shred(header, payload.clone(), DATA_SHREDS, DATA_SHREDS).unwrap();
+        let shreds = take_and_map_enough_shreds(data, coding);
+        let restored = reed_solomon_deshred(&shreds, DATA_SHREDS, DATA_SHREDS).unwrap();
+        assert_eq!(restored, payload);
     }
 
     #[test]

--- a/src/shredder/reed_solomon.rs
+++ b/src/shredder/reed_solomon.rs
@@ -123,6 +123,7 @@ pub(super) fn reed_solomon_deshred(
 mod tests {
     use super::*;
 
+    use crate::Slot;
     use crate::crypto::signature::SecretKey;
     use crate::shredder::data_and_coding_to_output_shreds;
     use crate::slice::{SlicePayload, create_random_slice};
@@ -159,8 +160,13 @@ mod tests {
 
     #[test]
     fn shred_too_much_data() {
-        let (header, payload) = create_random_slice(MAX_DATA_PER_SLICE + 1).deconstruct();
-        let res = reed_solomon_shred(header, payload.into(), DATA_SHREDS, DATA_SHREDS);
+        let header = SliceHeader {
+            slot: Slot::new(0),
+            slice_index: 0,
+            is_last: true,
+        };
+        let payload = vec![0; MAX_DATA_PER_SLICE + 1];
+        let res = reed_solomon_shred(header, payload, DATA_SHREDS, DATA_SHREDS);
         assert!(res.is_err());
         assert_eq!(res.err().unwrap(), ReedSolomonShredError::TooMuchData);
     }

--- a/src/shredder/reed_solomon.rs
+++ b/src/shredder/reed_solomon.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use super::{
     CodingShred, DATA_SHREDS, DataShred, MAX_DATA_PER_SLICE, MAX_DATA_PER_SLICE_AFTER_PADDING,
-    Shred, ShredPayload, ShredPayloadType, SliceHeader, SlicePayload, TOTAL_SHREDS,
+    Shred, ShredPayload, ShredPayloadType, SliceHeader, TOTAL_SHREDS,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
@@ -31,7 +31,7 @@ pub(super) enum ReedSolomonDeshredError {
 /// `num_coding` additional Reed-Solomon coding shreds.
 pub(super) fn reed_solomon_shred(
     header: SliceHeader,
-    mut payload: SlicePayload,
+    mut payload: Vec<u8>,
     num_data: usize,
     num_coding: usize,
 ) -> Result<(Vec<DataShred>, Vec<CodingShred>), ReedSolomonShredError> {
@@ -43,9 +43,7 @@ pub(super) fn reed_solomon_shred(
     // TODO: use a padding scheme that can support larger slices
     let padding_bytes = u8::try_from(2 * DATA_SHREDS - payload.len() % (2 * DATA_SHREDS))
         .expect("cannot fit number of padding bytes in u8");
-    payload
-        .data
-        .resize(payload.len() + padding_bytes as usize, padding_bytes);
+    payload.resize(payload.len() + padding_bytes as usize, padding_bytes);
     assert!(payload.len() <= MAX_DATA_PER_SLICE_AFTER_PADDING);
 
     let shred_bytes = payload.len().div_ceil(DATA_SHREDS);
@@ -125,28 +123,27 @@ pub(super) fn reed_solomon_deshred(
 mod tests {
     use super::*;
 
-    use crate::Slot;
     use crate::crypto::signature::SecretKey;
     use crate::shredder::data_and_coding_to_output_shreds;
+    use crate::slice::{SlicePayload, create_random_slice};
 
-    use rand::Rng;
     use static_assertions::const_assert;
 
     #[test]
     fn restore_full() {
-        let (header, payload) = random_slice(MAX_DATA_PER_SLICE);
+        let (header, payload) = create_random_slice(MAX_DATA_PER_SLICE).deconstruct();
         shred_deshred_restore(header, payload);
     }
 
     #[test]
     fn restore_tiny() {
-        let (header, payload) = random_slice(DATA_SHREDS - 1);
+        let (header, payload) = create_random_slice(DATA_SHREDS - 1).deconstruct();
         shred_deshred_restore(header, payload);
     }
 
     #[test]
     fn restore_empty() {
-        let (header, payload) = random_slice(0);
+        let (header, payload) = create_random_slice(0).deconstruct();
         shred_deshred_restore(header, payload);
     }
 
@@ -155,15 +152,15 @@ mod tests {
         const_assert!(MAX_DATA_PER_SLICE >= 2 * DATA_SHREDS);
         let slice_bytes = MAX_DATA_PER_SLICE / 2;
         for offset in 0..DATA_SHREDS {
-            let (header, payload) = random_slice(slice_bytes + offset);
+            let (header, payload) = create_random_slice(slice_bytes + offset).deconstruct();
             shred_deshred_restore(header, payload);
         }
     }
 
     #[test]
     fn shred_too_much_data() {
-        let (header, payload) = random_slice(MAX_DATA_PER_SLICE + 1);
-        let res = reed_solomon_shred(header, payload, DATA_SHREDS, DATA_SHREDS);
+        let (header, payload) = create_random_slice(MAX_DATA_PER_SLICE + 1).deconstruct();
+        let res = reed_solomon_shred(header, payload.into(), DATA_SHREDS, DATA_SHREDS);
         assert!(res.is_err());
         assert_eq!(res.err().unwrap(), ReedSolomonShredError::TooMuchData);
     }
@@ -171,9 +168,9 @@ mod tests {
     #[test]
     fn deshred_too_many_shreds() {
         const CODING_SHREDS: usize = TOTAL_SHREDS - DATA_SHREDS + 1;
-        let (header, payload) = random_slice(MAX_DATA_PER_SLICE);
+        let (header, payload) = create_random_slice(MAX_DATA_PER_SLICE).deconstruct();
         let (data, coding) =
-            reed_solomon_shred(header, payload.clone(), DATA_SHREDS, CODING_SHREDS).unwrap();
+            reed_solomon_shred(header, payload.clone().into(), DATA_SHREDS, CODING_SHREDS).unwrap();
         let sk = SecretKey::new(&mut rand::rng());
         let shreds = data_and_coding_to_output_shreds(data, coding, &sk);
         let res = reed_solomon_deshred(&shreds, DATA_SHREDS, DATA_SHREDS);
@@ -183,9 +180,9 @@ mod tests {
 
     #[test]
     fn deshred_not_enough_shreds() {
-        let (header, payload) = random_slice(MAX_DATA_PER_SLICE);
+        let (header, payload) = create_random_slice(MAX_DATA_PER_SLICE).deconstruct();
         let (data, coding) =
-            reed_solomon_shred(header, payload.clone(), DATA_SHREDS, DATA_SHREDS).unwrap();
+            reed_solomon_shred(header, payload.clone().into(), DATA_SHREDS, DATA_SHREDS).unwrap();
         let sk = SecretKey::new(&mut rand::rng());
         let mut shreds = data_and_coding_to_output_shreds(data, coding, &sk);
         shreds.truncate(DATA_SHREDS - 1);
@@ -194,25 +191,13 @@ mod tests {
         assert_eq!(res.err().unwrap(), ReedSolomonDeshredError::NotEnoughShreds);
     }
 
-    fn random_slice(num_bytes: usize) -> (SliceHeader, SlicePayload) {
-        let mut rng = rand::rng();
-        let header = SliceHeader {
-            slot: Slot::new(rng.random::<u64>()),
-            slice_index: rng.random::<u64>() as usize,
-            is_last: rng.random(),
-        };
-        let payload = SlicePayload {
-            data: vec![rng.random(); num_bytes],
-        };
-        (header, payload)
-    }
-
     fn shred_deshred_restore(header: SliceHeader, payload: SlicePayload) {
         let (data, coding) =
-            reed_solomon_shred(header, payload.clone(), DATA_SHREDS, DATA_SHREDS).unwrap();
+            reed_solomon_shred(header, payload.clone().into(), DATA_SHREDS, DATA_SHREDS).unwrap();
         let shreds = take_and_map_enough_shreds(data, coding);
         let restored = reed_solomon_deshred(&shreds, DATA_SHREDS, DATA_SHREDS).unwrap();
-        assert_eq!(restored, payload.data);
+        let payload: Vec<u8> = payload.into();
+        assert_eq!(restored, payload);
     }
 
     fn take_and_map_enough_shreds(data: Vec<DataShred>, coding: Vec<CodingShred>) -> Vec<Shred> {

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -144,10 +144,12 @@ fn num_bytes_set(mut val: usize) -> usize {
 /// This function should only be used for testing and benchmarking.
 //
 // XXX: This is only used in test and benchmarking code.  Ensure it is only compiled when we are testing or benchmarking.
-pub fn create_random_slice_payload(desired_size: usize) -> SlicePayload {
+pub fn create_random_slice_payload(
+    parent: Option<(Slot, Hash)>,
+    desired_size: usize,
+) -> SlicePayload {
     let mut payload = vec![0; desired_size];
 
-    let parent: Option<(Slot, Hash)> = None;
     let used = bincode::serde::encode_into_slice(parent, &mut payload, bincode::config::standard())
         .unwrap();
     let left = desired_size.checked_sub(used).unwrap();
@@ -169,7 +171,7 @@ pub fn create_random_slice_payload(desired_size: usize) -> SlicePayload {
 
 // XXX: This is only used in test and benchmarking code.  Ensure it is only compiled when we are testing or benchmarking.
 pub fn create_random_slice(desired_size: usize) -> Slice {
-    let payload = create_random_slice_payload(desired_size);
+    let payload = create_random_slice_payload(None, desired_size);
     let header = SliceHeader {
         slot: Slot::new(0),
         slice_index: 0,

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -25,12 +25,15 @@ pub struct Slice {
     pub is_last: bool,
     /// Merkle root hash over all shreds in this slice.
     pub merkle_root: Option<Hash>,
+    /// If first slice in the block or parent changed due to optimistic handover,
+    /// then indicates which block is the parent of the block this slice is part of.
     pub parent: Option<(Slot, Hash)>,
     /// Payload bytes.
     pub data: Vec<u8>,
 }
 
 impl Slice {
+    /// Constructs a [`Slice`] from its component parts.
     pub(crate) fn from_parts(
         header: SliceHeader,
         payload: SlicePayload,
@@ -136,6 +139,10 @@ fn num_bytes_set(mut val: usize) -> usize {
     cnt
 }
 
+/// Creates a [`Slice`] with a random payload of the desired size.
+///
+/// This function should only be used for testing and benchmarking.
+//
 // XXX: This is only used in test and benchmarking code.  Ensure it is only compiled when we are testing or benchmarking.
 pub fn create_random_slice_payload(desired_size: usize) -> SlicePayload {
     let mut payload = vec![0; desired_size];

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,7 +1,5 @@
-#[cfg(test)]
 use std::sync::Arc;
 
-#[cfg(test)]
 use crate::{
     ValidatorId, ValidatorInfo,
     all2all::TrivialAll2All,
@@ -11,7 +9,6 @@ use crate::{
     network::simulated::SimulatedNetworkCore,
 };
 
-#[cfg(test)]
 pub fn generate_validators(num_validators: u64) -> (Vec<SecretKey>, Arc<EpochInfo>) {
     let mut rng = rand::rng();
     let mut sks = Vec::new();
@@ -34,7 +31,6 @@ pub fn generate_validators(num_validators: u64) -> (Vec<SecretKey>, Arc<EpochInf
     (voting_sks, epoch_info)
 }
 
-#[cfg(test)]
 pub async fn generate_all2all_instances(
     mut validators: Vec<ValidatorInfo>,
 ) -> Vec<TrivialAll2All<SimulatedNetwork>> {


### PR DESCRIPTION
Part of #4.  We now track parent in the slice separately from the actual data payload.  This will make it easier to indicate when a slice contains a parent or not.