### PR TITLE
RFC: `Network::receive` only returns the desired type of message

### DIFF
--- a/src/all2all/robust.rs
+++ b/src/all2all/robust.rs
@@ -44,7 +44,7 @@ impl<N: Network> All2All for RobustAll2All<N> {
     }
 
     async fn receive(&self) -> Result<NetworkMessage, NetworkReceiveError> {
-        self.network.receive().await
+        self.network.receive_net_msg().await
         // loop {
         //     let msg = self.network.receive().await;
         //     match msg {

--- a/src/all2all/trivial.rs
+++ b/src/all2all/trivial.rs
@@ -39,7 +39,7 @@ impl<N: Network> All2All for TrivialAll2All<N> {
     }
 
     async fn receive(&self) -> Result<NetworkMessage, NetworkReceiveError> {
-        self.network.receive().await
+        self.network.receive_net_msg().await
     }
 }
 

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -414,7 +414,7 @@ where
             () = tokio::time::sleep(sleep_duration) => {
                 break Duration::ZERO;
             }
-            res = txs_receiver.receive() => {
+            res = txs_receiver.receive_net_msg() => {
                 res
             }
         };

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -122,7 +122,7 @@ impl<N: Network, S: SamplingStrategy + Sync + Send + 'static> Disseminator for R
 
     async fn receive(&self) -> Result<Shred, NetworkReceiveError> {
         loop {
-            match self.network.receive().await? {
+            match self.network.receive_net_msg().await? {
                 NetworkMessage::Shred(s) => return Ok(s),
                 m => warn!("unexpected message type for Rotor: {m:?}"),
             }

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -42,7 +42,7 @@ impl<N: Network> Disseminator for TrivialDisseminator<N> {
 
     async fn receive(&self) -> Result<Shred, NetworkReceiveError> {
         loop {
-            match self.network.receive().await? {
+            match self.network.receive_net_msg().await? {
                 NetworkMessage::Shred(s) => return Ok(s),
                 m => warn!("unexpected message type for disseminator: {m:?}"),
             }

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -140,7 +140,7 @@ impl<N: Network> Disseminator for Turbine<N> {
 
     async fn receive(&self) -> Result<Shred, NetworkReceiveError> {
         loop {
-            match self.network.receive().await? {
+            match self.network.receive_net_msg().await? {
                 NetworkMessage::Shred(s) => return Ok(s),
                 m => warn!("unexpected message type for Turbine: {m:?}"),
             }

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -72,7 +72,7 @@ impl Network for SimulatedNetwork {
         self.send_byte_vec(bytes.to_vec(), validator_id).await
     }
 
-    async fn receive(&self) -> Result<NetworkMessage, NetworkReceiveError> {
+    async fn receive_net_msg(&self) -> Result<NetworkMessage, NetworkReceiveError> {
         loop {
             let Some(bytes) = self.receiver.lock().await.recv().await else {
                 let io_error = std::io::Error::other("channel closed");
@@ -112,13 +112,13 @@ mod tests {
 
         // one direction
         net1.send(&msg, localhost_ip_sockaddr(1)).await.unwrap();
-        if !matches!(net2.receive().await, Ok(NetworkMessage::Ping)) {
+        if !matches!(net2.receive_net_msg().await, Ok(NetworkMessage::Ping)) {
             panic!("received wrong message");
         }
 
         // other direction
         net2.send(&msg, localhost_ip_sockaddr(0)).await.unwrap();
-        if !matches!(net1.receive().await, Ok(NetworkMessage::Ping)) {
+        if !matches!(net1.receive_net_msg().await, Ok(NetworkMessage::Ping)) {
             panic!("received wrong message");
         }
     }
@@ -161,7 +161,7 @@ mod tests {
         let receiver = tokio::spawn(async move {
             let mut shreds_received = 0;
             let now = Instant::now();
-            while let Ok(msg) = net2.receive().await {
+            while let Ok(msg) = net2.receive_net_msg().await {
                 if matches!(msg, NetworkMessage::Shred(_)) {
                     shreds_received += 1;
                     if shreds_received == 2 * TOTAL_SHREDS {
@@ -221,7 +221,7 @@ mod tests {
         let receiver = tokio::spawn(async move {
             let mut shreds_received = 0;
             let now = Instant::now();
-            while let Ok(msg) = net2.receive().await {
+            while let Ok(msg) = net2.receive_net_msg().await {
                 if matches!(msg, NetworkMessage::Shred(_)) {
                     shreds_received += 1;
                     if shreds_received == 1024 * TOTAL_SHREDS {
@@ -281,7 +281,7 @@ mod tests {
         let receiver = tokio::spawn(async move {
             let mut shreds_received = 0;
             let now = Instant::now();
-            while let Ok(msg) = net2.receive().await {
+            while let Ok(msg) = net2.receive_net_msg().await {
                 if matches!(msg, NetworkMessage::Shred(_)) {
                     shreds_received += 1;
                     if shreds_received == 1024 * TOTAL_SHREDS {

--- a/src/network/simulated/core.rs
+++ b/src/network/simulated/core.rs
@@ -278,7 +278,7 @@ mod tests {
         // one direction
         net1.send(&msg, localhost_ip_sockaddr(1)).await.unwrap();
         let now = Instant::now();
-        let _ = net2.receive().await.unwrap();
+        let _ = net2.receive_net_msg().await.unwrap();
         let latency = now.elapsed().as_micros();
         let min = (10_000.0 * (1.0 - ACCURACY)) as u128;
         let max = (10_000.0 * (1.0 + ACCURACY)) as u128;
@@ -288,7 +288,7 @@ mod tests {
         // other direction
         net2.send(&msg, localhost_ip_sockaddr(0)).await.unwrap();
         let now = Instant::now();
-        let _ = net1.receive().await.unwrap();
+        let _ = net1.receive_net_msg().await.unwrap();
         let latency = now.elapsed().as_micros();
         let min = (10_000.0 * (1.0 - ACCURACY)) as u128;
         let max = (10_000.0 * (1.0 + ACCURACY)) as u128;
@@ -318,7 +318,7 @@ mod tests {
         // one direction
         net1.send(&msg, localhost_ip_sockaddr(1)).await.unwrap();
         let now = Instant::now();
-        let _ = net2.receive().await.unwrap();
+        let _ = net2.receive_net_msg().await.unwrap();
         let latency = now.elapsed().as_micros();
         let min = (10_000.0 * (1.0 - ACCURACY)) as u128;
         let max = (10_000.0 * (1.0 + ACCURACY)) as u128;
@@ -334,7 +334,7 @@ mod tests {
         // other direction
         net2.send(&msg, localhost_ip_sockaddr(0)).await.unwrap();
         let now = Instant::now();
-        let _ = net1.receive().await.unwrap();
+        let _ = net1.receive_net_msg().await.unwrap();
         let latency = now.elapsed().as_micros();
         let min = (100_000.0 * (1.0 - ACCURACY)) as u128;
         let max = (100_000.0 * (1.0 + ACCURACY)) as u128;
@@ -361,9 +361,9 @@ mod tests {
         net3.send(&msg, sock0).await.unwrap();
 
         // ping should arrive before pong
-        let received = net1.receive().await.unwrap();
+        let received = net1.receive_net_msg().await.unwrap();
         assert!(matches!(received, NetworkMessage::Ping));
-        let received = net1.receive().await.unwrap();
+        let received = net1.receive_net_msg().await.unwrap();
         assert!(matches!(received, NetworkMessage::Pong));
 
         // queue messages in the other order
@@ -373,9 +373,9 @@ mod tests {
         net2.send(&msg, sock0).await.unwrap();
 
         // ping should still arrive before pong
-        let received = net1.receive().await.unwrap();
+        let received = net1.receive_net_msg().await.unwrap();
         assert!(matches!(received, NetworkMessage::Ping));
-        let received = net1.receive().await.unwrap();
+        let received = net1.receive_net_msg().await.unwrap();
         assert!(matches!(received, NetworkMessage::Pong));
     }
 
@@ -394,7 +394,7 @@ mod tests {
 
         let mut pings_received = 0;
         while let Ok(Ok(NetworkMessage::Ping)) =
-            timeout(Duration::from_millis(100), net2.receive()).await
+            timeout(Duration::from_millis(100), net2.receive_net_msg()).await
         {
             pings_received += 1;
         }

--- a/src/network/tcp.rs
+++ b/src/network/tcp.rs
@@ -77,7 +77,7 @@ impl Network for TcpNetwork {
         Ok(())
     }
 
-    async fn receive(&self) -> Result<NetworkMessage, NetworkReceiveError> {
+    async fn receive_net_msg(&self) -> Result<NetworkMessage, NetworkReceiveError> {
         loop {
             tokio::select! {
                 // accept new incoming connections

--- a/src/network/udp.rs
+++ b/src/network/udp.rs
@@ -64,7 +64,7 @@ impl Network for UdpNetwork {
         Ok(())
     }
 
-    async fn receive(&self) -> Result<NetworkMessage, NetworkReceiveError> {
+    async fn receive_net_msg(&self) -> Result<NetworkMessage, NetworkReceiveError> {
         let mut buf = [0; RECEIVE_BUFFER_SIZE];
         loop {
             let len = self.socket.recv(&mut buf).await?;
@@ -91,13 +91,13 @@ mod tests {
 
         // regular send()
         socket2.send(&NetworkMessage::Ping, addr1).await.unwrap();
-        let msg = socket1.receive().await.unwrap();
+        let msg = socket1.receive_net_msg().await.unwrap();
         assert!(matches!(msg, NetworkMessage::Ping));
 
         // send_serialized()
         let bytes = NetworkMessage::Ping.to_bytes();
         socket2.send_serialized(&bytes, addr1).await.unwrap();
-        let msg = socket1.receive().await.unwrap();
+        let msg = socket1.receive_net_msg().await.unwrap();
         assert!(matches!(msg, NetworkMessage::Ping));
     }
 
@@ -109,10 +109,10 @@ mod tests {
         let addr2 = localhost_ip_sockaddr(socket2.port());
 
         socket1.send(&NetworkMessage::Ping, addr2).await.unwrap();
-        let msg = socket2.receive().await.unwrap();
+        let msg = socket2.receive_net_msg().await.unwrap();
         assert!(matches!(msg, NetworkMessage::Ping));
         socket2.send(&NetworkMessage::Pong, addr1).await.unwrap();
-        let msg = socket1.receive().await.unwrap();
+        let msg = socket1.receive_net_msg().await.unwrap();
         assert!(matches!(msg, NetworkMessage::Pong));
     }
 }


### PR DESCRIPTION
Currently, whenever we are doing `Network::receive()`, we need to handle the different variants that we do not care about.  In most cases, we ignore the other variants and we simply call `receive()` again.

The idea here is to introduce a way to get the `Network` to keep looping till it receives the variant we care about.  The PR is still incomplete.  I wanted to get some feedback on whether this idea makes sense or not before I do the work to finish it up.

We introduce a new trait `FromNetworkMessage`.  This trait is implemented by the various types of network messages.  Then instead of calling `receive()`, we call e.g. `receive::<RepairMessage>()` and do not have to write additional looping code.

The only interesting part of the RFC is in `src/network.rs`.  You can ignore the rest of the changes.