### PR TITLE
feat: propagate errors from slice and block reconstruction

### DIFF
--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -171,6 +171,18 @@ impl BlockData {
         }
     }
 
+    fn add_shred(
+        &mut self,
+        shred: Shred,
+        leader_pk: PublicKey,
+    ) -> Result<Option<VotorEvent>, AddShredError> {
+        assert!(shred.payload().header.slot == self.slot);
+        let slice_index = shred.payload().header.slice_index;
+        let cached_merkle_root = self.merkle_root_cache.entry(slice_index);
+        let validated_shred = ValidatedShred::new(shred, cached_merkle_root, &leader_pk)?;
+        self.add_validated_shred(validated_shred)
+    }
+
     fn add_validated_shred(
         &mut self,
         validated_shred: ValidatedShred,
@@ -234,18 +246,6 @@ impl BlockData {
                 })),
             },
         }
-    }
-
-    fn add_shred(
-        &mut self,
-        shred: Shred,
-        leader_pk: PublicKey,
-    ) -> Result<Option<VotorEvent>, AddShredError> {
-        assert!(shred.payload().header.slot == self.slot);
-        let slice_index = shred.payload().header.slice_index;
-        let validated_shred =
-            ValidatedShred::new(shred, self.merkle_root_cache.entry(slice_index), &leader_pk)?;
-        self.add_validated_shred(validated_shred)
     }
 
     /// Reconstructs the slice if the blockstore contains enough shreds.

--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -15,8 +15,9 @@ use super::BlockInfo;
 use crate::consensus::votor::VotorEvent;
 use crate::crypto::signature::PublicKey;
 use crate::crypto::{Hash, MerkleTree};
-use crate::shredder::validated_shred::{ShredVerifyError, ValidatedShred};
-use crate::shredder::{DeshredError, RegularShredder, Shred, Shredder};
+use crate::shredder::{
+    DeshredError, RegularShredder, Shred, ShredVerifyError, Shredder, ValidatedShred,
+};
 use crate::types::{Slice, SliceIndex};
 use crate::{Block, Slot};
 

