### PR TITLE
refactor: remove `NetworkMessage::Vote` and `NetworkMessage::Cert`

### DIFF
--- a/benches/network.rs
+++ b/benches/network.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use alpenglow::consensus::Vote;
+use alpenglow::consensus::{ConsensusMessage, Vote};
 use alpenglow::crypto::{Hash, aggsig, signature};
 use alpenglow::network::{BINCODE_CONFIG, NetworkMessage};
 use alpenglow::shredder::{MAX_DATA_PER_SLICE, RegularShredder, Shredder};
@@ -24,9 +24,10 @@ fn serialize_vote(bencher: divan::Bencher) {
             let mut hash = Hash::default();
             rng.fill_bytes(&mut hash);
             let sk = aggsig::SecretKey::new(&mut rng);
-            NetworkMessage::Vote(Vote::new_notar(Slot::new(0), hash, &sk, 0))
+            let vote = Vote::new_notar(Slot::new(0), hash, &sk, 0);
+            ConsensusMessage::Vote(vote)
         })
-        .bench_values(|msg: NetworkMessage| msg.to_bytes());
+        .bench_values(|msg: ConsensusMessage| bincode::serde::encode_to_vec(msg, BINCODE_CONFIG));
 }
 
 #[divan::bench]
@@ -38,10 +39,14 @@ fn deserialize_vote(bencher: divan::Bencher) {
             let mut hash = Hash::default();
             rng.fill_bytes(&mut hash);
             let sk = aggsig::SecretKey::new(&mut rng);
-            let msg = NetworkMessage::Vote(Vote::new_notar(Slot::new(0), hash, &sk, 0));
-            msg.to_bytes()
+            let vote = Vote::new_notar(Slot::new(0), hash, &sk, 0);
+            let msg = ConsensusMessage::Vote(vote);
+            bincode::serde::encode_to_vec(msg, BINCODE_CONFIG).unwrap()
         })
-        .bench_values(|bytes: Vec<u8>| NetworkMessage::from_bytes(&bytes));
+        .bench_values(|bytes: Vec<u8>| {
+            let (_msg, _bytes_read): (ConsensusMessage, usize) =
+                bincode::serde::decode_from_slice(&bytes, BINCODE_CONFIG).unwrap();
+        });
 }
 
 #[divan::bench]

--- a/src/all2all.rs
+++ b/src/all2all.rs
@@ -39,7 +39,7 @@ use async_trait::async_trait;
 
 pub use self::robust::RobustAll2All;
 pub use self::trivial::TrivialAll2All;
-use crate::network::NetworkMessage;
+use crate::consensus::ConsensusMessage;
 
 /// Abstraction for a direct all-to-all network communication protocol.
 #[async_trait]
@@ -53,15 +53,15 @@ pub trait All2All {
     /// # Errors
     ///
     /// Implementors should return [`NetworkSendError`] iff the underlying network fails.
-    async fn broadcast(&self, msg: &NetworkMessage) -> std::io::Result<()>;
+    async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()>;
 
     /// Receives a message from any of the other nodes.
     ///
-    /// Resolves to the next successfully deserialized [`NetworkMessage`].
+    /// Resolves to the next successfully deserialized [`ConsensusMessage`].
     /// Does not provide information on which node sent the message.
     ///
     /// # Errors
     ///
     /// Implementors should return [`NetworkReceiveError`] iff the underlying network fails.
-    async fn receive(&self) -> std::io::Result<NetworkMessage>;
+    async fn receive(&self) -> std::io::Result<ConsensusMessage>;
 }

--- a/src/all2all/robust.rs
+++ b/src/all2all/robust.rs
@@ -10,7 +10,8 @@ use async_trait::async_trait;
 
 use super::All2All;
 use crate::ValidatorInfo;
