### PR TITLE
fix: cleaner genesis handling

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -359,6 +359,9 @@ where
             let mut block = parent;
             let mut block_hash = parent_hash;
             for slot in first_slot_in_window.slots_in_window() {
+                if slot.is_genesis() {
+                    continue;
+                }
                 self.produce_block(slot, (block, block_hash), parent_ready)
                     .await?;
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -315,7 +315,7 @@ where
                 self.pool.read().await.recover_from_standstill().await;
                 last_progress = Instant::now();
             }
-            tokio::time::sleep(Duration::from_millis(400)).await;
+            tokio::time::sleep(DELTA_BLOCK).await;
         }
     }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -344,7 +344,7 @@ where
                 continue;
             }
 
-            let (parent, parent_hash, parent_ready) = match wait_for_first_slot(
+            let (parent, parent_hash, mut parent_ready) = match wait_for_first_slot(
                 self.pool.clone(),
                 self.blockstore.clone(),
                 first_slot_in_window,
@@ -360,6 +360,7 @@ where
             let mut block_hash = parent_hash;
             for slot in first_slot_in_window.slots_in_window() {
                 if slot.is_genesis() {
+                    parent_ready = true;
                     continue;
                 }
                 self.produce_block(slot, (block, block_hash), parent_ready)
@@ -373,6 +374,7 @@ where
                     .await
                     .canonical_block_hash(slot)
                     .expect("missing own block during block production");
+                parent_ready = true;
             }
         }
 

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -166,10 +166,10 @@ impl Blockstore {
     /// Returns `None` if blockstore does not hold that block yet.
     pub fn get_block(&self, slot: Slot, hash: Hash) -> Option<&Block> {
         let slot_data = self.slot_data(slot)?;
-        if let Some((h, block)) = slot_data.canonical.completed.as_ref() {
-            if *h == hash {
-                return Some(block);
-            }
+        if let Some((h, block)) = slot_data.canonical.completed.as_ref()
+            && *h == hash
+        {
+            return Some(block);
         }
         slot_data
             .alternatives

--- a/src/consensus/pool/parent_ready_tracker/parent_ready_state.rs
+++ b/src/consensus/pool/parent_ready_tracker/parent_ready_state.rs
@@ -116,7 +116,7 @@ mod tests {
         state.add_to_ready(block_id);
         let res = state.wait_for_parent_ready();
         let Either::Left(received_block_id) = res else {
-            panic!("Unexpected result {res:?}");
+            panic!("unexpected result {res:?}");
         };
         assert_eq!(received_block_id, block_id);
         assert_eq!(state.ready_block_ids().len(), 1);
@@ -128,7 +128,7 @@ mod tests {
         assert_eq!(state.ready_block_ids().len(), 0);
         let res = state.wait_for_parent_ready();
         let Either::Right(rx) = res else {
-            panic!("Unexpected result {res:?}");
+            panic!("unexpected result {res:?}");
         };
         let block_id = (Slot::new(0), [1; 32]);
         state.add_to_ready(block_id);

--- a/src/consensus/pool/slot_state.rs
+++ b/src/consensus/pool/slot_state.rs
@@ -389,10 +389,10 @@ impl SlotState {
                 if self.votes.skip[v].is_some() {
                     return Some(SlashableOffence::SkipAndNotarize(voter, slot));
                 }
-                if let Some((old_hash, _)) = self.votes.notar[v] {
-                    if block_hash != old_hash {
-                        return Some(SlashableOffence::NotarDifferentHash(voter, slot));
-                    }
+                if let Some((old_hash, _)) = self.votes.notar[v]
+                    && block_hash != old_hash
+                {
+                    return Some(SlashableOffence::NotarDifferentHash(voter, slot));
                 }
             }
             VoteKind::NotarFallback(_, _) => {

--- a/src/consensus/produce_block.rs
+++ b/src/consensus/produce_block.rs
@@ -146,17 +146,17 @@ where
             // switch parent if necessary (for optimistic handover)
             if !parent_ready {
                 let pool = self.pool.read().await;
-                if let Some(p) = pool.parents_ready(slot).first() {
-                    if *p != parent {
-                        warn!(
-                            "switching block production parent from {} in slot {} to {} in slot {}",
-                            &hex::encode(parent.1)[..8],
-                            parent.0,
-                            &hex::encode(p.1)[..8],
-                            p.0,
-                        );
-                        unimplemented!("have to switch parents");
-                    }
+                if let Some(p) = pool.parents_ready(slot).first()
+                    && *p != parent
+                {
+                    warn!(
+                        "switching block production parent from {} in slot {} to {} in slot {}",
+                        &hex::encode(parent.1)[..8],
+                        parent.0,
+                        &hex::encode(p.1)[..8],
+                        p.0,
+                    );
+                    unimplemented!("have to switch parents");
                 }
             }
 

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -113,7 +113,7 @@ impl<A: All2All + Sync + Send + 'static> Votor<A> {
     ) -> Self {
         let mut parents_ready = BTreeSet::new();
         // add dummy genesis block
-        parents_ready.insert((Slot::new(0), Slot::new(0), Hash::default()));
+        parents_ready.insert((Slot::genesis(), Slot::genesis(), Hash::default()));
         let votor = Self {
             voted: BTreeSet::new(),
             voted_notar: BTreeMap::new(),
@@ -382,8 +382,8 @@ mod tests {
         // explicitly send parent ready for genesis
         votor_channel
             .send(VotorEvent::ParentReady {
-                slot: Slot::new(0),
-                parent_slot: Slot::new(0),
+                slot: Slot::genesis(),
+                parent_slot: Slot::genesis(),
                 parent_hash: Hash::default(),
             })
             .await
@@ -391,7 +391,7 @@ mod tests {
 
         // should vote skip for all slots
         let mut skipped_slots = Vec::new();
-        for _ in Slot::new(0).slots_in_window() {
+        for _ in Slot::genesis().slots_in_window() {
             if let Ok(msg) = other_a2a.receive().await {
                 match msg {
                     NetworkMessage::Vote(v) => {
@@ -402,7 +402,7 @@ mod tests {
                 }
             }
         }
-        for i in Slot::new(0).slots_in_window() {
+        for i in Slot::genesis().slots_in_window() {
             assert!(skipped_slots.contains(&i));
         }
     }

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -110,18 +110,24 @@ impl<A: All2All + Sync + Send + 'static> Votor<A> {
         event_receiver: Receiver<VotorEvent>,
         all2all: Arc<A>,
     ) -> Self {
-        let mut parents_ready = BTreeSet::new();
-        // add dummy genesis block
-        parents_ready.insert((Slot::genesis(), Slot::genesis(), Hash::default()));
+        // add dummy genesis block to some of the data structures
+        let voted = [Slot::genesis()].into_iter().collect();
+        let voted_notar = [(Slot::genesis(), Hash::default())].into_iter().collect();
+        let block_notarized = [(Slot::genesis(), Hash::default())].into_iter().collect();
+        let parents_ready = [(Slot::genesis(), Slot::genesis(), Hash::default())]
+            .into_iter()
+            .collect();
+        let retired_slots = [Slot::genesis()].into_iter().collect();
+
         let votor = Self {
-            voted: BTreeSet::new(),
-            voted_notar: BTreeMap::new(),
+            voted,
+            voted_notar,
             bad_window: BTreeSet::new(),
-            block_notarized: BTreeMap::new(),
+            block_notarized,
             parents_ready,
             received_shred: BTreeSet::new(),
             pending_blocks: BTreeMap::new(),
-            retired_slots: BTreeSet::new(),
+            retired_slots,
             validator_id,
             voting_key,
             event_receiver,

--- a/src/network/simulated/core.rs
+++ b/src/network/simulated/core.rs
@@ -73,13 +73,13 @@ impl Default for SimulatedNetworkCore {
         tokio::spawn(async move {
             loop {
                 let mut guard = p.lock().await;
-                if let Some(msg) = guard.peek() {
-                    if msg.deliver_at <= Instant::now() {
-                        let msg = guard.pop().unwrap();
-                        let n_guard = n.read().await;
-                        let channel = n_guard.get(&msg.to).unwrap();
-                        channel.send(msg).await.unwrap();
-                    }
+                if let Some(msg) = guard.peek()
+                    && msg.deliver_at <= Instant::now()
+                {
+                    let msg = guard.pop().unwrap();
+                    let n_guard = n.read().await;
+                    let channel = n_guard.get(&msg.to).unwrap();
+                    channel.send(msg).await.unwrap();
                 }
             }
         });

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -3,13 +3,12 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 
 /// Number of slots in each leader window.
-///
-/// NOTE: this is public to support testing and one function additional function.
-/// Consider hiding it.
+// NOTE: this is public to support testing and one additional function.
+// Consider hiding it.
 pub const SLOTS_PER_WINDOW: u64 = 4;
+
 /// Number of slots in each epoch.
-///
-/// NOTE: consider hiding this definition.
+// NOTE: consider hiding this definition.
 pub const SLOTS_PER_EPOCH: u64 = 18_000;
 
 /// Slot number type.
@@ -71,10 +70,15 @@ impl Slot {
         Self(self.0 - 1)
     }
 
-    /// Returns true if this slot is part of the genesis window.
+    /// Returns `true` iff this slot is part of the genesis window.
     pub fn is_genesis_window(&self) -> bool {
         let window = self.0 / SLOTS_PER_WINDOW;
         window == 0
+    }
+
+    /// Returns `true` iff this slot is the genesis slot.
+    pub fn is_genesis(&self) -> bool {
+        self.0 == 0
     }
 }
 

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -16,11 +16,17 @@ pub const SLOTS_PER_EPOCH: u64 = 18_000;
 pub struct Slot(u64);
 
 impl Slot {
+    /// Creates a new slot with the given number.
     pub fn new(slot: u64) -> Self {
         Self(slot)
     }
 
-    /// Returns the inner u64.
+    /// Returns the genesis slot.
+    pub fn genesis() -> Self {
+        Self(0)
+    }
+
+    /// Returns the inner `u64`.
     pub fn inner(self) -> u64 {
         self.0
     }


### PR DESCRIPTION
This addresses #54.

Slot 0 will no longer contain leader proposed blocks, only the genesis block. Block production and voting loop should thus both skip over slot 0.