### PR TITLE
refactor: combine the two definitions of `create_test_nodes` into one

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,16 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
-use std::sync::Arc;
 
-use alpenglow::all2all::TrivialAll2All;
-use alpenglow::consensus::{Alpenglow, EpochInfo};
-use alpenglow::crypto::aggsig;
-use alpenglow::crypto::signature::SecretKey;
-use alpenglow::disseminator::Rotor;
-use alpenglow::disseminator::rotor::StakeWeightedSampler;
-use alpenglow::network::{UdpNetwork, localhost_ip_sockaddr};
-use alpenglow::{ValidatorInfo, logging};
+use alpenglow::{create_test_nodes, logging};
 use color_eyre::Result;
 use fastrace::collector::Config;
 use fastrace::prelude::*;
@@ -20,7 +12,6 @@ use log::warn;
 use opentelemetry::{InstrumentationScope, KeyValue};
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 use opentelemetry_sdk::Resource;
-use rand::rng;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -74,54 +65,4 @@ async fn main() -> Result<()> {
     fastrace::flush();
 
     Ok(())
-}
-
-type TestNode =
-    Alpenglow<TrivialAll2All<UdpNetwork>, Rotor<UdpNetwork, StakeWeightedSampler>, UdpNetwork>;
-
-fn create_test_nodes(count: u64) -> Vec<TestNode> {
-    // prepare validator info for all nodes
-    let mut port = 3000;
-    let mut rng = rng();
-    let mut sks = Vec::new();
-    let mut voting_sks = Vec::new();
-    let mut validators = Vec::new();
-    for id in 0..count {
-        sks.push(SecretKey::new(&mut rng));
-        voting_sks.push(aggsig::SecretKey::new(&mut rng));
-        validators.push(ValidatorInfo {
-            id,
-            stake: 1,
-            pubkey: sks[id as usize].to_pk(),
-            voting_pubkey: voting_sks[id as usize].to_pk(),
-            all2all_address: localhost_ip_sockaddr(port),
-            disseminator_address: localhost_ip_sockaddr(port + 1),
-            repair_address: localhost_ip_sockaddr(port + 2),
-        });
-        port += 4;
-    }
-
-    // turn validator info into actual nodes
-    validators
-        .iter()
-        .map(|v| {
-            let epoch_info = Arc::new(EpochInfo::new(v.id, validators.clone()));
-            let start_port = 3000 + (v.id * 4) as u16;
-            let network = UdpNetwork::new(start_port);
-            let all2all = TrivialAll2All::new(validators.clone(), network);
-            let network = UdpNetwork::new(start_port + 1);
-            let disseminator = Rotor::new(network, epoch_info.clone());
-            let repair_network = UdpNetwork::new(start_port + 2);
-            let txs_receiver = UdpNetwork::new(start_port + 3);
-            Alpenglow::new(
-                sks[v.id as usize].clone(),
-                voting_sks[v.id as usize].clone(),
-                all2all,
-                disseminator,
-                repair_network,
-                epoch_info,
-                txs_receiver,
-            )
-        })
-        .collect()
 }

--- a/tests/liveness.rs
+++ b/tests/liveness.rs
@@ -1,18 +1,10 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
 use std::time::Duration;
 
-use alpenglow::all2all::TrivialAll2All;
-use alpenglow::consensus::EpochInfo;
-use alpenglow::crypto::aggsig;
-use alpenglow::crypto::signature::SecretKey;
-use alpenglow::disseminator::Rotor;
-use alpenglow::disseminator::rotor::StakeWeightedSampler;
-use alpenglow::network::{UdpNetwork, localhost_ip_sockaddr};
+use alpenglow::create_test_nodes;
 use alpenglow::types::Slot;
-use alpenglow::{Alpenglow, ValidatorInfo};
 use log::debug;
 use rand::prelude::*;
 
@@ -64,76 +56,6 @@ async fn three_nodes_crash() {
 // async fn transient_failure() {
 //     liveness_test(11, 1).await;
 // }
-
-type TestNode =
-    Alpenglow<TrivialAll2All<UdpNetwork>, Rotor<UdpNetwork, StakeWeightedSampler>, UdpNetwork>;
-
-struct Networks {
-    all2all: UdpNetwork,
-    disseminator: UdpNetwork,
-    repair: UdpNetwork,
-    txs: UdpNetwork,
-}
-
-impl Networks {
-    fn new() -> Self {
-        Self {
-            all2all: UdpNetwork::new_with_any_port(),
-            disseminator: UdpNetwork::new_with_any_port(),
-            repair: UdpNetwork::new_with_any_port(),
-            txs: UdpNetwork::new_with_any_port(),
-        }
-    }
-}
-
-fn create_test_nodes(count: u64) -> Vec<TestNode> {
-    // open sockets with arbitrary ports
-    let networks = (0..count).map(|_| Networks::new()).collect::<Vec<_>>();
-
-    // prepare validator info for all nodes
-    let mut rng = rand::rng();
-    let mut sks = Vec::new();
-    let mut voting_sks = Vec::new();
-    let mut validators = Vec::new();
-    for (id, network) in networks.iter().enumerate() {
-        sks.push(SecretKey::new(&mut rng));
-        voting_sks.push(aggsig::SecretKey::new(&mut rng));
-        let all2all_address = localhost_ip_sockaddr(network.all2all.port());
-        let disseminator_address = localhost_ip_sockaddr(network.disseminator.port());
-        let repair_address = localhost_ip_sockaddr(network.repair.port());
-        validators.push(ValidatorInfo {
-            id: id as u64,
-            stake: 1,
-            pubkey: sks[id].to_pk(),
-            voting_pubkey: voting_sks[id].to_pk(),
-            all2all_address,
-            disseminator_address,
-            repair_address,
-        });
-    }
-
-    // turn validator info into actual nodes
-    networks
-        .into_iter()
-        .enumerate()
-        .map(|(id, network)| {
-            let epoch_info = Arc::new(EpochInfo::new(id as u64, validators.clone()));
-            let all2all = TrivialAll2All::new(validators.clone(), network.all2all);
-            let disseminator = Rotor::new(network.disseminator, epoch_info.clone());
-            let repair_network = network.repair;
-            let txs_receiver = network.txs;
-            Alpenglow::new(
-                sks[id].clone(),
-                voting_sks[id].clone(),
-                all2all,
-                disseminator,
-                repair_network,
-                epoch_info,
-                txs_receiver,
-            )
-        })
-        .collect()
-}
 
 async fn liveness_test(num_nodes: usize, num_crashes: usize) {
     liveness_test_internal(num_nodes, num_crashes, true).await


### PR DESCRIPTION
We had a similar definition in two places: `src/main.rs` and `tests/liveness.rs`.

Unfortunately, the shared code has to go into `src/lib.rs`.