### PR TITLE
refactor: use `async_trait` for `Network` trait

### DIFF
--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -92,7 +92,7 @@ impl<N: Network> Turbine<N> {
         let root = tree.get_root();
         let msg: NetworkMessage = shred.clone().into();
         let addr = &self.validators[root as usize].disseminator_address;
-        self.network.send(&msg, &addr).await
+        self.network.send(&msg, addr).await
     }
 
     /// Forwards the shred to all our children in the correct Turbine tree.
@@ -108,7 +108,7 @@ impl<N: Network> Turbine<N> {
         let msg: NetworkMessage = shred.clone().into();
         for child in tree.get_children() {
             let addr = &self.validators[*child as usize].disseminator_address;
-            self.network.send(&msg, &addr).await?;
+            self.network.send(&msg, addr).await?;
         }
         Ok(())
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -30,6 +30,7 @@ mod udp;
 
 use std::str::FromStr;
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -140,24 +141,25 @@ pub enum NetworkError {
 }
 
 /// Abstraction of a network interface for sending and receiving messages.
+#[async_trait]
 pub trait Network: Send + Sync {
     type Address: Send;
 
-    fn send(
+    async fn send(
         &self,
         message: &NetworkMessage,
         to: impl AsRef<str> + Send,
-    ) -> impl Future<Output = Result<(), NetworkError>> + Send;
+    ) -> Result<(), NetworkError>;
 
-    fn send_serialized(
+    async fn send_serialized(
         &self,
         bytes: &[u8],
         to: impl AsRef<str> + Send,
-    ) -> impl Future<Output = Result<(), NetworkError>> + Send;
+    ) -> Result<(), NetworkError>;
 
     // TODO: implement brodcast at `Network` level?
 
-    fn receive(&self) -> impl Future<Output = Result<NetworkMessage, NetworkError>> + Send;
+    async fn receive(&self) -> Result<NetworkMessage, NetworkError>;
 
     fn parse_addr(str: impl AsRef<str>) -> Result<Self::Address, NetworkError>
     where

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -23,6 +23,7 @@ mod token_bucket;
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use log::warn;
 use tokio::sync::{Mutex, RwLock, mpsc};
 
@@ -63,6 +64,7 @@ impl SimulatedNetwork {
     }
 }
 
+#[async_trait]
 impl Network for SimulatedNetwork {
     type Address = ValidatorId;
 

--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -8,6 +8,7 @@
 
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
+use async_trait::async_trait;
 use futures::SinkExt;
 use tokio::net::TcpListener;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
@@ -61,6 +62,7 @@ impl TcpNetwork {
     }
 }
 
+#[async_trait]
 impl Network for TcpNetwork {
     type Address = SocketAddr;
 

--- a/src/network/udp.rs
+++ b/src/network/udp.rs
@@ -8,6 +8,7 @@
 
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
+use async_trait::async_trait;
 use log::warn;
 use tokio::net::UdpSocket;
 
@@ -50,6 +51,7 @@ impl UdpNetwork {
     }
 }
 
+#[async_trait]
 impl Network for UdpNetwork {
     type Address = SocketAddr;
 


### PR DESCRIPTION
Since we are already using `async_trait` in other places now, change stable use of `impl Future<...>` syntax to use of the `async_trait` crate for the `Network` trait as well.