### PR TITLE
fix: main/alpenglow binary crashes immediately

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -369,7 +369,7 @@ where
                     .read()
                     .await
                     .canonical_block_hash(slot)
-                    .unwrap();
+                    .expect("missing own block during block production");
             }
         }
 

--- a/src/consensus/produce_block.rs
+++ b/src/consensus/produce_block.rs
@@ -112,10 +112,11 @@ where
         let (parent_slot, parent_hash) = parent;
         let _slot_span = Span::enter_with_local_parent(format!("slot {slot}"));
         info!(
-            "producing block in slot {} with parent {} in slot {}",
+            "producing block in slot {} with parent {} in slot {} (parent ready: {})",
             slot,
             &hex::encode(parent_hash)[..8],
-            parent_slot
+            parent_slot,
+            parent_ready,
         );
 
         let mut sleep_duration = DELTA_BLOCK;
@@ -147,7 +148,13 @@ where
                 let pool = self.pool.read().await;
                 if let Some(p) = pool.parents_ready(slot).first() {
                     if *p != parent {
-                        warn!("switching block production parent");
+                        warn!(
+                            "switching block production parent from {} in slot {} to {} in slot {}",
+                            &hex::encode(parent.1)[..8],
+                            parent.0,
+                            &hex::encode(p.1)[..8],
+                            p.0,
+                        );
                         unimplemented!("have to switch parents");
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,24 +28,24 @@ async fn main() -> Result<()> {
     color_eyre::install()?;
 
     // enable `fastrace` tracing
-    let reporter = OpenTelemetryReporter::new(
-        SpanExporter::builder()
-            .with_tonic()
-            .with_endpoint("http://127.0.0.1:4317".to_string())
-            .with_protocol(opentelemetry_otlp::Protocol::Grpc)
-            .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
-            .build()
-            .expect("initialize oltp exporter"),
-        Cow::Owned(
-            Resource::builder()
-                .with_attributes([KeyValue::new("service.name", "alpenglow-main")])
-                .build(),
-        ),
-        InstrumentationScope::builder("alpenglow")
-            .with_version(env!("CARGO_PKG_VERSION"))
-            .build(),
-    );
-    fastrace::set_reporter(reporter, Config::default());
+    // let reporter = OpenTelemetryReporter::new(
+    //     SpanExporter::builder()
+    //         .with_tonic()
+    //         .with_endpoint("http://127.0.0.1:4317".to_string())
+    //         .with_protocol(opentelemetry_otlp::Protocol::Grpc)
+    //         .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
+    //         .build()
+    //         .expect("initialize oltp exporter"),
+    //     Cow::Owned(
+    //         Resource::builder()
+    //             .with_attributes([KeyValue::new("service.name", "alpenglow-main")])
+    //             .build(),
+    //     ),
+    //     InstrumentationScope::builder("alpenglow")
+    //         .with_version(env!("CARGO_PKG_VERSION"))
+    //         .build(),
+    // );
+    // fastrace::set_reporter(reporter, Config::default());
 
     logging::enable_logforth();
 
@@ -102,7 +102,7 @@ fn create_test_nodes(count: u64) -> Vec<TestNode> {
             disseminator_address: format!("127.0.0.1:{}", port + 1),
             repair_address: format!("127.0.0.1:{}", port + 2),
         });
-        port += 3;
+        port += 4;
     }
 
     // turn validator info into actual nodes

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,24 +28,24 @@ async fn main() -> Result<()> {
     color_eyre::install()?;
 
     // enable `fastrace` tracing
-    // let reporter = OpenTelemetryReporter::new(
-    //     SpanExporter::builder()
-    //         .with_tonic()
-    //         .with_endpoint("http://127.0.0.1:4317".to_string())
-    //         .with_protocol(opentelemetry_otlp::Protocol::Grpc)
-    //         .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
-    //         .build()
-    //         .expect("initialize oltp exporter"),
-    //     Cow::Owned(
-    //         Resource::builder()
-    //             .with_attributes([KeyValue::new("service.name", "alpenglow-main")])
-    //             .build(),
-    //     ),
-    //     InstrumentationScope::builder("alpenglow")
-    //         .with_version(env!("CARGO_PKG_VERSION"))
-    //         .build(),
-    // );
-    // fastrace::set_reporter(reporter, Config::default());
+    let reporter = OpenTelemetryReporter::new(
+        SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint("http://127.0.0.1:4317".to_string())
+            .with_protocol(opentelemetry_otlp::Protocol::Grpc)
+            .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
+            .build()
+            .expect("initialize oltp exporter"),
+        Cow::Owned(
+            Resource::builder()
+                .with_attributes([KeyValue::new("service.name", "alpenglow-main")])
+                .build(),
+        ),
+        InstrumentationScope::builder("alpenglow")
+            .with_version(env!("CARGO_PKG_VERSION"))
+            .build(),
+    );
+    fastrace::set_reporter(reporter, Config::default());
 
     logging::enable_logforth();
 

--- a/src/shredder/reed_solomon.rs
+++ b/src/shredder/reed_solomon.rs
@@ -133,25 +133,25 @@ mod tests {
     use static_assertions::const_assert;
 
     #[test]
-    fn test_reed_solomon_restore_full() {
+    fn restore_full() {
         let (header, payload) = random_slice(MAX_DATA_PER_SLICE);
         shred_deshred_restore(header, payload);
     }
 
     #[test]
-    fn test_reed_solomon_restore_tiny() {
+    fn restore_tiny() {
         let (header, payload) = random_slice(DATA_SHREDS - 1);
         shred_deshred_restore(header, payload);
     }
 
     #[test]
-    fn test_reed_solomon_restore_empty() {
+    fn restore_empty() {
         let (header, payload) = random_slice(0);
         shred_deshred_restore(header, payload);
     }
 
     #[test]
-    fn test_reed_solomon_restore_various() {
+    fn restore_various() {
         const_assert!(MAX_DATA_PER_SLICE >= 2 * DATA_SHREDS);
         let slice_bytes = MAX_DATA_PER_SLICE / 2;
         for offset in 0..DATA_SHREDS {
@@ -161,7 +161,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reed_solomon_shred_too_much_data() {
+    fn shred_too_much_data() {
         let (header, payload) = random_slice(MAX_DATA_PER_SLICE + 1);
         let res = reed_solomon_shred(header, payload, DATA_SHREDS, DATA_SHREDS);
         assert!(res.is_err());
@@ -169,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reed_solomon_deshred_too_many_shreds() {
+    fn deshred_too_many_shreds() {
         const CODING_SHREDS: usize = TOTAL_SHREDS - DATA_SHREDS + 1;
         let (header, payload) = random_slice(MAX_DATA_PER_SLICE);
         let (data, coding) =
@@ -182,7 +182,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reed_solomon_deshred_not_enough_shreds() {
+    fn deshred_not_enough_shreds() {
         let (header, payload) = random_slice(MAX_DATA_PER_SLICE);
         let (data, coding) =
             reed_solomon_shred(header, payload.clone(), DATA_SHREDS, DATA_SHREDS).unwrap();

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -83,3 +83,20 @@ impl Display for Slot {
         write!(f, "{}", self.0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let window_slots = Slot::windows().take(10).collect::<Vec<_>>();
+        for (window, first_slot) in window_slots.iter().take(9).enumerate() {
+            assert!(first_slot.is_start_of_window());
+            assert_eq!(*first_slot, first_slot.first_slot_in_window());
+            let last_slot = first_slot.last_slot_in_window();
+            assert_eq!(last_slot.next(), window_slots[window + 1]);
+            assert_eq!(last_slot, window_slots[window + 1].prev());
+        }
+    }
+}

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -89,7 +89,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_basic() {
+    fn basic() {
         let window_slots = Slot::windows().take(10).collect::<Vec<_>>();
         for (window, first_slot) in window_slots.iter().take(9).enumerate() {
             assert!(first_slot.is_start_of_window());

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -28,7 +28,7 @@ impl Slot {
 
     /// Returns an infinite iterator that yields the first slot in each window.
     pub fn windows() -> impl Iterator<Item = Self> {
-        (0..).map(Self)
+        (0..).step_by(SLOTS_PER_WINDOW as usize).map(Self)
     }
 
     /// Returns a double-ended iterator that yields all the slots in the


### PR DESCRIPTION
Right now, simply running `./run.sh` crashes immediately.

This PR fixes all these and makes this simple local test run again.