### PR TITLE
refactor: simplify `Network` trait

### DIFF
--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -110,9 +110,9 @@ async fn main() -> Result<()> {
 }
 
 type Node = Alpenglow<
-    TrivialAll2All<UdpNetwork<ConsensusMessage, ConsensusMessage>>,
-    Rotor<UdpNetwork<Shred, Shred>, StakeWeightedSampler>,
-    UdpNetwork<Transaction, Transaction>,
+    TrivialAll2All<UdpNetwork<ConsensusMessage>>,
+    Rotor<UdpNetwork<Shred>, StakeWeightedSampler>,
+    UdpNetwork<Transaction>,
 >;
 
 fn create_node(config: ConfigFile) -> color_eyre::Result<Node> {

--- a/src/bin/performance_test.rs
+++ b/src/bin/performance_test.rs
@@ -32,9 +32,9 @@ async fn main() -> Result<()> {
 }
 
 type TestNode = Alpenglow<
-    TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>,
-    Rotor<SimulatedNetwork<Shred, Shred>, StakeWeightedSampler>,
-    UdpNetwork<Transaction, Transaction>,
+    TrivialAll2All<SimulatedNetwork<ConsensusMessage>>,
+    Rotor<SimulatedNetwork<Shred>, StakeWeightedSampler>,
+    UdpNetwork<Transaction>,
 >;
 
 async fn create_test_nodes(count: u64) -> Vec<TestNode> {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -131,8 +131,8 @@ where
         txs_receiver: T,
     ) -> Self
     where
-        RR: Network<Recv = RepairRequest, Send = RepairResponse> + Send + Sync + 'static,
-        RN: Network<Recv = RepairResponse, Send = RepairRequest> + Send + Sync + 'static,
+        RR: Network<Recv = RepairRequest> + Send + Sync + 'static,
+        RN: Network<Recv = RepairResponse> + Send + Sync + 'static,
     {
         let cancel_token = CancellationToken::new();
         let (votor_tx, votor_rx) = mpsc::channel(1024);

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -369,7 +369,7 @@ mod tests {
     use crate::network::SimulatedNetwork;
     use crate::test_utils::{generate_all2all_instances, generate_validators};
 
-    type A2A = TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>;
+    type A2A = TrivialAll2All<SimulatedNetwork<ConsensusMessage>>;
 
     async fn start_votor() -> (A2A, mpsc::Sender<VotorEvent>, Arc<EpochInfo>) {
         let (sks, epoch_info) = generate_validators(2);

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -27,13 +27,13 @@ impl<N: Network> TrivialDisseminator<N> {
 #[async_trait]
 impl<N> Disseminator for TrivialDisseminator<N>
 where
-    N: Network<Recv = Shred, Send = Shred>,
+    N: Network<Recv = Shred>,
 {
     async fn send(&self, shred: &Shred) -> std::io::Result<()> {
         let bytes = bincode::serde::encode_to_vec(shred, BINCODE_CONFIG).unwrap();
         for v in &self.validators {
             self.network
-                .send_serialized(&bytes, v.disseminator_address)
+                .send(&bytes, v.disseminator_address)
                 .await?;
         }
         Ok(())
@@ -67,10 +67,7 @@ mod tests {
     fn create_disseminator_instances(
         count: u64,
         base_port: u16,
-    ) -> (
-        Vec<SecretKey>,
-        Vec<TrivialDisseminator<UdpNetwork<Shred, Shred>>>,
-    ) {
+    ) -> (Vec<SecretKey>, Vec<TrivialDisseminator<UdpNetwork<Shred>>>) {
         let mut sks = Vec::new();
         let mut voting_sks = Vec::new();
         let mut validators = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,17 +93,17 @@ pub(crate) fn highest_non_zero_byte(mut val: usize) -> usize {
 }
 
 type TestNode = Alpenglow<
-    TrivialAll2All<UdpNetwork<ConsensusMessage, ConsensusMessage>>,
-    Rotor<UdpNetwork<Shred, Shred>, StakeWeightedSampler>,
-    UdpNetwork<Transaction, Transaction>,
+    TrivialAll2All<UdpNetwork<ConsensusMessage>>,
+    Rotor<UdpNetwork<Shred>, StakeWeightedSampler>,
+    UdpNetwork<Transaction>,
 >;
 
 struct Networks {
-    all2all: UdpNetwork<ConsensusMessage, ConsensusMessage>,
-    disseminator: UdpNetwork<Shred, Shred>,
-    repair: UdpNetwork<RepairRequest, RepairResponse>,
-    repair_request: UdpNetwork<RepairResponse, RepairRequest>,
-    txs: UdpNetwork<Transaction, Transaction>,
+    all2all: UdpNetwork<ConsensusMessage>,
+    disseminator: UdpNetwork<Shred>,
+    repair: UdpNetwork<RepairResponse>,
+    repair_request: UdpNetwork<RepairRequest>,
+    txs: UdpNetwork<Transaction>,
 }
 
 impl Networks {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -55,7 +55,7 @@ pub fn generate_validators(num_validators: u64) -> (Vec<SecretKey>, Arc<EpochInf
 
 pub async fn generate_all2all_instances(
     mut validators: Vec<ValidatorInfo>,
-) -> Vec<TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>> {
+) -> Vec<TrivialAll2All<SimulatedNetwork<ConsensusMessage>>> {
     let core = Arc::new(
         SimulatedNetworkCore::default()
             .with_jitter(0.0)


### PR DESCRIPTION
Part of #187 
Closes: #196 

As the network trait already supports sending serialized data, we can remove the ability to send non-serialized data from it.  This simplifies the trait.  However, the downside is that now components can send arbitrary messages.  But compared to status quo, it is no worse as they could already send arbitrary messages by using `send_serialized`.  

- Removes `send()` from the `Network` trait
- renames `send_serialized()` to `send()`