### PR TITLE
refactor: Pass the btreemap `Entry` to `Shred::verify()` to consolidate updating the cache and error checking

### DIFF
--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -797,11 +797,12 @@ mod tests {
         let (invalid_shred, invalid_shred_sk) = create_random_shred();
 
         // checking against other public key should fail
+        // and should not be considered as equivocation
         let res = invalid_shred.verify(&random_pk, map.entry(slice_index));
         assert!(matches!(res, Err(ShredVerifyError::InvalidSignature)));
 
-        // checking different shred (with different Merkle root)
-        // against existing map entry should detect equivocation
+        // checking different shred (with different Merkle root and valid sig)
+        // against existing map entry should fail and detect equivocation
         let res = invalid_shred.verify(&invalid_shred_sk.to_pk(), map.entry(slice_index));
         assert!(matches!(res, Err(ShredVerifyError::Equivocation)));
     }

--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -116,12 +116,12 @@ impl ShredPayloadType {
 
 /// Different errors returned from [`Shred::verify()`].
 pub enum ShredVerifyError {
-    /// The shred contained an invalid merkle proof.
+    /// The shred contained an invalid Merkle proof.
     InvalidProof,
     /// The signature verification failed.
     InvalidSignature,
     /// Leader showed equivocation.
-    /// The merkle root that does not match the root from a previous shred.
+    /// The Merkle root does not match the root from a previous shred.
     Equivocation,
 }
 


### PR DESCRIPTION
If we pass the cache btreemap `Entry` to `Shred::verify()`, it can update it when the checks pass, use it to skip some checks, and we consolidate some error checking.