### PR TITLE
wip: half baked idea to introduce different types of slices

### DIFF
--- a/src/consensus/produce_block.rs
+++ b/src/consensus/produce_block.rs
@@ -102,7 +102,7 @@ where
         is_last,
     };
     let payload = SlicePayload::new(parent, txs);
-    let slice = Slice::from_parts(header, payload, None);
+    let slice = Slice::from_parts(header, payload, None).unwrap();
     (slice, cont_prod)
 }
 

--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -237,7 +237,8 @@ impl Shredder for RegularShredder {
 
     fn deshred(shreds: &[Shred]) -> Result<Slice, DeshredError> {
         let payload = reed_solomon_deshred(shreds, DATA_SHREDS, TOTAL_SHREDS - DATA_SHREDS)?;
-        let slice = Slice::from_shreds(payload.into(), &shreds[0]);
+        // XXX: handle error
+        let slice = Slice::from_shreds(payload.into(), &shreds[0]).unwrap();
 
         // additional Merkle tree validity check
         let merkle_root = shreds[0].merkle_root;
@@ -272,7 +273,8 @@ impl Shredder for CodingOnlyShredder {
 
     fn deshred(shreds: &[Shred]) -> Result<Slice, DeshredError> {
         let payload = reed_solomon_deshred(shreds, DATA_SHREDS, TOTAL_SHREDS)?;
-        let slice = Slice::from_shreds(payload.into(), &shreds[0]);
+        // XXX: handle error
+        let slice = Slice::from_shreds(payload.into(), &shreds[0]).unwrap();
 
         // additional Merkle tree validity check
         let merkle_root = shreds[0].merkle_root;
@@ -348,7 +350,8 @@ impl Shredder for PetsShredder {
 
         let mut cipher = Ctr64LE::<Aes128>::new(&key, &iv);
         cipher.apply_keystream(&mut buffer);
-        Ok(Slice::from_shreds(buffer.into(), &shreds[0]))
+        // XXX: handle error
+        Ok(Slice::from_shreds(buffer.into(), &shreds[0]).unwrap())
     }
 }
 
@@ -419,7 +422,8 @@ impl Shredder for AontShredder {
         let mut cipher = Ctr64LE::<Aes128>::new(&key, &iv);
         cipher.apply_keystream(&mut buffer);
 
-        Ok(Slice::from_shreds(buffer.into(), &shreds[0]))
+        // XXX: handle error
+        Ok(Slice::from_shreds(buffer.into(), &shreds[0]).unwrap())
     }
 }
 


### PR DESCRIPTION
If we were to add something like this, then we could get some nice properties, e.g. 
- shredding the last slice should result in a block; 
- we could store first and last slices explicitly in `BlockData` and `SlotBlockData`;

However, it looks like we will end up with an explosion of types and thereby explosions of functions to handle them: e.g.
- shred_and_disseminate first and middle slices; and last slices (this one will return a block).

So I don't think this idea is worth it.  Still putting it out there if we want to take some inspiration from this.