### PR TITLE
fix: timeouts

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -52,7 +52,7 @@ pub use vote::Vote;
 use votor::Votor;
 
 /// Time bound assumed on network transmission delays during periods of synchrony.
-const DELTA: Duration = Duration::from_millis(200);
+const DELTA: Duration = Duration::from_millis(250);
 /// Time the leader has for producing and sending the block.
 const DELTA_BLOCK: Duration = Duration::from_millis(400);
 /// Timeout to use when we haven't seen any shred from the leader's block.

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -61,9 +61,7 @@ const DELTA: Duration = Duration::from_millis(400);
 const DELTA_BLOCK: Duration = Duration::from_millis(400);
 /// Timeout to use when we haven't seen any shred from the leader's block.
 /// This is used to skip honest but crashed leaders faster.
-const DELTA_EARLY_TIMEOUT: Duration = DELTA.checked_mul(2).unwrap();
-/// Timeout to use when we have seen at least one shred from the leader's block.
-const DELTA_TIMEOUT: Duration = DELTA_EARLY_TIMEOUT.checked_add(DELTA_BLOCK).unwrap();
+const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
 /// Timeout for standstill detection mechanism.
 const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -55,8 +55,7 @@ use votor::Votor;
 const DELTA: Duration = Duration::from_millis(250);
 /// Time the leader has for producing and sending the block.
 const DELTA_BLOCK: Duration = Duration::from_millis(400);
-/// Timeout to use when we haven't seen any shred from the leader's block.
-/// This is used to skip honest but crashed leaders faster.
+/// Base timeout for when leader's first slice should arrive if they sent it immediately.
 const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
 /// Timeout for standstill detection mechanism.
 const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -52,7 +52,7 @@ pub use vote::Vote;
 use votor::Votor;
 
 /// Time bound assumed on network transmission delays during periods of synchrony.
-const DELTA: Duration = Duration::from_millis(400);
+const DELTA: Duration = Duration::from_millis(200);
 /// Time the leader has for producing and sending the block.
 const DELTA_BLOCK: Duration = Duration::from_millis(400);
 /// Timeout to use when we haven't seen any shred from the leader's block.

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -18,13 +18,12 @@ use color_eyre::Result;
 use log::{debug, trace, warn};
 use tokio::sync::mpsc::{Receiver, Sender};
 
-use crate::consensus::DELTA_BLOCK;
 use crate::crypto::Hash;
 use crate::crypto::aggsig::SecretKey;
 use crate::{All2All, Slot, ValidatorId};
 
 use super::blockstore::BlockInfo;
-use super::{Cert, DELTA_TIMEOUT, Vote};
+use super::{Cert, DELTA_BLOCK, DELTA_TIMEOUT, Vote};
 
 /// Events that Votor is interested in.
 ///

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -18,13 +18,13 @@ use color_eyre::Result;
 use log::{debug, trace, warn};
 use tokio::sync::mpsc::{Receiver, Sender};
 
-use crate::consensus::DELTA_TIMEOUT;
+use crate::consensus::DELTA_BLOCK;
 use crate::crypto::Hash;
 use crate::crypto::aggsig::SecretKey;
 use crate::{All2All, Slot, ValidatorId};
 
 use super::blockstore::BlockInfo;
-use super::{Cert, DELTA_BLOCK, DELTA_EARLY_TIMEOUT, SLOTS_PER_WINDOW, Vote};
+use super::{Cert, DELTA_TIMEOUT, SLOTS_PER_WINDOW, Vote};
 
 /// Events that Votor is interested in.
 ///
@@ -248,7 +248,7 @@ impl<A: All2All + Sync + Send + 'static> Votor<A> {
         assert_eq!(slot % SLOTS_PER_WINDOW, 0);
         let sender = self.event_sender.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(DELTA_TIMEOUT.saturating_sub(DELTA_EARLY_TIMEOUT)).await;
+            tokio::time::sleep(DELTA_TIMEOUT).await;
             for offset in 0..SLOTS_PER_WINDOW {
                 let event = VotorEvent::TimeoutCrashedLeader(slot + offset);
                 // HACK: ignoring errors to prevent panic when shutting down votor


### PR DESCRIPTION
This addresses #62 and fixes various minor problems with the timeouts:
- [x] inconsistent naming with the paper
- [x] https://github.com/qkniep/alpenglow/blob/main/src/consensus/votor.rs#L251
- [x] `2 * DELTA` too aggressive for Rotor
- [x] 400ms for `DELTA` potentially too high
- [ ] ~`3 * DELTA` conservative for Rotor~ (will be addressed separately, see #66)
- [ ] ~crashed leader timeout needs buffer for first slice~ (will be addressed separately, see #65)