### PR TITLE
fix: correctly account for first slice in crashed leader timeout

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -33,6 +33,7 @@ use color_eyre::Result;
 use fastrace::Span;
 use fastrace::future::FutureExt;
 use log::{trace, warn};
+use static_assertions::const_assert;
 use tokio::sync::{RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 
@@ -53,6 +54,9 @@ use crate::{All2All, Disseminator, Slot, ValidatorInfo};
 const DELTA: Duration = Duration::from_millis(250);
 /// Time the leader has for producing and sending the block.
 const DELTA_BLOCK: Duration = Duration::from_millis(400);
+/// Time the leader has for producing and sending the first slice.
+const DELTA_FIRST_SLICE: Duration = Duration::from_millis(10);
+const_assert!(DELTA_FIRST_SLICE.as_nanos() <= DELTA_BLOCK.as_nanos());
 /// Base timeout for when leader's first slice should arrive if they sent it immediately.
 const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
 /// Timeout for standstill detection mechanism.

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -160,6 +160,7 @@ where
             pool.clone(),
             cancel_token.clone(),
             DELTA_BLOCK,
+            DELTA_FIRST_SLICE,
         ));
 
         Self {

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -269,6 +269,7 @@ where
             } else {
                 None
             };
+            // make sure first slice is produced on time
             let (payload, maybe_duration) = if slice_index.is_first() {
                 let time_for_slice = duration_left.min(self.delta_first_slice);
                 produce_slice_payload(&self.txs_receiver, parent, time_for_slice).await

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -170,7 +170,7 @@ where
                 None
             };
 
-            let time_for_slice = if slice_index == SliceIndex::first() {
+            let time_for_slice = if slice_index.is_first() {
                 // make sure first slice is produced on time
                 // TODO: this can be made more accurate, only needed if production of first slice
                 // still takes more than delta_first_slice after we saw ParentReady, not if:

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -270,12 +270,13 @@ where
                 None
             };
             // make sure first slice is produced on time
-            let (payload, maybe_duration) = if slice_index.is_first() {
-                let time_for_slice = duration_left.min(self.delta_first_slice);
-                produce_slice_payload(&self.txs_receiver, parent, time_for_slice).await
+            let time_for_slice = if slice_index.is_first() {
+                duration_leaft.min(self.delta_first_slice)
             } else {
-                produce_slice_payload(&self.txs_receiver, parent, duration_left).await
+                duration_left
             };
+            let (payload, maybe_duration) = 
+                produce_slice_payload(&self.txs_receiver, parent, time_for_slice).await;
             let is_last = slice_index.is_max() || maybe_duration.is_none();
             let header = SliceHeader {
                 slot,

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -271,7 +271,7 @@ where
             };
             let time_for_slice = if slice_index.is_first() {
                 // make sure first slice is produced on time
-                duration_leaft.min(self.delta_first_slice)
+                duration_left.min(self.delta_first_slice)
             } else {
                 duration_left
             };

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -269,7 +269,7 @@ where
             } else {
                 None
             };
-            let (payload, maybe_duration) = if slice_index == SliceIndex::first() {
+            let (payload, maybe_duration) = if slice_index.is_first() {
                 let time_for_slice = duration_left.min(self.delta_first_slice);
                 produce_slice_payload(&self.txs_receiver, parent, time_for_slice).await
             } else {

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -269,13 +269,13 @@ where
             } else {
                 None
             };
-            // make sure first slice is produced on time
             let time_for_slice = if slice_index.is_first() {
+                // make sure first slice is produced on time
                 duration_leaft.min(self.delta_first_slice)
             } else {
                 duration_left
             };
-            let (payload, maybe_duration) = 
+            let (payload, maybe_duration) =
                 produce_slice_payload(&self.txs_receiver, parent, time_for_slice).await;
             let is_last = slice_index.is_max() || maybe_duration.is_none();
             let header = SliceHeader {

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -169,7 +169,7 @@ where
             } else {
                 None
             };
-            
+
             let time_for_slice = if slice_index == SliceIndex::first() {
                 // make sure first slice is produced on time
                 // TODO: this can be made more accurate, only needed if production of first slice


### PR DESCRIPTION
This introduces the additional parameter `DELTA_FIRST_SLICE` a short timeout for producing the first slice. The leader makes sure to only take at most this amount of time for the first slice. In return, we can account for the crashed leader timeout correctly. See issue #65 for more info.

Closes #65.