### PR TITLE
refactor: rename `canonical` and `alternatives` to `disseminated` and `repaired`

### DIFF
--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -496,7 +496,7 @@ async fn wait_for_first_slot(
                 loop {
                     let last_slot_in_prev_window = first_slot_in_window.prev();
                     if let Some(hash) = blockstore.read().await
-                        .canonical_block_hash(last_slot_in_prev_window)
+                        .disseminated_block_hash(last_slot_in_prev_window)
                     {
                         return Some((last_slot_in_prev_window, hash));
                     }

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -597,7 +597,7 @@ mod tests {
             }
         }
         assert_eq!(
-            blockstore.read().await.canonical_block_hash(slot),
+            blockstore.read().await.disseminated_block_hash(slot),
             Some(block_hash)
         );
         assert!(blockstore.read().await.get_block(block_to_repair).is_some());


### PR DESCRIPTION
Closes #147.