### PR TITLE
refactor: introduce ability to send to a single address

### DIFF
--- a/src/all2all/robust.rs
+++ b/src/all2all/robust.rs
@@ -48,7 +48,7 @@ where
             .validators
             .iter()
             .flat_map(|v| repeat_n(v.all2all_address, 1000));
-        self.network.send(msg, addrs).await
+        self.network.send_to_many(msg, addrs).await
     }
 
     async fn receive(&self) -> std::io::Result<ConsensusMessage> {

--- a/src/all2all/trivial.rs
+++ b/src/all2all/trivial.rs
@@ -40,7 +40,7 @@ where
 {
     async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()> {
         self.network
-            .send(msg, self.validators.iter().map(|v| v.all2all_address))
+            .send_to_many(msg, self.validators.iter().map(|v| v.all2all_address))
             .await?;
         Ok(())
     }

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -512,7 +512,6 @@ async fn wait_for_first_slot(
 
 #[cfg(test)]
 mod tests {
-    use std::iter::once;
     use std::time::Duration;
 
     use mockall::{Sequence, predicate};
@@ -562,7 +561,7 @@ mod tests {
             for i in 0..255 {
                 let data = vec![i; MAX_TRANSACTION_SIZE];
                 let msg = Transaction(data);
-                txs_sender.send(&msg, once(addr)).await.unwrap();
+                txs_sender.send(&msg, addr).await.unwrap();
             }
         });
 

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -3,7 +3,6 @@
 
 pub mod sampling_strategy;
 
-use std::iter::once;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -71,7 +70,7 @@ where
     async fn send_as_leader(&self, shred: &Shred) -> std::io::Result<()> {
         let relay = self.sample_relay(shred.payload().header.slot, shred.payload().index_in_slot());
         let v = self.epoch_info.validator(relay);
-        self.network.send(shred, once(v.disseminator_address)).await
+        self.network.send(shred, v.disseminator_address).await
     }
 
     /// Broadcasts a shred to all validators except for the leader and itself.
@@ -92,7 +91,7 @@ where
             .iter()
             .filter(|v| v.id != leader && v.id != relay)
             .map(|v| v.disseminator_address);
-        self.network.send(shred, to).await?;
+        self.network.send_to_many(shred, to).await?;
         Ok(())
     }
 

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -31,7 +31,7 @@ where
 {
     async fn send(&self, shred: &Shred) -> std::io::Result<()> {
         self.network
-            .send(
+            .send_to_many(
                 shred,
                 self.validators.iter().map(|v| v.disseminator_address),
             )

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -10,8 +10,6 @@
 
 mod weighted_shuffle;
 
-use std::iter::once;
-
 use async_trait::async_trait;
 use moka::future::Cache;
 use rand::prelude::*;
@@ -92,7 +90,7 @@ where
             .await;
         let root = tree.get_root();
         let addr = self.validators[root as usize].disseminator_address;
-        self.network.send(shred, once(addr)).await
+        self.network.send(shred, addr).await
     }
 
     /// Forwards the shred to all our children in the correct Turbine tree.
@@ -109,7 +107,7 @@ where
             .get_children()
             .iter()
             .map(|child| self.validators[*child as usize].disseminator_address);
-        self.network.send(shred, addrs).await?;
+        self.network.send_to_many(shred, addrs).await?;
         Ok(())
     }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -55,13 +55,17 @@ pub trait Network: Send + Sync {
     ///
     /// Note that a possible strategy for the implementators is to send to one address after another.
     /// In this strategy, it is possible that if sending to one address fails, the implementator gives up sending to the remaining addresses.
+    /// This means that the function is not atomic, if it fails, some messages may still have been sent.
     //
     // NOTE: Consider return a `Vec<Result<()>>` to indicate per address failures.
-    async fn send(
+    async fn send_to_many(
         &self,
         message: &Self::Send,
         addrs: impl Iterator<Item = SocketAddr> + Send,
     ) -> std::io::Result<()>;
+
+    /// Sends the `message` to `addr`.
+    async fn send(&self, message: &Self::Send, addr: SocketAddr) -> std::io::Result<()>;
 
     // TODO: implement brodcast at `Network` level?
 

--- a/src/network/simulated/core.rs
+++ b/src/network/simulated/core.rs
@@ -254,8 +254,6 @@ impl Default for SimulatedNetworkCore {
 
 #[cfg(test)]
 mod tests {
-    use std::iter::once;
-
     use tokio::time::timeout;
 
     use super::*;
@@ -282,9 +280,7 @@ mod tests {
         core.set_latency(0, 1, Duration::from_millis(10)).await;
 
         // one direction
-        net1.send(&msg, once(localhost_ip_sockaddr(1)))
-            .await
-            .unwrap();
+        net1.send(&msg, localhost_ip_sockaddr(1)).await.unwrap();
         let now = Instant::now();
         let _: Ping = net2.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
@@ -294,9 +290,7 @@ mod tests {
         assert!(latency < max);
 
         // other direction
-        net2.send(&msg, once(localhost_ip_sockaddr(0)))
-            .await
-            .unwrap();
+        net2.send(&msg, localhost_ip_sockaddr(0)).await.unwrap();
         let now = Instant::now();
         let _: Ping = net1.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
@@ -326,9 +320,7 @@ mod tests {
             .await;
 
         // one direction
-        net1.send(&msg, once(localhost_ip_sockaddr(1)))
-            .await
-            .unwrap();
+        net1.send(&msg, localhost_ip_sockaddr(1)).await.unwrap();
         let now = Instant::now();
         let _: Ping = net2.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
@@ -344,9 +336,7 @@ mod tests {
         );
 
         // other direction
-        net2.send(&msg, once(localhost_ip_sockaddr(0)))
-            .await
-            .unwrap();
+        net2.send(&msg, localhost_ip_sockaddr(0)).await.unwrap();
         let now = Instant::now();
         let _: Ping = net1.receive().await.unwrap();
         let latency = now.elapsed().as_micros();
@@ -363,16 +353,16 @@ mod tests {
         let net1: SimulatedNetwork<PingOrPong, PingOrPong> = core.join_unlimited(0).await;
         let net2: SimulatedNetwork<PingOrPong, PingOrPong> = core.join_unlimited(1).await;
         let net3: SimulatedNetwork<PingOrPong, PingOrPong> = core.join_unlimited(2).await;
-        let sock0 = once(localhost_ip_sockaddr(0));
+        let sock0 = localhost_ip_sockaddr(0);
         core.set_latency(0, 1, Duration::from_millis(10)).await;
         core.set_latency(0, 2, Duration::from_millis(20)).await;
 
         // send ping on faster link
         let msg = PingOrPong::Ping;
-        net2.send(&msg, sock0.clone()).await.unwrap();
+        net2.send(&msg, sock0).await.unwrap();
         // send pong on slower link
         let msg = PingOrPong::Pong;
-        net3.send(&msg, sock0.clone()).await.unwrap();
+        net3.send(&msg, sock0).await.unwrap();
 
         // ping should arrive before pong
         let received = net1.receive().await.unwrap();
@@ -382,7 +372,7 @@ mod tests {
 
         // queue messages in the other order
         let msg = PingOrPong::Pong;
-        net3.send(&msg, sock0.clone()).await.unwrap();
+        net3.send(&msg, sock0).await.unwrap();
         let msg = PingOrPong::Ping;
         net2.send(&msg, sock0).await.unwrap();
 
@@ -403,9 +393,7 @@ mod tests {
         // send 1000 pings
         let msg = Ping;
         for _ in 0..1000 {
-            net1.send(&msg, once(localhost_ip_sockaddr(1)))
-                .await
-                .unwrap();
+            net1.send(&msg, localhost_ip_sockaddr(1)).await.unwrap();
         }
 
         let mut pings_received = 0;

--- a/src/network/udp.rs
+++ b/src/network/udp.rs
@@ -58,6 +58,13 @@ impl<S, R> UdpNetwork<S, R> {
     pub fn port(&self) -> u16 {
         self.socket.local_addr().unwrap().port()
     }
+
+    async fn send_serialized(&self, bytes: &[u8], addr: SocketAddr) -> std::io::Result<()> {
+        assert!(bytes.len() <= MTU_BYTES, "each message should fit in MTU");
+        let bytes_sent = self.socket.send_to(bytes, addr).await?;
+        assert_eq!(bytes.len(), bytes_sent);
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -69,19 +76,22 @@ where
     type Recv = R;
     type Send = S;
 
-    async fn send(
+    async fn send_to_many(
         &self,
         msg: &S,
         addrs: impl Iterator<Item = SocketAddr> + Send,
     ) -> std::io::Result<()> {
         let bytes = &bincode::serde::encode_to_vec(msg, BINCODE_CONFIG).unwrap();
-        assert!(bytes.len() <= MTU_BYTES, "each message should fit in MTU");
-
-        let tasks = addrs.map(async move |addr| self.socket.send_to(bytes, addr).await);
+        let tasks = addrs.map(async move |addr| self.send_serialized(bytes, addr).await);
         for res in join_all(tasks).await {
-            assert_eq!(bytes.len(), res?);
+            let () = res?;
         }
         Ok(())
+    }
+
+    async fn send(&self, msg: &Self::Send, addr: SocketAddr) -> std::io::Result<()> {
+        let bytes = &bincode::serde::encode_to_vec(msg, BINCODE_CONFIG).unwrap();
+        self.send_serialized(bytes, addr).await
     }
 
     async fn receive(&self) -> std::io::Result<R> {
@@ -109,8 +119,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::iter::once;
-
     use super::*;
     use crate::network::localhost_ip_sockaddr;
     use crate::test_utils::{Ping, Pong};
@@ -119,7 +127,7 @@ mod tests {
     async fn ping() {
         let socket1: UdpNetwork<Ping, Ping> = UdpNetwork::new_with_any_port();
         let socket2: UdpNetwork<Ping, Ping> = UdpNetwork::new_with_any_port();
-        let addr1 = once(localhost_ip_sockaddr(socket1.port()));
+        let addr1 = localhost_ip_sockaddr(socket1.port());
 
         // regular send()
         socket2.send(&Ping, addr1).await.unwrap();
@@ -131,8 +139,8 @@ mod tests {
     async fn ping_pong() {
         let socket1 = UdpNetwork::new_with_any_port();
         let socket2 = UdpNetwork::new_with_any_port();
-        let addr1 = once(localhost_ip_sockaddr(socket1.port()));
-        let addr2 = once(localhost_ip_sockaddr(socket2.port()));
+        let addr1 = localhost_ip_sockaddr(socket1.port());
+        let addr2 = localhost_ip_sockaddr(socket2.port());
 
         socket1.send(&Ping, addr2).await.unwrap();
         let msg = socket2.receive().await.unwrap();


### PR DESCRIPTION
Also see https://github.com/qkniep/alpenglow/pull/211#discussion_r2361612892.

To make things more ergonomic:

- Changes `send` to that it can only send to a single address
- introduces `send_to_many` to allow sending to many addresses