### PR TITLE
nit: handle some TODO comments

### DIFF
--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -237,7 +237,7 @@ impl PoolImpl {
         certs
     }
 
-    /// Fetches finalization certficates for given `slot`.
+    /// Fetches finalization certficates for given `slot`, if any.
     ///
     /// Prefers fast-finalization over slow-finalization, if it's available.
     /// In that case this returns only the fast-finalization certificate.
@@ -246,16 +246,18 @@ impl PoolImpl {
         let Some(slot_state) = self.slot_states.get(&slot) else {
             return Vec::new();
         };
-
-        if let Some(ff_cert) = slot_state.certificates.fast_finalize.clone() {
-            vec![Cert::FastFinal(ff_cert)]
-        } else if let Some(final_cert) = slot_state.certificates.finalize.clone()
-            && let Some(notar_cert) = slot_state.certificates.notar.clone()
-        {
-            vec![Cert::Final(final_cert), Cert::Notar(notar_cert)]
-        } else {
-            vec![]
+        if let Some(ff_cert) = &slot_state.certificates.fast_finalize {
+            return vec![Cert::FastFinal(ff_cert.clone())];
         }
+        if let Some(final_cert) = &slot_state.certificates.finalize
+            && let Some(notar_cert) = &slot_state.certificates.notar
+        {
+            return vec![
+                Cert::Final(final_cert.clone()),
+                Cert::Notar(notar_cert.clone()),
+            ];
+        }
+        Vec::new()
     }
 
     /// Fetches all votes cast by myself for the provided range of `slots`.

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -486,6 +486,7 @@ impl Pool for PoolImpl {
     async fn recover_from_standstill(&self) {
         let slot = self.finalized_slot();
         let mut certs = self.get_final_certs(slot);
+        assert!(!certs.is_empty(), "no final cert");
         certs.extend(self.get_certs(slot.next()..));
         let votes = self.get_own_votes(slot.next()..);
 

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -11,6 +11,7 @@ mod parent_ready_tracker;
 mod slot_state;
 
 use std::collections::BTreeMap;
+use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -213,12 +214,10 @@ impl PoolImpl {
             .or_insert_with(|| SlotState::new(slot, Arc::clone(&self.epoch_info)))
     }
 
-    /// Fetches all certficates for any slots starting from `slot`.
-    // TODO: only return finalization for first slot, instead of all certs
-    // (need to update `standstill_recovery` test below)
-    fn get_certs(&self, slot: Slot) -> Vec<Cert> {
+    /// Fetches all certficates for the provided range of `slots`.
+    fn get_certs(&self, slots: impl RangeBounds<Slot>) -> Vec<Cert> {
         let mut certs = Vec::new();
-        for (_, slot_state) in self.slot_states.range(slot..) {
+        for (_, slot_state) in self.slot_states.range(slots) {
             if let Some(cert) = slot_state.certificates.finalize.clone() {
                 certs.push(Cert::Final(cert));
             }
@@ -238,11 +237,32 @@ impl PoolImpl {
         certs
     }
 
-    /// Fetches all votes cast by myself for any slots starting from `slot`.
-    fn get_own_votes(&self, slot: Slot) -> Vec<Vote> {
+    /// Fetches finalization certficates for given `slot`.
+    ///
+    /// Prefers fast-finalization over slow-finalization, if it's available.
+    /// In that case this returns only the fast-finalization certificate.
+    /// Otherwise, returns the finalization and notarization certificates.
+    fn get_final_certs(&self, slot: Slot) -> Vec<Cert> {
+        let Some(slot_state) = self.slot_states.get(&slot) else {
+            return Vec::new();
+        };
+
+        if let Some(ff_cert) = slot_state.certificates.fast_finalize.clone() {
+            vec![Cert::FastFinal(ff_cert)]
+        } else if let Some(final_cert) = slot_state.certificates.finalize.clone()
+            && let Some(notar_cert) = slot_state.certificates.notar.clone()
+        {
+            vec![Cert::Final(final_cert), Cert::Notar(notar_cert)]
+        } else {
+            vec![]
+        }
+    }
+
+    /// Fetches all votes cast by myself for the provided range of `slots`.
+    fn get_own_votes(&self, slots: impl RangeBounds<Slot>) -> Vec<Vote> {
         let mut votes = Vec::new();
         let own_id = self.epoch_info.own_id;
-        for (_, slot_state) in self.slot_states.range(slot..) {
+        for (_, slot_state) in self.slot_states.range(slots) {
             if let Some(vote) = &slot_state.votes.finalize[own_id as usize] {
                 votes.push(vote.clone());
             }
@@ -465,8 +485,9 @@ impl Pool for PoolImpl {
     /// Should be called after not seeing any progress for the standstill duration.
     async fn recover_from_standstill(&self) {
         let slot = self.finalized_slot();
-        let certs = self.get_certs(slot);
-        let votes = self.get_own_votes(slot.next());
+        let mut certs = self.get_final_certs(slot);
+        certs.extend(self.get_certs(slot.next()..));
+        let votes = self.get_own_votes(slot.next()..);
 
         warn!("recovering from standstill at slot {slot}");
         debug!(
@@ -1144,7 +1165,7 @@ mod tests {
 
         // check against expected response
         assert_eq!(slot, slot2);
-        assert_eq!(certs.len(), 5);
+        assert_eq!(certs.len(), 3);
         for cert in certs {
             assert!(matches!(
                 cert,

--- a/src/consensus/pool/slot_state.rs
+++ b/src/consensus/pool/slot_state.rs
@@ -12,7 +12,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use either::Either;
-use log::warn;
 use smallvec::SmallVec;
 
 use super::SlashableOffence;
@@ -205,16 +204,7 @@ impl SlotState {
 
     /// Mark the parent of the block given by `hash` as known (in Blokstor).
     pub fn notify_parent_known(&mut self, hash: Hash) {
-        // TODO: maybe turn this back into a panic once repair is fully implemented
-        if self.parents.contains_key(&hash) {
-            warn!(
-                "parent of block {} in slot {} was alredy known",
-                &hex::encode(hash)[..8],
-                self.slot
-            );
-            return;
-        }
-        self.parents.insert(hash, ParentStatus::Known);
+        self.parents.entry(hash).or_insert(ParentStatus::Known);
     }
 
     /// Mark the parent of the block given by `hash` as notarized-fallback.

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -83,7 +83,6 @@ impl<N: Network> Turbine<N> {
     ///
     /// Returns an error if the send operation on the underlying network fails.
     pub async fn send_shred_to_root(&self, shred: &Shred) -> Result<(), NetworkError> {
-        // TODO: fix duplicate use indices between data and coding shreds
         let tree = self
             .get_tree(shred.payload().header.slot, shred.payload().index_in_slot())
             .await;


### PR DESCRIPTION
Addresses some minor TODO comments. Most importantly, when standstill recovery kicks in, Pool now only sends one type of finalization for the last finalized slot. Instead of all certificates for that slot.