### PR TITLE
refactor: more readability improvements in performance_test.rs

### DIFF
--- a/src/bin/performance_test.rs
+++ b/src/bin/performance_test.rs
@@ -51,11 +51,9 @@ async fn create_test_nodes(count: u64) -> Vec<TestNode> {
     // first `count` networks are for all2all and the next `count` networks are for disseminator
     let core = Arc::new(SimulatedNetworkCore::default().with_packet_loss(0.0));
     let mut all2all_networks = VecDeque::new();
-    for i in 0..count {
-        all2all_networks.push_back(core.join_unlimited(i).await);
-    }
     let mut disseminator_networks = VecDeque::new();
     for i in 0..count {
+        all2all_networks.push_back(core.join_unlimited(i).await);
         disseminator_networks.push_back(core.join_unlimited(count + i).await);
     }
 


### PR DESCRIPTION
We are finally storing all types of networks in different containers which is necessary as moving forward the different types of networks will actually have different type signatures and cannot be stored in the same container.

Part of #187 