### PR TITLE
refactor: remove `send_serialized()` from `Network` trait

### DIFF
--- a/src/all2all/trivial.rs
+++ b/src/all2all/trivial.rs
@@ -39,9 +39,9 @@ where
     N: Network<Recv = ConsensusMessage, Send = ConsensusMessage>,
 {
     async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()> {
-        for v in &self.validators {
-            self.network.send(msg, v.all2all_address).await?;
-        }
+        self.network
+            .send(msg, self.validators.iter().map(|v| v.all2all_address))
+            .await?;
         Ok(())
     }
 

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -513,6 +513,7 @@ async fn wait_for_first_slot(
 
 #[cfg(test)]
 mod tests {
+    use std::iter::once;
     use std::time::Duration;
 
     use mockall::{Sequence, predicate};
@@ -562,7 +563,7 @@ mod tests {
             for i in 0..255 {
                 let data = vec![i; MAX_TRANSACTION_SIZE];
                 let msg = Transaction(data);
-                txs_sender.send(&msg, addr).await.unwrap();
+                txs_sender.send(&msg, once(addr)).await.unwrap();
             }
         });
 

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 
 use super::Disseminator;
 use crate::ValidatorInfo;
-use crate::network::{BINCODE_CONFIG, Network};
+use crate::network::Network;
 use crate::shredder::Shred;
 
 /// A trivial implementation for a block disseminator.
@@ -30,12 +30,12 @@ where
     N: Network<Recv = Shred, Send = Shred>,
 {
     async fn send(&self, shred: &Shred) -> std::io::Result<()> {
-        let bytes = bincode::serde::encode_to_vec(shred, BINCODE_CONFIG).unwrap();
-        for v in &self.validators {
-            self.network
-                .send_serialized(&bytes, v.disseminator_address)
-                .await?;
-        }
+        self.network
+            .send(
+                shred,
+                self.validators.iter().map(|v| v.disseminator_address),
+            )
+            .await?;
         Ok(())
     }
 

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -10,6 +10,8 @@
 
 mod weighted_shuffle;
 
+use std::iter::once;
+
 use async_trait::async_trait;
 use moka::future::Cache;
 use rand::prelude::*;
@@ -90,7 +92,7 @@ where
             .await;
         let root = tree.get_root();
         let addr = self.validators[root as usize].disseminator_address;
-        self.network.send(shred, addr).await
+        self.network.send(shred, once(addr)).await
     }
 
     /// Forwards the shred to all our children in the correct Turbine tree.
@@ -103,10 +105,11 @@ where
         let tree = self
             .get_tree(shred.payload().header.slot, shred.payload().index_in_slot())
             .await;
-        for child in tree.get_children() {
-            let addr = self.validators[*child as usize].disseminator_address;
-            self.network.send(shred, addr).await?;
-        }
+        let addrs = tree
+            .get_children()
+            .into_iter()
+            .map(|child| self.validators[*child as usize].disseminator_address);
+        self.network.send(shred, addrs).await?;
         Ok(())
     }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -47,9 +47,17 @@ pub trait Network: Send + Sync {
     type Send;
     type Recv;
 
-    async fn send(&self, message: &Self::Send, to: SocketAddr) -> std::io::Result<()>;
-
-    async fn send_serialized(&self, bytes: &[u8], to: SocketAddr) -> std::io::Result<()>;
+    /// Sends the `message` to all the addresses in `addrs`.
+    ///
+    /// Note that a possible strategy for the implementators is to send to one address after another.
+    /// In this strategy, it is possible that if sending to one address fails, the implementator gives up sending to the remaining addresses.
+    ///
+    /// NOTE: Consider return a `Vec<Result<()>>` to indicate per address failures.
+    async fn send(
+        &self,
+        message: &Self::Send,
+        addrs: impl Iterator<Item = SocketAddr> + Send,
+    ) -> std::io::Result<()>;
 
     // TODO: implement brodcast at `Network` level?
 

--- a/src/network/simulated/core.rs
+++ b/src/network/simulated/core.rs
@@ -254,6 +254,8 @@ impl Default for SimulatedNetworkCore {
 
 #[cfg(test)]
 mod tests {
+    use std::iter::once;
+
     use tokio::time::timeout;
 
     use super::*;
@@ -280,7 +282,9 @@ mod tests {
         core.set_latency(0, 1, Duration::from_millis(10)).await;
 
         // one direction
-        net1.send(&msg, localhost_ip_sockaddr(1)).await.unwrap();
+        net1.send(&msg, once(localhost_ip_sockaddr(1)))
+            .await
+            .unwrap();
         let now = Instant::now();
         let _: Ping = net2.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
@@ -290,7 +294,9 @@ mod tests {
         assert!(latency < max);
 
         // other direction
-        net2.send(&msg, localhost_ip_sockaddr(0)).await.unwrap();
+        net2.send(&msg, once(localhost_ip_sockaddr(0)))
+            .await
+            .unwrap();
         let now = Instant::now();
         let _: Ping = net1.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
@@ -320,7 +326,9 @@ mod tests {
             .await;
 
         // one direction
-        net1.send(&msg, localhost_ip_sockaddr(1)).await.unwrap();
+        net1.send(&msg, once(localhost_ip_sockaddr(1)))
+            .await
+            .unwrap();
         let now = Instant::now();
         let _: Ping = net2.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
@@ -336,7 +344,9 @@ mod tests {
         );
 
         // other direction
-        net2.send(&msg, localhost_ip_sockaddr(0)).await.unwrap();
+        net2.send(&msg, once(localhost_ip_sockaddr(0)))
+            .await
+            .unwrap();
         let now = Instant::now();
         let _: Ping = net1.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
@@ -353,16 +363,16 @@ mod tests {
         let net1: SimulatedNetwork<PingOrPong, PingOrPong> = core.join_unlimited(0).await;
         let net2: SimulatedNetwork<PingOrPong, PingOrPong> = core.join_unlimited(1).await;
         let net3: SimulatedNetwork<PingOrPong, PingOrPong> = core.join_unlimited(2).await;
-        let sock0 = localhost_ip_sockaddr(0);
+        let sock0 = once(localhost_ip_sockaddr(0));
         core.set_latency(0, 1, Duration::from_millis(10)).await;
         core.set_latency(0, 2, Duration::from_millis(20)).await;
 
         // send ping on faster link
         let msg = PingOrPong::Ping;
-        net2.send(&msg, sock0).await.unwrap();
+        net2.send(&msg, sock0.clone()).await.unwrap();
         // send pong on slower link
         let msg = PingOrPong::Pong;
-        net3.send(&msg, sock0).await.unwrap();
+        net3.send(&msg, sock0.clone()).await.unwrap();
 
         // ping should arrive before pong
         let received = net1.receive().await.unwrap();
@@ -372,7 +382,7 @@ mod tests {
 
         // queue messages in the other order
         let msg = PingOrPong::Pong;
-        net3.send(&msg, sock0).await.unwrap();
+        net3.send(&msg, sock0.clone()).await.unwrap();
         let msg = PingOrPong::Ping;
         net2.send(&msg, sock0).await.unwrap();
 
@@ -393,7 +403,9 @@ mod tests {
         // send 1000 pings
         let msg = Ping;
         for _ in 0..1000 {
-            net1.send(&msg, localhost_ip_sockaddr(1)).await.unwrap();
+            net1.send(&msg, once(localhost_ip_sockaddr(1)))
+                .await
+                .unwrap();
         }
 
         let mut pings_received = 0;

--- a/src/network/udp.rs
+++ b/src/network/udp.rs
@@ -10,6 +10,7 @@ use std::marker::PhantomData;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use async_trait::async_trait;
+use futures::future::join_all;
 use log::warn;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -68,14 +69,18 @@ where
     type Recv = R;
     type Send = S;
 
-    async fn send(&self, msg: &S, to: SocketAddr) -> std::io::Result<()> {
-        let bytes = bincode::serde::encode_to_vec(msg, BINCODE_CONFIG).unwrap();
+    async fn send(
+        &self,
+        msg: &S,
+        addrs: impl Iterator<Item = SocketAddr> + Send,
+    ) -> std::io::Result<()> {
+        let bytes = &bincode::serde::encode_to_vec(msg, BINCODE_CONFIG).unwrap();
         assert!(bytes.len() <= MTU_BYTES, "each message should fit in MTU");
-        self.send_serialized(&bytes, to).await
-    }
 
-    async fn send_serialized(&self, bytes: &[u8], to: SocketAddr) -> std::io::Result<()> {
-        self.socket.send_to(bytes, to).await?;
+        let tasks = addrs.map(async move |addr| self.socket.send_to(bytes, addr).await);
+        for res in join_all(tasks).await {
+            assert_eq!(bytes.len(), res?);
+        }
         Ok(())
     }
 
@@ -104,6 +109,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::iter::once;
+
     use super::*;
     use crate::network::localhost_ip_sockaddr;
     use crate::test_utils::{Ping, Pong};
@@ -112,17 +119,10 @@ mod tests {
     async fn ping() {
         let socket1: UdpNetwork<Ping, Ping> = UdpNetwork::new_with_any_port();
         let socket2: UdpNetwork<Ping, Ping> = UdpNetwork::new_with_any_port();
-        let addr1 = localhost_ip_sockaddr(socket1.port());
+        let addr1 = once(localhost_ip_sockaddr(socket1.port()));
 
         // regular send()
         socket2.send(&Ping, addr1).await.unwrap();
-        let msg = socket1.receive().await.unwrap();
-        assert!(matches!(msg, Ping));
-
-        // send_serialized()
-        let bytes = bincode::serde::encode_to_vec(Ping, BINCODE_CONFIG).unwrap();
-        assert!(bytes.len() <= MTU_BYTES, "each message should fit in MTU");
-        socket2.send_serialized(&bytes, addr1).await.unwrap();
         let msg = socket1.receive().await.unwrap();
         assert!(matches!(msg, Ping));
     }
@@ -131,8 +131,8 @@ mod tests {
     async fn ping_pong() {
         let socket1 = UdpNetwork::new_with_any_port();
         let socket2 = UdpNetwork::new_with_any_port();
-        let addr1 = localhost_ip_sockaddr(socket1.port());
-        let addr2 = localhost_ip_sockaddr(socket2.port());
+        let addr1 = once(localhost_ip_sockaddr(socket1.port()));
+        let addr2 = once(localhost_ip_sockaddr(socket2.port()));
 
         socket1.send(&Ping, addr2).await.unwrap();
         let msg = socket2.receive().await.unwrap();


### PR DESCRIPTION
Part of #187 
Closes of #210 

- Additionally allows us to a couple of opportunities of improvements where we can sent to multiple addresses concurrently.