### PR TITLE
bug: fix some broadcast test failures

### DIFF
--- a/src/all2all/robust.rs
+++ b/src/all2all/robust.rs
@@ -123,6 +123,11 @@ mod tests {
             let vote = Vote::new_skip(Slot::genesis(), &voting_sk, 0);
             let msg = ConsensusMessage::Vote(vote);
             all2all_sender.broadcast(&msg).await.unwrap();
+            while let Ok(Ok(_)) =
+                timeout(Duration::from_millis(1000), all2all_sender.receive()).await
+            {
+                // do nothing
+            }
         });
         for all2all in all2all_others {
             tasks.spawn(async move {

--- a/src/network/simulated/core.rs
+++ b/src/network/simulated/core.rs
@@ -82,6 +82,7 @@ impl SimulatedNetworkCore {
                     let n_guard = n.read().await;
                     let channel = n_guard.get(&msg.to).unwrap();
                     if let Err(_e) = channel.send(msg).await {
+                        #[cfg(test)]
                         println!("sending failed. Ignoring");
                         warn!("sending failed. Ignoring");
                     }

--- a/src/network/simulated/core.rs
+++ b/src/network/simulated/core.rs
@@ -6,6 +6,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use log::warn;
 use rand::Rng;
 use tokio::sync::{Mutex, RwLock, mpsc};
 
@@ -80,7 +81,10 @@ impl SimulatedNetworkCore {
                     let msg = guard.pop().unwrap();
                     let n_guard = n.read().await;
                     let channel = n_guard.get(&msg.to).unwrap();
-                    channel.send(msg).await.unwrap();
+                    if let Err(_e) = channel.send(msg).await {
+                        println!("sending failed. Ignoring");
+                        warn!("sending failed. Ignoring");
+                    }
                 }
             }
         });


### PR DESCRIPTION
In https://github.com/qkniep/alpenglow/pull/213, we observed some test failures.  Debugging it, I believe the following is happening:

- The sender is broadcasting and then exiting without receiving the messages that it broadcast
- if we send the messages too quickly as is happening in #213, the sender is exiting before simulated/core is able to deliver the msgs to it.
- the sender exits and then the core tries to send it message, finds that the channel is closed, and panics
- now the other receivers get stuck as they have not received all of the messages they wanted

The proposed fix is for the sender to receive messages that it broadcast before exiting and for the the core to not panic if it fails deliver messages.