-use crate::network::{Network, NetworkMessage};
+use crate::consensus::ConsensusMessage;
+use crate::network::Network;
 
 /// Instance of the robust all-to-all broadcast protocol.
 // TODO: acutally make more robust (retransmits, ...)
@@ -37,9 +38,9 @@ impl<N: Network> RobustAll2All<N> {
 #[async_trait]
 impl<N: Network> All2All for RobustAll2All<N>
 where
-    N: Network<Recv = NetworkMessage, Send = NetworkMessage>,
+    N: Network<Recv = ConsensusMessage, Send = ConsensusMessage>,
 {
-    async fn broadcast(&self, msg: &NetworkMessage) -> std::io::Result<()> {
+    async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()> {
         for v in &self.validators {
             // HACK: stupidly expensive retransmits
             for _ in 0..1000 {
@@ -49,7 +50,7 @@ where
         Ok(())
     }
 
-    async fn receive(&self) -> std::io::Result<NetworkMessage> {
+    async fn receive(&self) -> std::io::Result<ConsensusMessage> {
         self.network.receive().await
         // loop {
         //     let msg = self.network.receive().await;
@@ -72,10 +73,12 @@ mod tests {
     use tokio::time::timeout;
 
     use super::*;
+    use crate::consensus::Vote;
     use crate::crypto::aggsig;
     use crate::crypto::signature::SecretKey;
     use crate::network::simulated::SimulatedNetworkCore;
     use crate::network::{dontcare_sockaddr, localhost_ip_sockaddr};
+    use crate::types::Slot;
 
     async fn broadcast_test(packet_loss: f64) {
         // set up network and nodes
@@ -115,13 +118,15 @@ mod tests {
         // run sender and receivers
         let mut tasks = JoinSet::new();
         tasks.spawn(async move {
-            let msg = NetworkMessage::Ping;
+            let voting_sk = aggsig::SecretKey::new(&mut rand::rng());
+            let vote = Vote::new_skip(Slot::genesis(), &voting_sk, 0);
+            let msg = ConsensusMessage::Vote(vote);
             all2all_sender.broadcast(&msg).await.unwrap();
         });
         for all2all in all2all_others {
             tasks.spawn(async move {
                 let received = all2all.receive().await.unwrap();
-                assert!(matches!(received, NetworkMessage::Ping));
+                assert!(matches!(received, ConsensusMessage::Vote(_)));
                 while let Ok(Ok(_)) = timeout(Duration::from_millis(1000), all2all.receive()).await
                 {
                     // do nothing

--- a/src/all2all/trivial.rs
+++ b/src/all2all/trivial.rs
@@ -11,7 +11,8 @@ use async_trait::async_trait;
 
 use super::All2All;
 use crate::ValidatorInfo;
-use crate::network::{Network, NetworkMessage};
+use crate::consensus::ConsensusMessage;
+use crate::network::Network;
 
 /// Instance of the trivial all-to-all broadcast protocol.
 pub struct TrivialAll2All<N: Network> {
@@ -35,16 +36,16 @@ impl<N: Network> TrivialAll2All<N> {
 #[async_trait]
 impl<N: Network> All2All for TrivialAll2All<N>
 where
-    N: Network<Recv = NetworkMessage, Send = NetworkMessage>,
+    N: Network<Recv = ConsensusMessage, Send = ConsensusMessage>,
 {
-    async fn broadcast(&self, msg: &NetworkMessage) -> std::io::Result<()> {
+    async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()> {
         for v in &self.validators {
             self.network.send(msg, v.all2all_address).await?;
         }
         Ok(())
     }
 
-    async fn receive(&self) -> std::io::Result<NetworkMessage> {
+    async fn receive(&self) -> std::io::Result<ConsensusMessage> {
         self.network.receive().await
     }
 }
@@ -57,10 +58,12 @@ mod tests {
     use tokio::task::JoinSet;
 
     use super::*;
+    use crate::consensus::Vote;
     use crate::crypto::aggsig;
     use crate::crypto::signature::SecretKey;
     use crate::network::simulated::SimulatedNetworkCore;
-    use crate::network::{dontcare_sockaddr, localhost_ip_sockaddr};
+    use crate::network::{SimulatedNetwork, dontcare_sockaddr, localhost_ip_sockaddr};
+    use crate::types::Slot;
 
     #[tokio::test]
     async fn simple_broadcast() {
@@ -70,12 +73,15 @@ mod tests {
                 .with_default_latency(Duration::from_millis(10))
                 .with_packet_loss(0.0),
         );
-        let net_sender = core.join_unlimited(0).await;
+        let net_sender: SimulatedNetwork<ConsensusMessage, ConsensusMessage> =
+            core.join_unlimited(0).await;
         let mut net_others = Vec::new();
         let mut validators = Vec::new();
         for i in 0..20 {
             if i > 0 {
-                net_others.push(core.join_unlimited(i).await);
+                let net: SimulatedNetwork<ConsensusMessage, ConsensusMessage> =
+                    core.join_unlimited(i).await;
+                net_others.push(net);
             }
             let sk = SecretKey::new(&mut rand::rng());
             let voting_sk = aggsig::SecretKey::new(&mut rand::rng());
@@ -101,13 +107,15 @@ mod tests {
         // run sender and receivers
         let mut tasks = JoinSet::new();
         tasks.spawn(async move {
-            let msg = NetworkMessage::Ping;
+            let voting_sk = aggsig::SecretKey::new(&mut rand::rng());
+            let vote = Vote::new_skip(Slot::genesis(), &voting_sk, 0);
+            let msg = ConsensusMessage::Vote(vote);
             all2all_sender.broadcast(&msg).await.unwrap();
         });
         for all2all in all2all_others {
             tasks.spawn(async move {
                 let received = all2all.receive().await.unwrap();
-                assert!(matches!(received, NetworkMessage::Ping));
+                assert!(matches!(received, ConsensusMessage::Vote(_)));
             });
         }
         tasks.join_all().await;

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -8,7 +8,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use alpenglow::all2all::TrivialAll2All;
-use alpenglow::consensus::{Alpenglow, EpochInfo};
+use alpenglow::consensus::{Alpenglow, ConsensusMessage, EpochInfo};
 use alpenglow::crypto::aggsig;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Rotor;
@@ -109,7 +109,7 @@ async fn main() -> Result<()> {
 }
 
 type Node = Alpenglow<
-    TrivialAll2All<UdpNetwork<NetworkMessage, NetworkMessage>>,
+    TrivialAll2All<UdpNetwork<ConsensusMessage, ConsensusMessage>>,
     Rotor<UdpNetwork<NetworkMessage, NetworkMessage>, StakeWeightedSampler>,
     UdpNetwork<Transaction, Transaction>,
 >;

--- a/src/bin/performance_test.rs
+++ b/src/bin/performance_test.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use alpenglow::all2all::TrivialAll2All;
-use alpenglow::consensus::EpochInfo;
+use alpenglow::consensus::{ConsensusMessage, EpochInfo};
 use alpenglow::crypto::aggsig;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Rotor;
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
 }
 
 type TestNode = Alpenglow<
-    TrivialAll2All<SimulatedNetwork<NetworkMessage, NetworkMessage>>,
+    TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>,
     Rotor<SimulatedNetwork<NetworkMessage, NetworkMessage>, StakeWeightedSampler>,
     UdpNetwork<Transaction, Transaction>,
 >;

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -364,12 +364,12 @@ mod tests {
 
     use super::*;
     use crate::all2all::TrivialAll2All;
-    use crate::consensus::EpochInfo;
     use crate::consensus::cert::NotarCert;
-    use crate::network::{NetworkMessage, SimulatedNetwork};
+    use crate::consensus::{ConsensusMessage, EpochInfo};
+    use crate::network::SimulatedNetwork;
     use crate::test_utils::{generate_all2all_instances, generate_validators};
 
-    type A2A = TrivialAll2All<SimulatedNetwork<NetworkMessage, NetworkMessage>>;
+    type A2A = TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>;
 
     async fn start_votor() -> (A2A, mpsc::Sender<VotorEvent>, Arc<EpochInfo>) {
         let (sks, epoch_info) = generate_validators(2);
@@ -395,11 +395,11 @@ mod tests {
         for _ in slots.clone() {
             if let Ok(msg) = other_a2a.receive().await {
                 match msg {
-                    NetworkMessage::Vote(v) => {
+                    ConsensusMessage::Vote(v) => {
                         assert!(v.is_skip());
                         skipped_slots.push(v.slot());
                     }
-                    _ => unreachable!(),
+                    m => panic!("other msg: {m:?}"),
                 }
             }
         }
@@ -421,7 +421,7 @@ mod tests {
         let event = VotorEvent::Block { slot, block_info };
         tx.send(event).await.unwrap();
         let vote = match other_a2a.receive().await.unwrap() {
-            NetworkMessage::Vote(v) => v,
+            ConsensusMessage::Vote(v) => v,
             m => panic!("other msg: {m:?}"),
         };
         assert!(vote.is_notar());
@@ -432,7 +432,7 @@ mod tests {
         let event = VotorEvent::CertCreated(Box::new(cert));
         tx.send(event).await.unwrap();
         match other_a2a.receive().await.unwrap() {
-            NetworkMessage::Vote(v) => {
+            ConsensusMessage::Vote(v) => {
                 assert!(v.is_final());
                 assert_eq!(v.slot(), slot);
             }
@@ -482,7 +482,7 @@ mod tests {
         // should now see notar votes
         for _ in 0..2 {
             match other_a2a.receive().await.unwrap() {
-                NetworkMessage::Vote(vote) => {
+                ConsensusMessage::Vote(vote) => {
                     assert!(vote.is_notar());
                     assert!(vote.slot() == slot1 || vote.slot() == slot2);
                 }
@@ -503,8 +503,8 @@ mod tests {
             }
             if let Ok(msg) = other_a2a.receive().await {
                 match msg {
-                    NetworkMessage::Vote(v) => assert!(v.is_skip()),
-                    _ => unreachable!(),
+                    ConsensusMessage::Vote(v) => assert!(v.is_skip()),
+                    m => panic!("other msg: {m:?}"),
                 }
             }
         }
@@ -513,7 +513,7 @@ mod tests {
         let event = VotorEvent::SafeToNotar(slot, [1; 32]);
         tx.send(event).await.unwrap();
         match other_a2a.receive().await.unwrap() {
-            NetworkMessage::Vote(v) => {
+            ConsensusMessage::Vote(v) => {
                 assert!(v.is_notar_fallback());
                 assert_eq!(v.slot(), slot);
                 assert_eq!(v.block_hash(), Some([1; 32]));
@@ -537,7 +537,7 @@ mod tests {
         let event = VotorEvent::Block { slot, block_info };
         tx.send(event).await.unwrap();
         let vote = match other_a2a.receive().await.unwrap() {
-            NetworkMessage::Vote(v) => v,
+            ConsensusMessage::Vote(v) => v,
             m => panic!("other msg: {m:?}"),
         };
         assert!(vote.is_notar());
@@ -547,7 +547,7 @@ mod tests {
         let event = VotorEvent::SafeToSkip(slot);
         tx.send(event).await.unwrap();
         match other_a2a.receive().await.unwrap() {
-            NetworkMessage::Vote(v) => {
+            ConsensusMessage::Vote(v) => {
                 assert!(v.is_skip_fallback());
                 assert_eq!(v.slot(), slot);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use self::disseminator::Disseminator;
 use self::types::Slot;
 pub use self::validator::Validator;
 use crate::all2all::TrivialAll2All;
-use crate::consensus::EpochInfo;
+use crate::consensus::{ConsensusMessage, EpochInfo};
 use crate::crypto::signature::SecretKey;
 use crate::disseminator::Rotor;
 use crate::disseminator::rotor::StakeWeightedSampler;
@@ -92,13 +92,13 @@ pub(crate) fn highest_non_zero_byte(mut val: usize) -> usize {
 }
 
 type TestNode = Alpenglow<
-    TrivialAll2All<UdpNetwork<NetworkMessage, NetworkMessage>>,
+    TrivialAll2All<UdpNetwork<ConsensusMessage, ConsensusMessage>>,
     Rotor<UdpNetwork<NetworkMessage, NetworkMessage>, StakeWeightedSampler>,
     UdpNetwork<Transaction, Transaction>,
 >;
 
 struct Networks {
-    all2all: UdpNetwork<NetworkMessage, NetworkMessage>,
+    all2all: UdpNetwork<ConsensusMessage, ConsensusMessage>,
     disseminator: UdpNetwork<NetworkMessage, NetworkMessage>,
     repair: UdpNetwork<RepairRequest, RepairResponse>,
     repair_request: UdpNetwork<RepairResponse, RepairRequest>,

--- a/src/network.rs
+++ b/src/network.rs
@@ -36,7 +36,6 @@ use serde::{Deserialize, Serialize};
 pub use self::simulated::SimulatedNetwork;
 pub use self::tcp::TcpNetwork;
 pub use self::udp::UdpNetwork;
-use crate::consensus::{Cert, Vote};
 use crate::shredder::Shred;
 
 /// Maximum payload size of a UDP packet.
@@ -53,8 +52,6 @@ pub enum NetworkMessage {
     Ping,
     Pong,
     Shred(Shred),
-    Vote(Vote),
-    Cert(Cert),
 }
 
 impl NetworkMessage {
@@ -112,18 +109,6 @@ impl NetworkMessage {
 impl From<Shred> for NetworkMessage {
     fn from(shred: Shred) -> Self {
         Self::Shred(shred)
-    }
-}
-
-impl From<Vote> for NetworkMessage {
-    fn from(vote: Vote) -> Self {
-        Self::Vote(vote)
-    }
-}
-
-impl From<Cert> for NetworkMessage {
-    fn from(cert: Cert) -> Self {
-        Self::Cert(cert)
     }
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -6,11 +6,11 @@ use std::sync::Arc;
 use rand::RngCore;
 
 use crate::all2all::TrivialAll2All;
-use crate::consensus::EpochInfo;
+use crate::consensus::{ConsensusMessage, EpochInfo};
 use crate::crypto::aggsig::SecretKey;
 use crate::crypto::{Hash, MerkleTree, signature};
 use crate::network::simulated::SimulatedNetworkCore;
-use crate::network::{BINCODE_CONFIG, NetworkMessage, SimulatedNetwork, localhost_ip_sockaddr};
+use crate::network::{BINCODE_CONFIG, SimulatedNetwork, localhost_ip_sockaddr};
 use crate::shredder::{MAX_DATA_PER_SLICE, RegularShredder, Shred, Shredder};
 use crate::types::{Slice, SliceHeader, SliceIndex, SlicePayload};
 use crate::{
@@ -42,7 +42,7 @@ pub fn generate_validators(num_validators: u64) -> (Vec<SecretKey>, Arc<EpochInf
 
 pub async fn generate_all2all_instances(
     mut validators: Vec<ValidatorInfo>,
-) -> Vec<TrivialAll2All<SimulatedNetwork<NetworkMessage, NetworkMessage>>> {
+) -> Vec<TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>> {
     let core = Arc::new(
         SimulatedNetworkCore::default()
             .with_jitter(0.0)


### PR DESCRIPTION
Closes #198.