### PR TITLE
nit: make `DataShred` and `CodingShred` private to `shredder` module

### DIFF
--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -152,10 +152,10 @@ impl Shred {
 
 /// A data shred without the Merkle proof.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct DataShred(ShredPayload);
+struct DataShred(ShredPayload);
 /// A coding shred without the Merkle proof.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CodingShred(ShredPayload);
+struct CodingShred(ShredPayload);
 
 /// Base payload of a shred, regardless of its type.
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
These are internal types that should only be used for translating between the interface of the `reed_solomon` module and the public API of the `shredder` module.