### PR TITLE
fix: finalization slot/block, naming around certs/finalization, adapt tests

### DIFF
--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -265,7 +265,7 @@ impl PoolImpl {
     /// Cleans up old finalized slots from the pool.
     ///
     /// After this, [`Self::slot_states`] will only contain entries for slots
-    /// >= [`Self::highest_finalized_slot`].
+    /// >= [`Self::finalized_slot`].
     fn prune(&mut self) {
         let last_slot = self.finalized_slot();
         self.slot_states = self.slot_states.split_off(&last_slot);
@@ -283,7 +283,7 @@ impl PoolImpl {
     }
 
     /// Returns `true` iff the pool contains a notar(-fallback) certificate for the slot.
-    pub fn is_notarized_fallback(&self, slot: Slot) -> bool {
+    pub fn has_notar_or_fallback_cert(&self, slot: Slot) -> bool {
         self.slot_states.get(&slot).is_some_and(|state| {
             state.certificates.notar.is_some() || !state.certificates.notar_fallback.is_empty()
         })
@@ -301,21 +301,21 @@ impl PoolImpl {
     }
 
     /// Returns `true` iff the pool contains a (fast) finalization certificate for the slot.
-    pub fn is_finalized(&self, slot: Slot) -> bool {
+    pub fn has_final_cert(&self, slot: Slot) -> bool {
         self.slot_states.get(&slot).is_some_and(|state| {
             state.certificates.fast_finalize.is_some() || state.certificates.finalize.is_some()
         })
     }
 
     /// Returns `true` iff the pool contains a notarization certificate for the slot.
-    pub fn is_notarized(&self, slot: Slot) -> bool {
+    pub fn has_notar_cert(&self, slot: Slot) -> bool {
         self.slot_states
             .get(&slot)
             .is_some_and(|state| state.certificates.notar.is_some())
     }
 
     /// Returns `true` iff the pool contains a skip certificate for the slot.
-    pub fn is_skip_certified(&self, slot: Slot) -> bool {
+    pub fn has_skip_cert(&self, slot: Slot) -> bool {
         self.slot_states
             .get(&slot)
             .is_some_and(|state| state.certificates.skip.is_some())
@@ -532,28 +532,28 @@ mod tests {
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
 
         // all nodes notarize block in slot 0
-        assert!(!pool.is_notarized(Slot::new(0)));
+        assert!(!pool.has_notar_cert(Slot::new(0)));
         for v in 0..11 {
             let vote = Vote::new_notar(Slot::new(0), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_notarized(Slot::new(0)));
+        assert!(pool.has_notar_cert(Slot::new(0)));
 
         // just enough nodes notarize block in slot 1
-        assert!(!pool.is_notarized(Slot::new(1)));
+        assert!(!pool.has_notar_cert(Slot::new(1)));
         for v in 0..7 {
             let vote = Vote::new_notar(Slot::new(1), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_notarized(Slot::new(1)));
+        assert!(pool.has_notar_cert(Slot::new(1)));
 
         // just NOT enough nodes notarize block in slot 2
-        assert!(!pool.is_notarized(Slot::new(2)));
+        assert!(!pool.has_notar_cert(Slot::new(2)));
         for v in 0..6 {
             let vote = Vote::new_notar(Slot::new(2), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(!pool.is_notarized(Slot::new(2)));
+        assert!(!pool.has_notar_cert(Slot::new(2)));
     }
 
     #[tokio::test]
@@ -564,28 +564,28 @@ mod tests {
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
 
         // all nodes vote skip on slot 0
-        assert!(!pool.is_skip_certified(Slot::new(0)));
+        assert!(!pool.has_skip_cert(Slot::new(0)));
         for v in 0..11 {
             let vote = Vote::new_skip(Slot::new(0), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_skip_certified(Slot::new(0)));
+        assert!(pool.has_skip_cert(Slot::new(0)));
 
         // just enough nodes vote skip on slot 1
-        assert!(!pool.is_skip_certified(Slot::new(1)));
+        assert!(!pool.has_skip_cert(Slot::new(1)));
         for v in 0..7 {
             let vote = Vote::new_skip(Slot::new(1), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_skip_certified(Slot::new(1)));
+        assert!(pool.has_skip_cert(Slot::new(1)));
 
         // just NOT enough nodes notarize block in slot 2
-        assert!(!pool.is_skip_certified(Slot::new(2)));
+        assert!(!pool.has_skip_cert(Slot::new(2)));
         for v in 0..6 {
             let vote = Vote::new_skip(Slot::new(2), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(!pool.is_skip_certified(Slot::new(2)));
+        assert!(!pool.has_skip_cert(Slot::new(2)));
     }
 
     #[tokio::test]
@@ -595,32 +595,50 @@ mod tests {
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
 
-        // all nodes vote finalize on slot 0
-        assert!(!pool.is_finalized(Slot::new(0)));
-        for v in 0..11 {
-            let vote = Vote::new_final(Slot::new(0), &sks[v as usize], v);
-            assert_eq!(pool.add_vote(vote).await, Ok(()));
-        }
-        assert!(pool.is_finalized(Slot::new(0)));
-        assert_eq!(pool.finalized_slot(), Slot::new(0));
-
-        // just enough nodes vote finalize on slot 1
-        assert!(!pool.is_finalized(Slot::new(1)));
+        // just enough nodes vote notar, this is NOT enough on its own to finalize
+        let slot1 = Slot::genesis().next();
         for v in 0..7 {
-            let vote = Vote::new_final(Slot::new(1), &sks[v as usize], v);
+            let vote = Vote::new_notar(slot1, [1; 32], &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_finalized(Slot::new(1)));
-        assert_eq!(pool.finalized_slot(), Slot::new(1));
+        assert!(!pool.has_final_cert(slot1));
+        assert_eq!(pool.finalized_slot(), Slot::genesis());
 
-        // just NOT enough nodes vote finalize on slot 2
-        assert!(!pool.is_finalized(Slot::new(2)));
-        for v in 0..6 {
-            let vote = Vote::new_final(Slot::new(2), &sks[v as usize], v);
+        // just enough nodes vote final, NOW slot 1 should be finalized
+        for v in 0..7 {
+            let vote = Vote::new_final(slot1, &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(!pool.is_finalized(Slot::new(2)));
-        assert_eq!(pool.finalized_slot(), Slot::new(1));
+        assert!(pool.has_final_cert(slot1));
+        assert_eq!(pool.finalized_slot(), slot1);
+
+        // just enough nodes vote final, this is NOT enough on its own to finalize
+        let slot2 = slot1.next();
+        for v in 0..7 {
+            let vote = Vote::new_final(slot2, &sks[v as usize], v);
+            assert_eq!(pool.add_vote(vote).await, Ok(()));
+        }
+        assert!(pool.has_final_cert(slot2));
+        assert_eq!(pool.finalized_slot(), slot1);
+
+        // just enough nodes vote notar, NOW slot 2 should be finalized
+        for v in 0..7 {
+            let vote = Vote::new_notar(slot2, [2; 32], &sks[v as usize], v);
+            assert_eq!(pool.add_vote(vote).await, Ok(()));
+        }
+        assert!(pool.has_final_cert(slot2));
+        assert_eq!(pool.finalized_slot(), slot2);
+
+        // just NOT enough nodes vote notar + final on slot 3
+        let slot3 = slot2.next();
+        for v in 0..6 {
+            let vote = Vote::new_notar(slot3, [3; 32], &sks[v as usize], v);
+            assert_eq!(pool.add_vote(vote).await, Ok(()));
+            let vote = Vote::new_final(slot3, &sks[v as usize], v);
+            assert_eq!(pool.add_vote(vote).await, Ok(()));
+        }
+        assert!(!pool.has_final_cert(slot3));
+        assert_eq!(pool.finalized_slot(), slot2);
     }
 
     #[tokio::test]
@@ -631,30 +649,30 @@ mod tests {
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
 
         // all nodes vote notarize on slot 0
-        assert!(!pool.is_finalized(Slot::new(0)));
+        assert!(!pool.has_final_cert(Slot::new(0)));
         for v in 0..11 {
             let vote = Vote::new_notar(Slot::new(0), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_finalized(Slot::new(0)));
+        assert!(pool.has_final_cert(Slot::new(0)));
         assert_eq!(pool.finalized_slot(), Slot::new(0));
 
         // just enough nodes to fast finalize slot 1
-        assert!(!pool.is_finalized(Slot::new(1)));
+        assert!(!pool.has_final_cert(Slot::new(1)));
         for v in 0..9 {
             let vote = Vote::new_notar(Slot::new(1), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(pool.is_finalized(Slot::new(1)));
+        assert!(pool.has_final_cert(Slot::new(1)));
         assert_eq!(pool.finalized_slot(), Slot::new(1));
 
         // just NOT enough nodes to fast finalize slot 2
-        assert!(!pool.is_finalized(Slot::new(2)));
+        assert!(!pool.has_final_cert(Slot::new(2)));
         for v in 0..8 {
             let vote = Vote::new_notar(Slot::new(2), Hash::default(), &sks[v as usize], v);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
         }
-        assert!(!pool.is_finalized(Slot::new(2)));
+        assert!(!pool.has_final_cert(Slot::new(2)));
         assert_eq!(pool.finalized_slot(), Slot::new(1));
     }
 
@@ -902,15 +920,16 @@ mod tests {
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
 
-        // all nodes vote finalize on 3 leader windows
+        // all nodes vote to fast finalize 3 leader windows
         for slot in 0..3 * SLOTS_PER_WINDOW {
             let slot = Slot::new(slot);
-            assert!(!pool.is_finalized(slot));
+            let hash = [slot.inner() as u8; 32];
+            assert!(!pool.has_final_cert(slot));
             for v in 0..11 {
-                let vote = Vote::new_final(slot, &sks[v as usize], v);
+                let vote = Vote::new_notar(slot, hash, &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
-            assert!(pool.is_finalized(slot));
+            assert!(pool.has_final_cert(slot));
         }
         let last_slot = Slot::new(3 * SLOTS_PER_WINDOW - 1);
         assert_eq!(pool.finalized_slot(), last_slot);
@@ -922,14 +941,15 @@ mod tests {
         }
         assert!(pool.slot_states.contains_key(&(last_slot)));
 
-        // NOT enough nodes vote finalize on next 10 slots
+        // NOT enough nodes vote to fast finalize next 10 slots
         for s in 1..=10 {
             let slot = Slot::new(last_slot.inner() + s);
-            for v in 0..6 {
-                let vote = Vote::new_final(slot, &sks[v as usize], v);
+            let hash = [slot.inner() as u8; 32];
+            for v in 0..8 {
+                let vote = Vote::new_notar(slot, hash, &sks[v as usize], v);
                 assert_eq!(pool.add_vote(vote).await, Ok(()));
             }
-            assert!(!pool.is_finalized(slot));
+            assert!(!pool.has_final_cert(slot));
         }
         assert_eq!(pool.finalized_slot(), last_slot);
 
@@ -942,21 +962,20 @@ mod tests {
         // add one more vote each to finalize next 10 slots
         for s in 1..=10 {
             let slot = Slot::new(last_slot.inner() + s);
-            let vote = Vote::new_final(slot, &sks[6], 6);
+            let hash = [slot.inner() as u8; 32];
+            let vote = Vote::new_notar(slot, hash, &sks[8], 8);
             assert_eq!(pool.add_vote(vote).await, Ok(()));
-            assert!(pool.is_finalized(slot));
+            assert!(pool.has_final_cert(slot));
         }
         assert_eq!(pool.finalized_slot().inner(), last_slot.inner() + 10);
 
-        // NOW first 10 slots should be gone
+        // NOW next 10 slots should be gone
         for s in 0..10 {
             let slot = Slot::new(last_slot.inner() + s);
             assert!(!pool.slot_states.contains_key(&slot));
         }
-        assert!(
-            pool.slot_states
-                .contains_key(&Slot::new(last_slot.inner() + 10))
-        );
+        let new_last_slot = Slot::new(last_slot.inner() + 10);
+        assert!(pool.slot_states.contains_key(&new_last_slot));
     }
 
     #[tokio::test]

--- a/src/consensus/pool/finality_tracker.rs
+++ b/src/consensus/pool/finality_tracker.rs
@@ -31,6 +31,9 @@ pub struct FinalityTracker {
     /// Maps blocks to their parents.
     parents: BTreeMap<BlockId, BlockId>,
     /// The highest finalized slot so far.
+    ///
+    /// This means that slot has a fast finalization OR finalization + notarization.
+    /// Also, all prior slots are finalized (directly or implicitly) OR implicitly skipped.
     highest_finalized_slot: Slot,
 }
 
@@ -39,7 +42,7 @@ pub struct FinalityTracker {
 pub enum FinalizationStatus {
     /// Block with given hash is notarized, but slot is not yet (known to be) finalized.
     Notarized(Hash),
-    /// Slot is finalized, but notarized block is not yet known.
+    /// Slot is known to be finalized, but we are missing the notarization certificate.
     FinalPendingNotar,
     /// Slot is finalized, and notarized block is known to have the given hash.
     Finalized(Hash),


### PR DESCRIPTION
Previously, the basically meaningless notion of a finalized slot without a block was wrongfully exposed and used (i.e. the case when we have a finalization cert but don't yet have the notarization cert for a block). This is now fixed, only exposing the notion of notarized block as having fast finalization or final+notar certs outside of `FinalityTracker`. To go along with this, some of the naming around finalization and certificates has been adapted to be more accurate and less error prone.