### PR TITLE
refactor: use marker traits for different variants of `Network`

### DIFF
--- a/src/all2all/robust.rs
+++ b/src/all2all/robust.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use super::All2All;
 use crate::ValidatorInfo;
 use crate::consensus::ConsensusMessage;
-use crate::network::Network;
+use crate::network::{ConsensusNetwork, Network};
 
 /// Instance of the robust all-to-all broadcast protocol.
 // TODO: acutally make more robust (retransmits, ...)
@@ -40,7 +40,7 @@ impl<N: Network> RobustAll2All<N> {
 #[async_trait]
 impl<N: Network> All2All for RobustAll2All<N>
 where
-    N: Network<Recv = ConsensusMessage, Send = ConsensusMessage>,
+    N: ConsensusNetwork,
 {
     async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()> {
         // HACK: stupidly expensive retransmits

--- a/src/all2all/trivial.rs
+++ b/src/all2all/trivial.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use super::All2All;
 use crate::ValidatorInfo;
 use crate::consensus::ConsensusMessage;
-use crate::network::Network;
+use crate::network::{ConsensusNetwork, Network};
 
 /// Instance of the trivial all-to-all broadcast protocol.
 pub struct TrivialAll2All<N: Network> {
@@ -36,7 +36,7 @@ impl<N: Network> TrivialAll2All<N> {
 #[async_trait]
 impl<N: Network> All2All for TrivialAll2All<N>
 where
-    N: Network<Recv = ConsensusMessage, Send = ConsensusMessage>,
+    N: ConsensusNetwork,
 {
     async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()> {
         self.network

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -46,10 +46,10 @@ pub use self::vote::Vote;
 use self::votor::Votor;
 use crate::consensus::block_producer::BlockProducer;
 use crate::crypto::{aggsig, signature};
-use crate::network::Network;
-use crate::repair::{Repair, RepairRequest, RepairRequestHandler, RepairResponse};
+use crate::network::{RepairNetwork, RepairRequestNetwork, TransactionNetwork};
+use crate::repair::{Repair, RepairRequestHandler};
 use crate::shredder::Shred;
-use crate::{All2All, Disseminator, Slot, Transaction, ValidatorInfo};
+use crate::{All2All, Disseminator, Slot, ValidatorInfo};
 
 /// Time bound assumed on network transmission delays during periods of synchrony.
 const DELTA: Duration = Duration::from_millis(250);
@@ -84,7 +84,7 @@ impl From<Cert> for ConsensusMessage {
 /// Alpenglow consensus protocol implementation.
 pub struct Alpenglow<A: All2All, D: Disseminator, T>
 where
-    T: Network<Recv = Transaction> + Send + Sync + 'static,
+    T: TransactionNetwork + 'static,
 {
     /// Other validators' info.
     epoch_info: Arc<EpochInfo>,
@@ -112,7 +112,7 @@ impl<A, D, T> Alpenglow<A, D, T>
 where
     A: All2All + Sync + Send + 'static,
     D: Disseminator + Sync + Send + 'static,
-    T: Network<Recv = Transaction> + Send + Sync + 'static,
+    T: TransactionNetwork + 'static,
 {
     /// Creates a new Alpenglow consensus node.
     ///
@@ -131,8 +131,8 @@ where
         txs_receiver: T,
     ) -> Self
     where
-        RR: Network<Recv = RepairRequest, Send = RepairResponse> + Send + Sync + 'static,
-        RN: Network<Recv = RepairResponse, Send = RepairRequest> + Send + Sync + 'static,
+        RR: RepairRequestNetwork + 'static,
+        RN: RepairNetwork + 'static,
     {
         let cancel_token = CancellationToken::new();
         let (votor_tx, votor_rx) = mpsc::channel(1024);

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -18,12 +18,11 @@ use tokio_util::sync::CancellationToken;
 
 use crate::consensus::{Blockstore, EpochInfo, Pool};
 use crate::crypto::{Hash, signature};
-use crate::network::{BINCODE_CONFIG, Network};
+use crate::network::{BINCODE_CONFIG, Network, TransactionNetwork};
 use crate::shredder::{MAX_DATA_PER_SLICE, RegularShredder, Shredder};
 use crate::types::{Slice, SliceHeader, SliceIndex, SlicePayload, Slot};
 use crate::{
-    BlockId, Disseminator, MAX_TRANSACTION_SIZE, MAX_TRANSACTIONS_PER_SLICE, Transaction,
-    highest_non_zero_byte,
+    BlockId, Disseminator, MAX_TRANSACTION_SIZE, MAX_TRANSACTIONS_PER_SLICE, highest_non_zero_byte,
 };
 
 /// Produces blocks from transactions and dissminates them.
@@ -63,7 +62,7 @@ pub(super) struct BlockProducer<D: Disseminator, T: Network> {
 impl<D, T> BlockProducer<D, T>
 where
     D: Disseminator,
-    T: Network<Recv = Transaction>,
+    T: TransactionNetwork,
 {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
@@ -390,7 +389,7 @@ async fn produce_slice_payload<T>(
     duration_left: Duration,
 ) -> (SlicePayload, Duration)
 where
-    T: Network<Recv = Transaction>,
+    T: TransactionNetwork,
 {
     let start_time = Instant::now();
     const_assert!(MAX_DATA_PER_SLICE >= MAX_TRANSACTION_SIZE);

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -13,7 +13,7 @@ use self::sampling_strategy::PartitionSampler;
 pub use self::sampling_strategy::{FaitAccompli1Sampler, SamplingStrategy, StakeWeightedSampler};
 use super::Disseminator;
 use crate::consensus::EpochInfo;
-use crate::network::Network;
+use crate::network::{Network, ShredNetwork};
 use crate::shredder::{Shred, TOTAL_SHREDS};
 use crate::{Slot, ValidatorId};
 
@@ -59,7 +59,7 @@ impl<N: Network> Rotor<N, FaitAccompli1Sampler<PartitionSampler>> {
 
 impl<N, S: SamplingStrategy> Rotor<N, S>
 where
-    N: Network<Recv = Shred, Send = Shred>,
+    N: ShredNetwork,
 {
     /// Turns this instance into a new instance with a different sampling strategy.
     #[must_use]
@@ -112,7 +112,7 @@ where
 #[async_trait]
 impl<N, S: SamplingStrategy + Sync + Send + 'static> Disseminator for Rotor<N, S>
 where
-    N: Network<Recv = Shred, Send = Shred>,
+    N: ShredNetwork,
 {
     async fn send(&self, shred: &Shred) -> std::io::Result<()> {
         Self::send_as_leader(self, shred).await

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 
 use super::Disseminator;
 use crate::ValidatorInfo;
-use crate::network::Network;
+use crate::network::{Network, ShredNetwork};
 use crate::shredder::Shred;
 
 /// A trivial implementation for a block disseminator.
@@ -27,7 +27,7 @@ impl<N: Network> TrivialDisseminator<N> {
 #[async_trait]
 impl<N> Disseminator for TrivialDisseminator<N>
 where
-    N: Network<Recv = Shred, Send = Shred>,
+    N: ShredNetwork,
 {
     async fn send(&self, shred: &Shred) -> std::io::Result<()> {
         self.network

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -18,7 +18,7 @@ use rand::prelude::*;
 
 pub(crate) use self::weighted_shuffle::WeightedShuffle;
 use super::Disseminator;
-use crate::network::Network;
+use crate::network::{Network, ShredNetwork};
 use crate::shredder::Shred;
 use crate::{Slot, ValidatorId, ValidatorInfo};
 
@@ -54,7 +54,7 @@ pub(crate) struct TurbineTree {
 
 impl<N> Turbine<N>
 where
-    N: Network<Recv = Shred, Send = Shred>,
+    N: ShredNetwork,
 {
     /// Creates a new Turbine instance, configured with the default fanout.
     pub fn new(validator_id: ValidatorId, validators: Vec<ValidatorInfo>, network: N) -> Self {
@@ -134,7 +134,7 @@ where
 #[async_trait]
 impl<N> Disseminator for Turbine<N>
 where
-    N: Network<Recv = Shred, Send = Shred>,
+    N: ShredNetwork,
 {
     async fn send(&self, shred: &Shred) -> std::io::Result<()> {
         self.send_shred_to_root(shred).await

--- a/src/network.rs
+++ b/src/network.rs
@@ -35,6 +35,10 @@ use async_trait::async_trait;
 pub use self::simulated::SimulatedNetwork;
 pub use self::tcp::TcpNetwork;
 pub use self::udp::UdpNetwork;
+use crate::Transaction;
+use crate::consensus::ConsensusMessage;
+use crate::repair::{RepairRequest, RepairResponse};
+use crate::shredder::Shred;
 
 /// Maximum payload size of a UDP packet.
 pub const MTU_BYTES: usize = 1500;
@@ -63,6 +67,26 @@ pub trait Network: Send + Sync {
 
     async fn receive(&self) -> std::io::Result<Self::Recv>;
 }
+
+pub trait ShredNetwork: Network<Recv = Shred, Send = Shred> {}
+impl ShredNetwork for UdpNetwork<Shred, Shred> {}
+impl ShredNetwork for SimulatedNetwork<Shred, Shred> {}
+
+pub trait TransactionNetwork: Network<Recv = Transaction> {}
+impl TransactionNetwork for UdpNetwork<Transaction, Transaction> {}
+impl TransactionNetwork for SimulatedNetwork<Transaction, Transaction> {}
+
+pub trait ConsensusNetwork: Network<Recv = ConsensusMessage, Send = ConsensusMessage> {}
+impl ConsensusNetwork for UdpNetwork<ConsensusMessage, ConsensusMessage> {}
+impl ConsensusNetwork for SimulatedNetwork<ConsensusMessage, ConsensusMessage> {}
+
+pub trait RepairRequestNetwork: Network<Recv = RepairRequest, Send = RepairResponse> {}
+impl RepairRequestNetwork for UdpNetwork<RepairResponse, RepairRequest> {}
+impl RepairRequestNetwork for SimulatedNetwork<RepairResponse, RepairRequest> {}
+
+pub trait RepairNetwork: Network<Recv = RepairResponse, Send = RepairRequest> {}
+impl RepairNetwork for UdpNetwork<RepairRequest, RepairResponse> {}
+impl RepairNetwork for SimulatedNetwork<RepairRequest, RepairResponse> {}
 
 /// Returns a [`SocketAddr`] bound to the localhost IPv4 and given port.
 ///

--- a/src/network.rs
+++ b/src/network.rs
@@ -68,22 +68,27 @@ pub trait Network: Send + Sync {
     async fn receive(&self) -> std::io::Result<Self::Recv>;
 }
 
+/// A marker trait that constrains [`Network`] to send and receive [`Shred`]
 pub trait ShredNetwork: Network<Recv = Shred, Send = Shred> {}
 impl ShredNetwork for UdpNetwork<Shred, Shred> {}
 impl ShredNetwork for SimulatedNetwork<Shred, Shred> {}
 
+/// A marker trait that constrains [`Network`] to receive [`Transaction`]
 pub trait TransactionNetwork: Network<Recv = Transaction> {}
 impl TransactionNetwork for UdpNetwork<Transaction, Transaction> {}
 impl TransactionNetwork for SimulatedNetwork<Transaction, Transaction> {}
 
+/// A marker trait that constrains [`Network`] to send and receive [`ConsensusMessage`]
 pub trait ConsensusNetwork: Network<Recv = ConsensusMessage, Send = ConsensusMessage> {}
 impl ConsensusNetwork for UdpNetwork<ConsensusMessage, ConsensusMessage> {}
 impl ConsensusNetwork for SimulatedNetwork<ConsensusMessage, ConsensusMessage> {}
 
+/// A marker trait that constrains [`Network`] to send [`RepairResponse`] and receive [`RepairRequest`]
 pub trait RepairRequestNetwork: Network<Recv = RepairRequest, Send = RepairResponse> {}
 impl RepairRequestNetwork for UdpNetwork<RepairResponse, RepairRequest> {}
 impl RepairRequestNetwork for SimulatedNetwork<RepairResponse, RepairRequest> {}
 
+/// A marker trait that constrains [`Network`] to send [`RepairRequest`] and receive [`RepairResponse`]
 pub trait RepairNetwork: Network<Recv = RepairResponse, Send = RepairRequest> {}
 impl RepairNetwork for UdpNetwork<RepairRequest, RepairResponse> {}
 impl RepairNetwork for SimulatedNetwork<RepairRequest, RepairResponse> {}

--- a/src/network.rs
+++ b/src/network.rs
@@ -70,28 +70,23 @@ pub trait Network: Send + Sync {
 
 /// A marker trait that constrains [`Network`] to send and receive [`Shred`]
 pub trait ShredNetwork: Network<Recv = Shred, Send = Shred> {}
-impl ShredNetwork for UdpNetwork<Shred, Shred> {}
-impl ShredNetwork for SimulatedNetwork<Shred, Shred> {}
+impl<N> ShredNetwork for N where N: Network<Recv = Shred, Send = Shred> {}
 
 /// A marker trait that constrains [`Network`] to receive [`Transaction`]
 pub trait TransactionNetwork: Network<Recv = Transaction> {}
-impl TransactionNetwork for UdpNetwork<Transaction, Transaction> {}
-impl TransactionNetwork for SimulatedNetwork<Transaction, Transaction> {}
+impl<N> TransactionNetwork for N where N: Network<Recv = Transaction> {}
 
 /// A marker trait that constrains [`Network`] to send and receive [`ConsensusMessage`]
 pub trait ConsensusNetwork: Network<Recv = ConsensusMessage, Send = ConsensusMessage> {}
-impl ConsensusNetwork for UdpNetwork<ConsensusMessage, ConsensusMessage> {}
-impl ConsensusNetwork for SimulatedNetwork<ConsensusMessage, ConsensusMessage> {}
+impl<N> ConsensusNetwork for N where N: Network<Recv = ConsensusMessage, Send = ConsensusMessage> {}
 
 /// A marker trait that constrains [`Network`] to send [`RepairResponse`] and receive [`RepairRequest`]
 pub trait RepairRequestNetwork: Network<Recv = RepairRequest, Send = RepairResponse> {}
-impl RepairRequestNetwork for UdpNetwork<RepairResponse, RepairRequest> {}
-impl RepairRequestNetwork for SimulatedNetwork<RepairResponse, RepairRequest> {}
+impl<N> RepairRequestNetwork for N where N: Network<Recv = RepairRequest, Send = RepairResponse> {}
 
 /// A marker trait that constrains [`Network`] to send [`RepairRequest`] and receive [`RepairResponse`]
 pub trait RepairNetwork: Network<Recv = RepairResponse, Send = RepairRequest> {}
-impl RepairNetwork for UdpNetwork<RepairRequest, RepairResponse> {}
-impl RepairNetwork for SimulatedNetwork<RepairRequest, RepairResponse> {}
+impl<N> RepairNetwork for N where N: Network<Recv = RepairResponse, Send = RepairRequest> {}
 
 /// Returns a [`SocketAddr`] bound to the localhost IPv4 and given port.
 ///

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -22,7 +22,7 @@ use tokio::sync::RwLock;
 use crate::consensus::{Blockstore, EpochInfo, Pool};
 use crate::crypto::{Hash, MerkleTree, hash};
 use crate::disseminator::rotor::{SamplingStrategy, StakeWeightedSampler};
-use crate::network::{BINCODE_CONFIG, Network};
+use crate::network::{BINCODE_CONFIG, Network, RepairNetwork, RepairRequestNetwork};
 use crate::shredder::{Shred, TOTAL_SHREDS};
 use crate::types::SliceIndex;
 use crate::{BlockId, ValidatorId};
@@ -104,7 +104,7 @@ pub struct RepairRequestHandler<N: Network> {
 
 impl<N> RepairRequestHandler<N>
 where
-    N: Network<Recv = RepairRequest, Send = RepairResponse>,
+    N: RepairRequestNetwork,
 {
     /// Creates a new repair request handler instance.
     ///
@@ -202,7 +202,7 @@ pub struct Repair<N: Network> {
 
 impl<N> Repair<N>
 where
-    N: Network<Recv = RepairResponse, Send = RepairRequest>,
+    N: RepairNetwork,
 {
     /// Creates a new repair instance.
     ///


### PR DESCRIPTION
Part of #187 
Closes #200 

Introduces some new traits that constrain the `Network` trait and uses them in various places.