### PR TITLE
refactor: use `SocketAddr` instead of `String` for storing addresses

### DIFF
--- a/src/all2all/robust.rs
+++ b/src/all2all/robust.rs
@@ -37,7 +37,7 @@ impl<N: Network> All2All for RobustAll2All<N> {
         for v in &self.validators {
             // HACK: stupidly expensive retransmits
             for _ in 0..1000 {
-                self.network.send(msg, &v.all2all_address).await?;
+                self.network.send(msg, v.all2all_address).await?;
             }
         }
         Ok(())
@@ -69,6 +69,7 @@ mod tests {
     use crate::crypto::aggsig;
     use crate::crypto::signature::SecretKey;
     use crate::network::simulated::SimulatedNetworkCore;
+    use crate::network::{dontcare_sockaddr, localhost_ip_sockaddr};
 
     async fn broadcast_test(packet_loss: f64) {
         // set up network and nodes
@@ -91,9 +92,9 @@ mod tests {
                 stake: 1,
                 pubkey: sk.to_pk(),
                 voting_pubkey: voting_sk.to_pk(),
-                all2all_address: i.to_string(),
-                disseminator_address: String::new(),
-                repair_address: String::new(),
+                all2all_address: localhost_ip_sockaddr(i.try_into().unwrap()),
+                disseminator_address: dontcare_sockaddr(),
+                repair_address: dontcare_sockaddr(),
             });
         }
 

--- a/src/all2all/trivial.rs
+++ b/src/all2all/trivial.rs
@@ -33,7 +33,7 @@ impl<N: Network> TrivialAll2All<N> {
 impl<N: Network> All2All for TrivialAll2All<N> {
     async fn broadcast(&self, msg: &NetworkMessage) -> Result<(), NetworkError> {
         for v in &self.validators {
-            self.network.send(msg, &v.all2all_address).await?;
+            self.network.send(msg, v.all2all_address).await?;
         }
         Ok(())
     }
@@ -54,6 +54,7 @@ mod tests {
     use crate::crypto::aggsig;
     use crate::crypto::signature::SecretKey;
     use crate::network::simulated::SimulatedNetworkCore;
+    use crate::network::{dontcare_sockaddr, localhost_ip_sockaddr};
 
     #[tokio::test]
     async fn simple_broadcast() {
@@ -77,9 +78,9 @@ mod tests {
                 stake: 1,
                 pubkey: sk.to_pk(),
                 voting_pubkey: voting_sk.to_pk(),
-                all2all_address: i.to_string(),
-                disseminator_address: String::new(),
-                repair_address: String::new(),
+                all2all_address: localhost_ip_sockaddr(i.try_into().unwrap()),
+                disseminator_address: dontcare_sockaddr(),
+                repair_address: dontcare_sockaddr(),
             });
         }
 

--- a/src/bin/performance_test.rs
+++ b/src/bin/performance_test.rs
@@ -12,7 +12,7 @@ use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Rotor;
 use alpenglow::disseminator::rotor::StakeWeightedSampler;
 use alpenglow::network::simulated::SimulatedNetworkCore;
-use alpenglow::network::{SimulatedNetwork, UdpNetwork};
+use alpenglow::network::{SimulatedNetwork, UdpNetwork, localhost_ip_sockaddr};
 use alpenglow::types::Slot;
 use alpenglow::{Alpenglow, ValidatorInfo, logging};
 use color_eyre::Result;
@@ -77,17 +77,17 @@ async fn create_test_nodes(count: u64) -> Vec<TestNode> {
     for id in 0..count {
         sks.push(SecretKey::new(&mut rng));
         voting_sks.push(aggsig::SecretKey::new(&mut rng));
-        let a2a_port = 3 * id;
-        let dis_port = 3 * id + 1;
-        let rep_port = udp_networks[id as usize].port();
+        let all2all_address = localhost_ip_sockaddr((3 * id).try_into().unwrap());
+        let disseminator_address = localhost_ip_sockaddr((3 * id + 1).try_into().unwrap());
+        let repair_address = localhost_ip_sockaddr(udp_networks[id as usize].port());
         validators.push(ValidatorInfo {
             id,
             stake: 1,
             pubkey: sks[id as usize].to_pk(),
             voting_pubkey: voting_sks[id as usize].to_pk(),
-            all2all_address: format!("{a2a_port}"),
-            disseminator_address: format!("{dis_port}"),
-            repair_address: format!("127.0.0.1:{rep_port}"),
+            all2all_address,
+            disseminator_address,
+            repair_address,
         });
     }
 

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -567,7 +567,7 @@ mod tests {
             for i in 0..255 {
                 let data = vec![i; MAX_TRANSACTION_SIZE];
                 let msg = NetworkMessage::Transaction(Transaction(data));
-                txs_sender.send(&msg, addr.clone()).await.unwrap();
+                txs_sender.send(&msg, addr).await.unwrap();
             }
         });
 

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -529,7 +529,7 @@ mod tests {
     use crate::consensus::pool::MockPool;
     use crate::crypto::Hash;
     use crate::disseminator::MockDisseminator;
-    use crate::network::UdpNetwork;
+    use crate::network::{UdpNetwork, localhost_ip_sockaddr};
     use crate::shredder::TOTAL_SHREDS;
     use crate::test_utils::generate_validators;
 
@@ -558,7 +558,7 @@ mod tests {
     #[tokio::test]
     async fn produce_slice_full_slices() {
         let txs_receiver = UdpNetwork::new_with_any_port();
-        let addr = format!("127.0.0.1:{}", txs_receiver.port());
+        let addr = localhost_ip_sockaddr(txs_receiver.port());
         let txs_sender = UdpNetwork::new_with_any_port();
         // long enough duration so hopefully doesn't fire while collecting txs
         let duration_left = Duration::from_secs(100);

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -332,6 +332,7 @@ mod tests {
     use crate::ValidatorInfo;
     use crate::crypto::signature::SecretKey;
     use crate::crypto::{MerkleTree, aggsig};
+    use crate::network::dontcare_sockaddr;
     use crate::shredder::{DATA_SHREDS, RegularShredder, Shredder, TOTAL_SHREDS};
     use crate::test_utils::{create_random_block, create_random_shredded_block};
     use crate::types::SliceIndex;
@@ -339,14 +340,15 @@ mod tests {
     fn test_setup(tx: Sender<VotorEvent>) -> (SecretKey, BlockstoreImpl) {
         let sk = SecretKey::new(&mut rand::rng());
         let voting_sk = aggsig::SecretKey::new(&mut rand::rng());
+        let sockaddr = dontcare_sockaddr();
         let info = ValidatorInfo {
             id: 0,
             stake: 1,
             pubkey: sk.to_pk(),
             voting_pubkey: voting_sk.to_pk(),
-            all2all_address: String::new(),
-            disseminator_address: String::new(),
-            repair_address: String::new(),
+            all2all_address: sockaddr,
+            disseminator_address: sockaddr,
+            repair_address: sockaddr,
         };
         let validators = vec![info];
         let epoch_info = EpochInfo::new(0, validators);

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -340,15 +340,14 @@ mod tests {
     fn test_setup(tx: Sender<VotorEvent>) -> (SecretKey, BlockstoreImpl) {
         let sk = SecretKey::new(&mut rand::rng());
         let voting_sk = aggsig::SecretKey::new(&mut rand::rng());
-        let sockaddr = dontcare_sockaddr();
         let info = ValidatorInfo {
             id: 0,
             stake: 1,
             pubkey: sk.to_pk(),
             voting_pubkey: voting_sk.to_pk(),
-            all2all_address: sockaddr,
-            disseminator_address: sockaddr,
-            repair_address: sockaddr,
+            all2all_address: dontcare_sockaddr(),
+            disseminator_address: dontcare_sockaddr(),
+            repair_address: dontcare_sockaddr(),
         };
         let validators = vec![info];
         let epoch_info = EpochInfo::new(0, validators);

--- a/src/consensus/cert.rs
+++ b/src/consensus/cert.rs
@@ -560,11 +560,13 @@ mod tests {
     use super::*;
     use crate::crypto::aggsig::SecretKey;
     use crate::crypto::signature;
+    use crate::network::dontcare_sockaddr;
 
     fn create_signers(signers: u64) -> (Vec<SecretKey>, Vec<ValidatorInfo>) {
         let mut sks = Vec::new();
         let mut voting_sks = Vec::new();
         let mut info = Vec::new();
+        let sockaddr = dontcare_sockaddr();
 
         for i in 0..signers {
             sks.push(signature::SecretKey::new(&mut rand::rng()));
@@ -574,9 +576,9 @@ mod tests {
                 stake: 1,
                 pubkey: sks.last().unwrap().to_pk(),
                 voting_pubkey: voting_sks.last().unwrap().to_pk(),
-                all2all_address: String::new(),
-                disseminator_address: String::new(),
-                repair_address: String::new(),
+                all2all_address: sockaddr,
+                disseminator_address: sockaddr,
+                repair_address: sockaddr,
             });
         }
 

--- a/src/consensus/cert.rs
+++ b/src/consensus/cert.rs
@@ -566,7 +566,6 @@ mod tests {
         let mut sks = Vec::new();
         let mut voting_sks = Vec::new();
         let mut info = Vec::new();
-        let sockaddr = dontcare_sockaddr();
 
         for i in 0..signers {
             sks.push(signature::SecretKey::new(&mut rand::rng()));
@@ -576,9 +575,9 @@ mod tests {
                 stake: 1,
                 pubkey: sks.last().unwrap().to_pk(),
                 voting_pubkey: voting_sks.last().unwrap().to_pk(),
-                all2all_address: sockaddr,
-                disseminator_address: sockaddr,
-                repair_address: sockaddr,
+                all2all_address: dontcare_sockaddr(),
+                disseminator_address: dontcare_sockaddr(),
+                repair_address: dontcare_sockaddr(),
             });
         }
 

--- a/src/disseminator/rotor/sampling_strategy.rs
+++ b/src/disseminator/rotor/sampling_strategy.rs
@@ -656,6 +656,7 @@ mod tests {
     use crate::crypto::aggsig;
     use crate::crypto::signature::SecretKey;
     use crate::disseminator::turbine::WeightedShuffle;
+    use crate::network::dontcare_sockaddr;
     use crate::network::simulated::stake_distribution::VALIDATOR_DATA;
     use crate::shredder::TOTAL_SHREDS;
 
@@ -664,14 +665,15 @@ mod tests {
         for i in 0..count {
             let sk = SecretKey::new(&mut rand::rng());
             let voting_sk = aggsig::SecretKey::new(&mut rand::rng());
+            let sockaddr = dontcare_sockaddr();
             validators.push(ValidatorInfo {
                 id: i,
                 stake: 1,
                 pubkey: sk.to_pk(),
                 voting_pubkey: voting_sk.to_pk(),
-                all2all_address: String::new(),
-                disseminator_address: String::new(),
-                repair_address: String::new(),
+                all2all_address: sockaddr,
+                disseminator_address: sockaddr,
+                repair_address: sockaddr,
             });
         }
         validators

--- a/src/disseminator/rotor/sampling_strategy.rs
+++ b/src/disseminator/rotor/sampling_strategy.rs
@@ -665,15 +665,14 @@ mod tests {
         for i in 0..count {
             let sk = SecretKey::new(&mut rand::rng());
             let voting_sk = aggsig::SecretKey::new(&mut rand::rng());
-            let sockaddr = dontcare_sockaddr();
             validators.push(ValidatorInfo {
                 id: i,
                 stake: 1,
                 pubkey: sk.to_pk(),
                 voting_pubkey: voting_sk.to_pk(),
-                all2all_address: sockaddr,
-                disseminator_address: sockaddr,
-                repair_address: sockaddr,
+                all2all_address: dontcare_sockaddr(),
+                disseminator_address: dontcare_sockaddr(),
+                repair_address: dontcare_sockaddr(),
             });
         }
         validators

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -30,7 +30,7 @@ impl<N: Network> Disseminator for TrivialDisseminator<N> {
     async fn send(&self, shred: &Shred) -> Result<(), NetworkError> {
         let msg = NetworkMessage::Shred(shred.clone());
         for v in &self.validators {
-            self.network.send(&msg, &v.disseminator_address).await?;
+            self.network.send(&msg, v.disseminator_address).await?;
         }
         Ok(())
     }
@@ -61,7 +61,7 @@ mod tests {
     use super::*;
     use crate::crypto::aggsig;
     use crate::crypto::signature::SecretKey;
-    use crate::network::UdpNetwork;
+    use crate::network::{UdpNetwork, dontcare_sockaddr, localhost_ip_sockaddr};
     use crate::shredder::{MAX_DATA_PER_SLICE, RegularShredder, Shredder, TOTAL_SHREDS};
     use crate::types::slice::create_slice_with_invalid_txs;
 
@@ -80,9 +80,9 @@ mod tests {
                 stake: 1,
                 pubkey: sks[i as usize].to_pk(),
                 voting_pubkey: voting_sks[i as usize].to_pk(),
-                all2all_address: String::new(),
-                disseminator_address: format!("127.0.0.1:{}", base_port + i as u16),
-                repair_address: String::new(),
+                all2all_address: dontcare_sockaddr(),
+                disseminator_address: localhost_ip_sockaddr(base_port + i as u16),
+                repair_address: dontcare_sockaddr(),
             });
         }
 

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -244,15 +244,14 @@ mod tests {
         for i in 0..count {
             sks.push(SecretKey::new(&mut rand::rng()));
             voting_sks.push(aggsig::SecretKey::new(&mut rand::rng()));
-            let sock = dontcare_sockaddr();
             validators.push(ValidatorInfo {
                 id: i,
                 stake: 1,
                 pubkey: sks[i as usize].to_pk(),
                 voting_pubkey: voting_sks[i as usize].to_pk(),
-                all2all_address: sock,
-                disseminator_address: sock,
-                repair_address: sock,
+                all2all_address: dontcare_sockaddr(),
+                disseminator_address: dontcare_sockaddr(),
+                repair_address: dontcare_sockaddr(),
             });
         }
         (sks, validators)

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -88,7 +88,7 @@ impl<N: Network> Turbine<N> {
             .await;
         let root = tree.get_root();
         let msg: NetworkMessage = shred.clone().into();
-        let addr = &self.validators[root as usize].disseminator_address;
+        let addr = self.validators[root as usize].disseminator_address;
         self.network.send(&msg, addr).await
     }
 
@@ -104,7 +104,7 @@ impl<N: Network> Turbine<N> {
             .await;
         let msg: NetworkMessage = shred.clone().into();
         for child in tree.get_children() {
-            let addr = &self.validators[*child as usize].disseminator_address;
+            let addr = self.validators[*child as usize].disseminator_address;
             self.network.send(&msg, addr).await?;
         }
         Ok(())
@@ -232,8 +232,8 @@ mod tests {
     use super::*;
     use crate::crypto::aggsig;
     use crate::crypto::signature::SecretKey;
-    use crate::network::SimulatedNetwork;
     use crate::network::simulated::SimulatedNetworkCore;
+    use crate::network::{SimulatedNetwork, dontcare_sockaddr, localhost_ip_sockaddr};
     use crate::shredder::{MAX_DATA_PER_SLICE, RegularShredder, Shredder, TOTAL_SHREDS};
     use crate::types::slice::create_slice_with_invalid_txs;
 
@@ -244,14 +244,15 @@ mod tests {
         for i in 0..count {
             sks.push(SecretKey::new(&mut rand::rng()));
             voting_sks.push(aggsig::SecretKey::new(&mut rand::rng()));
+            let sock = dontcare_sockaddr();
             validators.push(ValidatorInfo {
                 id: i,
                 stake: 1,
                 pubkey: sks[i as usize].to_pk(),
                 voting_pubkey: voting_sks[i as usize].to_pk(),
-                all2all_address: String::new(),
-                disseminator_address: String::new(),
-                repair_address: String::new(),
+                all2all_address: sock,
+                disseminator_address: sock,
+                repair_address: sock,
             });
         }
         (sks, validators)
@@ -266,7 +267,7 @@ mod tests {
                 .with_packet_loss(0.0),
         );
         for (i, v) in validators.iter_mut().enumerate() {
-            v.disseminator_address = i.to_string();
+            v.disseminator_address = localhost_ip_sockaddr(i.try_into().unwrap());
         }
         let mut disseminators = Vec::new();
         for i in 0..validators.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ pub mod test_utils;
 pub mod types;
 pub mod validator;
 
+use std::net::SocketAddr;
+
 use serde::{Deserialize, Serialize};
 
 pub use self::all2all::All2All;
@@ -63,9 +65,9 @@ pub struct ValidatorInfo {
     pub pubkey: signature::PublicKey,
     #[serde(deserialize_with = "aggsig::PublicKey::from_array_of_bytes")]
     pub voting_pubkey: aggsig::PublicKey,
-    pub all2all_address: String,
-    pub disseminator_address: String,
-    pub repair_address: String,
+    pub all2all_address: SocketAddr,
+    pub disseminator_address: SocketAddr,
+    pub repair_address: SocketAddr,
 }
 
 /// Returns the highest non-zero byte in `val`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use alpenglow::all2all::TrivialAll2All;
@@ -11,7 +10,7 @@ use alpenglow::crypto::aggsig;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Rotor;
 use alpenglow::disseminator::rotor::StakeWeightedSampler;
-use alpenglow::network::UdpNetwork;
+use alpenglow::network::{UdpNetwork, localhost_ip_sockaddr};
 use alpenglow::{ValidatorInfo, logging};
 use color_eyre::Result;
 use fastrace::collector::Config;
@@ -82,7 +81,6 @@ type TestNode =
 
 fn create_test_nodes(count: u64) -> Vec<TestNode> {
     // prepare validator info for all nodes
-    let ipaddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let mut port = 3000;
     let mut rng = rng();
     let mut sks = Vec::new();
@@ -96,9 +94,9 @@ fn create_test_nodes(count: u64) -> Vec<TestNode> {
             stake: 1,
             pubkey: sks[id as usize].to_pk(),
             voting_pubkey: voting_sks[id as usize].to_pk(),
-            all2all_address: SocketAddr::new(ipaddr, port),
-            disseminator_address: SocketAddr::new(ipaddr, port + 1),
-            repair_address: SocketAddr::new(ipaddr, port + 2),
+            all2all_address: localhost_ip_sockaddr(port),
+            disseminator_address: localhost_ip_sockaddr(port + 1),
+            repair_address: localhost_ip_sockaddr(port + 2),
         });
         port += 4;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use alpenglow::all2all::TrivialAll2All;
@@ -81,6 +82,7 @@ type TestNode =
 
 fn create_test_nodes(count: u64) -> Vec<TestNode> {
     // prepare validator info for all nodes
+    let ipaddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let mut port = 3000;
     let mut rng = rng();
     let mut sks = Vec::new();
@@ -94,9 +96,9 @@ fn create_test_nodes(count: u64) -> Vec<TestNode> {
             stake: 1,
             pubkey: sks[id as usize].to_pk(),
             voting_pubkey: voting_sks[id as usize].to_pk(),
-            all2all_address: format!("127.0.0.1:{port}"),
-            disseminator_address: format!("127.0.0.1:{}", port + 1),
-            repair_address: format!("127.0.0.1:{}", port + 2),
+            all2all_address: SocketAddr::new(ipaddr, port),
+            disseminator_address: SocketAddr::new(ipaddr, port + 1),
+            repair_address: SocketAddr::new(ipaddr, port + 2),
         });
         port += 4;
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -28,7 +28,7 @@ pub mod simulated;
 mod tcp;
 mod udp;
 
-use std::str::FromStr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -156,32 +156,23 @@ pub enum NetworkError {
 /// Abstraction of a network interface for sending and receiving messages.
 #[async_trait]
 pub trait Network: Send + Sync {
-    type Address: Send;
+    async fn send(&self, message: &NetworkMessage, to: SocketAddr) -> Result<(), NetworkError>;
 
-    async fn send(
-        &self,
-        message: &NetworkMessage,
-        to: impl AsRef<str> + Send,
-    ) -> Result<(), NetworkError>;
-
-    async fn send_serialized(
-        &self,
-        bytes: &[u8],
-        to: impl AsRef<str> + Send,
-    ) -> Result<(), NetworkError>;
+    async fn send_serialized(&self, bytes: &[u8], to: SocketAddr) -> Result<(), NetworkError>;
 
     // TODO: implement brodcast at `Network` level?
 
     async fn receive(&self) -> Result<NetworkMessage, NetworkError>;
+}
 
-    fn parse_addr(str: impl AsRef<str>) -> Result<Self::Address, NetworkError>
-    where
-        Self::Address: FromStr,
-    {
-        str.as_ref()
-            .parse()
-            .map_err(|_| NetworkError::MalformedAddress)
-    }
+/// Returns a [`SocketAddr`] bound to the localhost IPv4 and given port.
+pub fn localhost_ip_sockaddr(port: u16) -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)
+}
+
+/// Returns a [`SocketAddr`] that could be bound any arbitrary IP and port.
+pub fn dontcare_sockaddr() -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 1234)
 }
 
 #[cfg(test)]

--- a/src/network.rs
+++ b/src/network.rs
@@ -171,6 +171,9 @@ pub fn localhost_ip_sockaddr(port: u16) -> SocketAddr {
 }
 
 /// Returns a [`SocketAddr`] that could be bound any arbitrary IP and port.
+///
+/// This is present here to enable sharing of code between testing and benchmarking.
+/// This should not be used in production.
 pub fn dontcare_sockaddr() -> SocketAddr {
     SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 1234)
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -166,6 +166,10 @@ pub trait Network: Send + Sync {
 }
 
 /// Returns a [`SocketAddr`] bound to the localhost IPv4 and given port.
+///
+/// NOTE: port 0 is generally reserved and used to get the OS to assign a port.
+/// Using this function with port=0 on actual networks might lead to unexpected behaviour.
+/// TODO: prevent being able to call this function with port = 0.
 pub fn localhost_ip_sockaddr(port: u16) -> SocketAddr {
     SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)
 }

--- a/src/network/simulated/stake_distribution.rs
+++ b/src/network/simulated/stake_distribution.rs
@@ -30,6 +30,7 @@ use serde::Deserialize;
 use super::ping_data::{PingServer, coordinates_for_city, find_closest_ping_server, get_ping};
 use crate::crypto::aggsig;
 use crate::crypto::signature::SecretKey;
+use crate::network::dontcare_sockaddr;
 use crate::{Stake, ValidatorId, ValidatorInfo};
 
 /// Information about all validators on Solana mainnet.
@@ -187,6 +188,7 @@ pub fn validators_from_validator_data(
     Vec<ValidatorInfo>,
     Vec<(ValidatorInfo, &'static PingServer)>,
 ) {
+    let sockaddr = dontcare_sockaddr();
     let mut validators = Vec::new();
     for v in validator_data {
         if !(v.is_active && v.delinquent == Some(false)) {
@@ -202,9 +204,9 @@ pub fn validators_from_validator_data(
                 stake,
                 pubkey: sk.to_pk(),
                 voting_pubkey: voting_sk.to_pk(),
-                all2all_address: String::new(),
-                disseminator_address: String::new(),
-                repair_address: String::new(),
+                all2all_address: sockaddr,
+                disseminator_address: sockaddr,
+                repair_address: sockaddr,
             });
         }
     }
@@ -231,9 +233,9 @@ pub fn validators_from_validator_data(
                 stake,
                 pubkey: sk.to_pk(),
                 voting_pubkey: voting_sk.to_pk(),
-                all2all_address: String::new(),
-                disseminator_address: String::new(),
-                repair_address: String::new(),
+                all2all_address: sockaddr,
+                disseminator_address: sockaddr,
+                repair_address: sockaddr,
             },
             ping_server,
         ));

--- a/src/network/simulated/stake_distribution.rs
+++ b/src/network/simulated/stake_distribution.rs
@@ -188,7 +188,6 @@ pub fn validators_from_validator_data(
     Vec<ValidatorInfo>,
     Vec<(ValidatorInfo, &'static PingServer)>,
 ) {
-    let sockaddr = dontcare_sockaddr();
     let mut validators = Vec::new();
     for v in validator_data {
         if !(v.is_active && v.delinquent == Some(false)) {
@@ -204,9 +203,9 @@ pub fn validators_from_validator_data(
                 stake,
                 pubkey: sk.to_pk(),
                 voting_pubkey: voting_sk.to_pk(),
-                all2all_address: sockaddr,
-                disseminator_address: sockaddr,
-                repair_address: sockaddr,
+                all2all_address: dontcare_sockaddr(),
+                disseminator_address: dontcare_sockaddr(),
+                repair_address: dontcare_sockaddr(),
             });
         }
     }
@@ -233,9 +232,9 @@ pub fn validators_from_validator_data(
                 stake,
                 pubkey: sk.to_pk(),
                 voting_pubkey: voting_sk.to_pk(),
-                all2all_address: sockaddr,
-                disseminator_address: sockaddr,
-                repair_address: sockaddr,
+                all2all_address: dontcare_sockaddr(),
+                disseminator_address: dontcare_sockaddr(),
+                repair_address: dontcare_sockaddr(),
             },
             ping_server,
         ));

--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -64,22 +64,12 @@ impl TcpNetwork {
 
 #[async_trait]
 impl Network for TcpNetwork {
-    type Address = SocketAddr;
-
-    async fn send(
-        &self,
-        message: &NetworkMessage,
-        to: impl AsRef<str> + Send,
-    ) -> Result<(), NetworkError> {
+    async fn send(&self, message: &NetworkMessage, to: SocketAddr) -> Result<(), NetworkError> {
         let bytes = message.to_bytes();
         self.send_serialized(&bytes, to).await
     }
 
-    async fn send_serialized(
-        &self,
-        bytes: &[u8],
-        _to: impl AsRef<str> + Send,
-    ) -> Result<(), NetworkError> {
+    async fn send_serialized(&self, bytes: &[u8], _to: SocketAddr) -> Result<(), NetworkError> {
         // TODO: use correct socket
         let writer = &self.writers.read().await[0];
         writer.lock().await.send(bytes.to_vec().into()).await?;

--- a/src/network/udp.rs
+++ b/src/network/udp.rs
@@ -53,24 +53,13 @@ impl UdpNetwork {
 
 #[async_trait]
 impl Network for UdpNetwork {
-    type Address = SocketAddr;
-
-    async fn send(
-        &self,
-        message: &NetworkMessage,
-        to: impl AsRef<str> + Send,
-    ) -> Result<(), NetworkError> {
+    async fn send(&self, message: &NetworkMessage, to: SocketAddr) -> Result<(), NetworkError> {
         let bytes = message.to_bytes();
         self.send_serialized(&bytes, to).await
     }
 
-    async fn send_serialized(
-        &self,
-        bytes: &[u8],
-        to: impl AsRef<str> + Send,
-    ) -> Result<(), NetworkError> {
-        let to_addr = Self::parse_addr(to).unwrap();
-        self.socket.send_to(bytes, to_addr).await?;
+    async fn send_serialized(&self, bytes: &[u8], to: SocketAddr) -> Result<(), NetworkError> {
+        self.socket.send_to(bytes, to).await?;
         Ok(())
     }
 
@@ -89,22 +78,24 @@ impl Network for UdpNetwork {
 
 #[cfg(test)]
 mod tests {
+    use std::net::IpAddr;
+
     use super::*;
 
     #[tokio::test]
     async fn ping() {
         let socket1 = UdpNetwork::new_with_any_port();
         let socket2 = UdpNetwork::new_with_any_port();
-        let addr1 = format!("127.0.0.1:{}", socket1.port());
+        let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), socket1.port());
 
         // regular send()
-        socket2.send(&NetworkMessage::Ping, &addr1).await.unwrap();
+        socket2.send(&NetworkMessage::Ping, addr1).await.unwrap();
         let msg = socket1.receive().await.unwrap();
         assert!(matches!(msg, NetworkMessage::Ping));
 
         // send_serialized()
         let bytes = NetworkMessage::Ping.to_bytes();
-        socket2.send_serialized(&bytes, &addr1).await.unwrap();
+        socket2.send_serialized(&bytes, addr1).await.unwrap();
         let msg = socket1.receive().await.unwrap();
         assert!(matches!(msg, NetworkMessage::Ping));
     }
@@ -113,13 +104,13 @@ mod tests {
     async fn ping_pong() {
         let socket1 = UdpNetwork::new_with_any_port();
         let socket2 = UdpNetwork::new_with_any_port();
-        let addr1 = format!("127.0.0.1:{}", socket1.port());
-        let addr2 = format!("127.0.0.1:{}", socket2.port());
+        let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), socket1.port());
+        let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), socket2.port());
 
-        socket1.send(&NetworkMessage::Ping, &addr2).await.unwrap();
+        socket1.send(&NetworkMessage::Ping, addr2).await.unwrap();
         let msg = socket2.receive().await.unwrap();
         assert!(matches!(msg, NetworkMessage::Ping));
-        socket2.send(&NetworkMessage::Pong, &addr1).await.unwrap();
+        socket2.send(&NetworkMessage::Pong, addr1).await.unwrap();
         let msg = socket1.receive().await.unwrap();
         assert!(matches!(msg, NetworkMessage::Pong));
     }

--- a/src/network/udp.rs
+++ b/src/network/udp.rs
@@ -78,7 +78,7 @@ impl Network for UdpNetwork {
 
 #[cfg(test)]
 mod tests {
-    use std::net::IpAddr;
+    use crate::network::localhost_ip_sockaddr;
 
     use super::*;
 
@@ -86,7 +86,7 @@ mod tests {
     async fn ping() {
         let socket1 = UdpNetwork::new_with_any_port();
         let socket2 = UdpNetwork::new_with_any_port();
-        let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), socket1.port());
+        let addr1 = localhost_ip_sockaddr(socket1.port());
 
         // regular send()
         socket2.send(&NetworkMessage::Ping, addr1).await.unwrap();
@@ -104,8 +104,8 @@ mod tests {
     async fn ping_pong() {
         let socket1 = UdpNetwork::new_with_any_port();
         let socket2 = UdpNetwork::new_with_any_port();
-        let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), socket1.port());
-        let addr2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), socket2.port());
+        let addr1 = localhost_ip_sockaddr(socket1.port());
+        let addr2 = localhost_ip_sockaddr(socket2.port());
 
         socket1.send(&NetworkMessage::Ping, addr2).await.unwrap();
         let msg = socket2.receive().await.unwrap();

--- a/src/network/udp.rs
+++ b/src/network/udp.rs
@@ -78,9 +78,8 @@ impl Network for UdpNetwork {
 
 #[cfg(test)]
 mod tests {
-    use crate::network::localhost_ip_sockaddr;
-
     use super::*;
+    use crate::network::localhost_ip_sockaddr;
 
     #[tokio::test]
     async fn ping() {

--- a/tests/liveness.rs
+++ b/tests/liveness.rs
@@ -11,7 +11,7 @@ use alpenglow::crypto::aggsig;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Rotor;
 use alpenglow::disseminator::rotor::StakeWeightedSampler;
-use alpenglow::network::UdpNetwork;
+use alpenglow::network::{UdpNetwork, localhost_ip_sockaddr};
 use alpenglow::types::Slot;
 use alpenglow::{Alpenglow, ValidatorInfo};
 use log::debug;
@@ -92,9 +92,9 @@ fn create_test_nodes(count: u64) -> Vec<TestNode> {
             stake: 1,
             pubkey: sks[id as usize].to_pk(),
             voting_pubkey: voting_sks[id as usize].to_pk(),
-            all2all_address: format!("127.0.0.1:{a2a_port}"),
-            disseminator_address: format!("127.0.0.1:{dis_port}"),
-            repair_address: format!("127.0.0.1:{rep_port}"),
+            all2all_address: localhost_ip_sockaddr(a2a_port),
+            disseminator_address: localhost_ip_sockaddr(dis_port),
+            repair_address: localhost_ip_sockaddr(rep_port),
         });
     }
 


### PR DESCRIPTION
This makes things a bit more ergonomic; reduces string parsing when sending messages; etc.