--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -394,16 +394,11 @@ mod tests {
         let mut events = vec![];
         for shred in shreds {
             match block_data.add_shred(shred, pk) {
-                Ok(maybe_event) => {
-                    if let Some(event) = maybe_event {
-                        events.push(event);
-                    }
+                Ok(Some(event)) => {
+                    events.push(event);
                 }
-                Err(err) => {
-                    if AddShredError::Duplicate != err {
-                        return (events, Err(err));
-                    }
-                }
+                Ok(None) | Err(AddShredError::Duplicate) => (),
+                Err(err) => return (events, Err(err)),
             }
         }
         (events, Ok(()))

--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -116,7 +116,7 @@ impl SlotBlockData {
     }
 }
 
-/// Returned value from [`try_reconstruct_slice`]
+/// Returned value from [`BlockData::try_reconstruct_slice`]
 enum ReconstructSliceResult {
     /// Either slice was already reconstructed or not enough data.
     NoAction,
@@ -126,7 +126,7 @@ enum ReconstructSliceResult {
     Complete,
 }
 
-/// Returned value from [`try_reconstruct_block`]
+/// Returned value from [`BlockData::try_reconstruct_block`]
 enum ReconstructBlockResult {
     /// Either block was already reconstructed or not enough data.
     NoAction,
@@ -145,7 +145,7 @@ pub struct BlockData {
     pub(super) completed: Option<(Hash, Block)>,
     /// Any shreds of this block stored so far, indexed by slice index.
     //
-    // TODO: Consider storing [`ValidatedShred`] here instead.
+    // TODO: Consider storing ValidatedShred here instead.
     pub(super) shreds: BTreeMap<SliceIndex, Vec<Shred>>,
     /// Any already reconstructed slices of this block.
     pub(super) slices: BTreeMap<SliceIndex, Slice>,

--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -29,7 +29,7 @@ pub enum AddShredError {
     Duplicate,
     #[error("shred shows leader equivocation")]
     Equivocation,
-    #[error("slice index mismatch")]
+    #[error("invalid slice index relative to last slice")]
     InvalidSliceIndex,
     #[error("slice reconstruction failed")]
     ReconstructSlice,

--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -18,7 +18,7 @@
 //! It also uses the [`Slice`] struct defined in the [`crate::slice`] module.
 
 mod reed_solomon;
-pub mod validated_shred;
+mod validated_shred;
 
 use aes::Aes128;
 use aes::cipher::{Array, KeyIvInit, StreamCipher};
@@ -30,6 +30,7 @@ use thiserror::Error;
 use self::reed_solomon::{
     ReedSolomonDeshredError, ReedSolomonShredError, reed_solomon_deshred, reed_solomon_shred,
 };
+pub use self::validated_shred::{ShredVerifyError, ValidatedShred};
 use crate::crypto::signature::{SecretKey, Signature};
 use crate::crypto::{Hash, MerkleTree, hash};
 use crate::types::{Slice, SliceHeader};

--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -126,7 +126,7 @@ pub struct Shred {
 impl Shred {
     /// Verifies only the Merkle proof of this shred.
     ///
-    /// For full verification, see [`Shred::verify`].
+    /// For full verification, see [`ValidatedShred::new`].
     ///
     /// Returns `true` iff the Merkle root matches the given root and the proof is valid.
     #[must_use]

--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -18,8 +18,7 @@
 //! It also uses the [`Slice`] struct defined in the [`crate::slice`] module.
 
 mod reed_solomon;
-
-use std::collections::btree_map::Entry;
+pub mod validated_shred;
 
 use aes::Aes128;
 use aes::cipher::{Array, KeyIvInit, StreamCipher};
@@ -31,9 +30,9 @@ use thiserror::Error;
 use self::reed_solomon::{
     ReedSolomonDeshredError, ReedSolomonShredError, reed_solomon_deshred, reed_solomon_shred,
 };
-use crate::crypto::signature::{PublicKey, SecretKey, Signature};
+use crate::crypto::signature::{SecretKey, Signature};
 use crate::crypto::{Hash, MerkleTree, hash};
-use crate::types::{Slice, SliceHeader, SliceIndex};
+use crate::types::{Slice, SliceHeader};
 
 /// Number of data shreds the payload of a slice is split into.
 pub const DATA_SHREDS: usize = 32;
@@ -114,18 +113,6 @@ impl ShredPayloadType {
     }
 }
 
-/// Different errors returned from [`Shred::verify()`].
-#[derive(Debug)]
-pub enum ShredVerifyError {
-    /// The shred contained an invalid Merkle proof.
-    InvalidProof,
-    /// The signature verification failed.
-    InvalidSignature,
-    /// Leader showed equivocation.
-    /// The Merkle root does not match the root from a previous shred.
-    Equivocation,
-}
-
 /// A shred is the smallest unit of data that is used when disseminating blocks.
 /// Shreds are crafted to fit into an MTU size packet.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -137,45 +124,6 @@ pub struct Shred {
 }
 
 impl Shred {
-    /// Verifies the proof and signature of this shred.
-    ///
-    /// Uses a cached entry to potentially skip signature verification and to detect equivocation.
-    pub fn verify(
-        &self,
-        pk: &PublicKey,
-        cached_merkle_root: Entry<SliceIndex, Hash>,
-    ) -> Result<(), ShredVerifyError> {
-        if !MerkleTree::check_proof(
-            &self.payload().data,
-            self.payload().index_in_slice,
-            self.merkle_root,
-            &self.merkle_path,
-        ) {
-            return Err(ShredVerifyError::InvalidProof);
-        }
-
-        match cached_merkle_root {
-            Entry::Occupied(entry) => {
-                if entry.get() == &self.merkle_root {
-                    return Ok(());
-                }
-                if self.merkle_root_sig.verify(&self.merkle_root, pk) {
-                    Err(ShredVerifyError::Equivocation)
-                } else {
-                    Err(ShredVerifyError::InvalidSignature)
-                }
-            }
-            Entry::Vacant(entry) => {
-                if self.merkle_root_sig.verify(&self.merkle_root, pk) {
-                    entry.insert(self.merkle_root);
-                    Ok(())
-                } else {
-                    Err(ShredVerifyError::InvalidSignature)
-                }
-            }
-        }
-    }
-
     /// Verifies only the Merkle proof of this shred.
     ///
     /// For full verification, see [`Shred::verify`].
@@ -596,19 +544,10 @@ fn build_merkle_tree(data_shreds: &[DataShred], coding_shreds: &[CodingShred]) -
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use color_eyre::Result;
 
     use super::*;
     use crate::types::slice::create_slice_with_invalid_txs;
-
-    fn create_random_shred() -> (Shred, SecretKey) {
-        let sk = SecretKey::new(&mut rng());
-        let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE - 16);
-        let mut shreds = RegularShredder::shred(slice, &sk).unwrap();
-        (shreds.pop().unwrap(), sk)
-    }
 
     #[test]
     fn regular_shredding() -> Result<()> {
@@ -774,36 +713,5 @@ mod tests {
         assert_eq!(result.err(), Some(DeshredError::NotEnoughShreds));
 
         Ok(())
-    }
-
-    #[test]
-    fn shred_verification() {
-        let mut map = BTreeMap::new();
-        let slice_index = SliceIndex::first();
-        let random_pk = SecretKey::new(&mut rng()).to_pk();
-
-        let (shred, sk) = create_random_shred();
-
-        // checking against other public key should fail
-        let res = shred.verify(&random_pk, map.entry(slice_index));
-        assert!(matches!(res, Err(ShredVerifyError::InvalidSignature)));
-        assert!(!map.contains_key(&slice_index));
-
-        // checking against correct public key should succeed
-        let res = shred.verify(&sk.to_pk(), map.entry(slice_index));
-        assert!(matches!(res, Ok(())));
-        assert!(map.contains_key(&slice_index));
-
-        let (invalid_shred, invalid_shred_sk) = create_random_shred();
-
-        // checking against other public key should fail
-        // and should not be considered as equivocation
-        let res = invalid_shred.verify(&random_pk, map.entry(slice_index));
-        assert!(matches!(res, Err(ShredVerifyError::InvalidSignature)));
-
-        // checking different shred (with different Merkle root and valid sig)
-        // against existing map entry should fail and detect equivocation
-        let res = invalid_shred.verify(&invalid_shred_sk.to_pk(), map.entry(slice_index));
-        assert!(matches!(res, Err(ShredVerifyError::Equivocation)));
     }
 }

--- a/src/shredder/reed_solomon.rs
+++ b/src/shredder/reed_solomon.rs
@@ -8,8 +8,9 @@ use thiserror::Error;
 
 use super::{
     CodingShred, DATA_SHREDS, DataShred, MAX_DATA_PER_SLICE, MAX_DATA_PER_SLICE_AFTER_PADDING,
-    Shred, ShredPayload, ShredPayloadType, SliceHeader, TOTAL_SHREDS,
+    ShredPayload, ShredPayloadType, SliceHeader, TOTAL_SHREDS,
 };
+use crate::shredder::Shred;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
 pub(super) enum ReedSolomonShredError {

--- a/src/shredder/validated_shred.rs
+++ b/src/shredder/validated_shred.rs
@@ -5,7 +5,7 @@ use crate::crypto::{Hash, MerkleTree};
 use crate::shredder::Shred;
 use crate::types::SliceIndex;
 
-/// Different errors returned from [`Shred::verify()`].
+/// Different errors returned from [`ValidatedShred::new`].
 #[derive(Debug)]
 pub enum ShredVerifyError {
     /// The shred contained an invalid Merkle proof.
@@ -25,7 +25,8 @@ pub struct ValidatedShred(Shred);
 impl ValidatedShred {
     /// Performs various verification checks on the [`Shred`] and if they succeed, returns a shred.
     ///
-    /// `cached_merkle_root`: is used to cache and skip certain checks for related shreds and detect equivocation.
+    /// `cached_merkle_root`: Refers to Merkle root of the slice, if known from earlier shred.
+    /// It is used to potentially skip expensive signature verification or detect equivocation.
     pub fn new(
         shred: Shred,
         cached_merkle_root: Entry<SliceIndex, Hash>,

--- a/src/shredder/validated_shred.rs
+++ b/src/shredder/validated_shred.rs
@@ -17,7 +17,10 @@ pub enum ShredVerifyError {
     Equivocation,
 }
 
-/// Using the new type pattern, this struct provides the guarantee that various verification checks have been performaned on the encapsulated [`Shred`].
+/// A verified wrapper around a [`Shred`].
+///
+/// It uses the new type pattern to encode verification in the type system.  
+/// The encapsulated [`Shred`] has passed all required checks.
 #[derive(Debug, Clone)]
 #[repr(transparent)]
 pub struct ValidatedShred(Shred);

--- a/src/shredder/validated_shred.rs
+++ b/src/shredder/validated_shred.rs
@@ -1,0 +1,122 @@
+use std::collections::btree_map::Entry;
+
+use crate::crypto::signature::PublicKey;
+use crate::crypto::{Hash, MerkleTree};
+use crate::shredder::Shred;
+use crate::types::SliceIndex;
+
+/// Different errors returned from [`Shred::verify()`].
+#[derive(Debug)]
+pub enum ShredVerifyError {
+    /// The shred contained an invalid Merkle proof.
+    InvalidProof,
+    /// The signature verification failed.
+    InvalidSignature,
+    /// Leader showed equivocation.
+    /// The Merkle root does not match the root from a previous shred.
+    Equivocation,
+}
+
+#[derive(Debug, Clone)]
+#[repr(transparent)]
+pub struct ValidatedShred(Shred);
+
+impl ValidatedShred {
+    pub fn new(
+        shred: Shred,
+        cached_merkle_root: Entry<SliceIndex, Hash>,
+        pk: &PublicKey,
+    ) -> Result<Self, ShredVerifyError> {
+        if !MerkleTree::check_proof(
+            &shred.payload().data,
+            shred.payload().index_in_slice,
+            shred.merkle_root,
+            &shred.merkle_path,
+        ) {
+            return Err(ShredVerifyError::InvalidProof);
+        }
+
+        match cached_merkle_root {
+            Entry::Occupied(entry) => {
+                if entry.get() == &shred.merkle_root {
+                    return Ok(Self(shred));
+                }
+                if shred.merkle_root_sig.verify(&shred.merkle_root, pk) {
+                    Err(ShredVerifyError::Equivocation)
+                } else {
+                    Err(ShredVerifyError::InvalidSignature)
+                }
+            }
+            Entry::Vacant(entry) => {
+                if shred.merkle_root_sig.verify(&shred.merkle_root, pk) {
+                    entry.insert(shred.merkle_root);
+                    Ok(Self(shred))
+                } else {
+                    Err(ShredVerifyError::InvalidSignature)
+                }
+            }
+        }
+    }
+
+    pub fn to_shred(&self) -> &Shred {
+        &self.0
+    }
+
+    pub fn into_shred(self) -> Shred {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use rand::rng;
+
+    use super::*;
+    use crate::crypto::signature::SecretKey;
+    use crate::shredder::{MAX_DATA_PER_SLICE, RegularShredder, Shredder};
+    use crate::types::slice::create_slice_with_invalid_txs;
+
+    fn create_random_shred() -> (Shred, SecretKey) {
+        let sk = SecretKey::new(&mut rng());
+        let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE - 16);
+        let mut shreds = RegularShredder::shred(slice, &sk).unwrap();
+        (shreds.pop().unwrap(), sk)
+    }
+
+    #[test]
+    fn shred_verification() {
+        let mut map = BTreeMap::new();
+        let slice_index = SliceIndex::first();
+        let random_pk = SecretKey::new(&mut rng()).to_pk();
+
+        let (shred, sk) = create_random_shred();
+
+        // checking against other public key should fail
+        let res = ValidatedShred::new(shred.clone(), map.entry(slice_index), &random_pk);
+        assert!(matches!(res, Err(ShredVerifyError::InvalidSignature)));
+        assert!(!map.contains_key(&slice_index));
+
+        // checking against correct public key should succeed
+        let res = ValidatedShred::new(shred, map.entry(slice_index), &sk.to_pk());
+        assert!(res.is_ok());
+        assert!(map.contains_key(&slice_index));
+
+        let (invalid_shred, invalid_shred_sk) = create_random_shred();
+
+        // checking against other public key should fail
+        // and should not be considered as equivocation
+        let res = ValidatedShred::new(invalid_shred.clone(), map.entry(slice_index), &random_pk);
+        assert!(matches!(res, Err(ShredVerifyError::InvalidSignature)));
+
+        // checking different shred (with different Merkle root and valid sig)
+        // against existing map entry should fail and detect equivocation
+        let res = ValidatedShred::new(
+            invalid_shred,
+            map.entry(slice_index),
+            &invalid_shred_sk.to_pk(),
+        );
+        assert!(matches!(res, Err(ShredVerifyError::Equivocation)));
+    }
+}

--- a/src/shredder/validated_shred.rs
+++ b/src/shredder/validated_shred.rs
@@ -17,11 +17,15 @@ pub enum ShredVerifyError {
     Equivocation,
 }
 
+/// Using the new type pattern, this struct provides the guarantee that various verification checks have been performaned on the encapsulated [`Shred`].
 #[derive(Debug, Clone)]
 #[repr(transparent)]
 pub struct ValidatedShred(Shred);
 
 impl ValidatedShred {
+    /// Performs various verification checks on the [`Shred`] and if they succeed, returns a shred.
+    ///
+    /// `cached_merkle_root`: is used to cache and skip certain checks for related shreds and detect equivocation.
     pub fn new(
         shred: Shred,
         cached_merkle_root: Entry<SliceIndex, Hash>,
@@ -58,10 +62,12 @@ impl ValidatedShred {
         }
     }
 
+    /// Get a reference to the inner [`Shred`].
     pub fn to_shred(&self) -> &Shred {
         &self.0
     }
 
+    /// Get access to the inner [`Shred`] consuming self.
     pub fn into_shred(self) -> Shred {
         self.0
     }


### PR DESCRIPTION
Part of https://github.com/qkniep/alpenglow/issues/85.

If `try_reconstruct_slice()` and `try_reconstruct_block()` fail, then propagate the error up the call stack to eventually call `try_skip_window()`.

In order to accomplish the above in a clean manner, the following changes are made:

- Introduces `ValidatedShred` which can only be constructed by verifying a shred.
- refactors `check_shred_to_add` and `add_valid_shred` so that the first function (`add_shred`) validates the shred and the second function (`add_validated_shred`) performs various checks, adds the shred, and calls `try_reconstruct_slice()` and `try_reconstruct_block()` as needed.

## Future work

- [ ] store and use `ValidatedShred` in more places
