### PR TITLE
wip: feat: handle different types of leader misbehavior better

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -329,7 +329,7 @@ where
             .await
             .add_shred_from_disseminator(shred)
             .await;
-        if let Ok(Some((slot, block_info))) = res {
+        if let Some((slot, block_info)) = res {
             let mut guard = self.pool.write().await;
             let block_id = (slot, block_info.hash);
             guard.add_block(block_id, block_info.parent).await;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -329,7 +329,7 @@ where
             .await
             .add_shred_from_disseminator(shred)
             .await;
-        if let Some(block_info) = res {
+        if let Ok(Some(block_info)) = res {
             let mut guard = self.pool.write().await;
             let block_id = (slot, block_info.hash);
             guard.add_block(block_id, block_info.parent).await;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -329,7 +329,7 @@ where
             .await
             .add_shred_from_disseminator(shred)
             .await;
-        if let Some((slot, block_info)) = res {
+        if let Some(block_info) = res {
             let mut guard = self.pool.write().await;
             let block_id = (slot, block_info.hash);
             guard.add_block(block_id, block_info.parent).await;

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -360,7 +360,7 @@ where
                 .await
                 .add_shred_from_disseminator(s.into_shred())
                 .await;
-            if let Ok(Some((block_slot, block_info))) = block {
+            if let Some((block_slot, block_info)) = block {
                 assert_eq!(block_slot, slot);
                 assert!(maybe_block_hash.is_none());
                 maybe_block_hash = Some(block_info.hash);
@@ -679,12 +679,12 @@ mod tests {
             .expect_add_shred_from_disseminator()
             .times(TOTAL_SHREDS - 1)
             .in_sequence(&mut seq)
-            .returning(move |_| Box::pin(async move { Ok(None) }));
+            .returning(move |_| Box::pin(async move { None }));
         blockstore
             .expect_add_shred_from_disseminator()
             .times(1)
             .in_sequence(&mut seq)
-            .returning(move |_| Box::pin(async move { Ok(Some((slot, block_info))) }));
+            .returning(move |_| Box::pin(async move { Some((slot, block_info)) }));
 
         let mut pool = MockPool::new();
         pool.expect_add_block()
@@ -740,7 +740,7 @@ mod tests {
             .expect_add_shred_from_disseminator()
             .times(TOTAL_SHREDS - 1)
             .in_sequence(&mut seq)
-            .returning(move |_| Box::pin(async move { Ok(None) }));
+            .returning(move |_| Box::pin(async move { None }));
         blockstore
             .expect_add_shred_from_disseminator()
             .times(1)
@@ -750,7 +750,7 @@ mod tests {
                     // last shred; wait for the parent ready event to be sent before continuing
                     first_slice_finished_tx.send(()).unwrap();
                     let () = start_second_slice_rx.await.unwrap();
-                    Ok(None)
+                    None
                 })
             });
 
@@ -759,7 +759,7 @@ mod tests {
             .expect_add_shred_from_disseminator()
             .times(TOTAL_SHREDS - 1)
             .in_sequence(&mut seq)
-            .returning(move |_| Box::pin(async move { Ok(None) }));
+            .returning(move |_| Box::pin(async move { None }));
         blockstore
             .expect_add_shred_from_disseminator()
             .times(1)
@@ -768,7 +768,7 @@ mod tests {
                 Box::pin(async move {
                     // final shred of second slice
                     // block is constructed with the new parent
-                    Ok(Some((slot, new_block_info)))
+                    Some((slot, new_block_info))
                 })
             });
 

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -360,11 +360,10 @@ where
                 .await
                 .add_shred_from_disseminator(s.into_shred())
                 .await;
-            if let Some((block_slot, block_info)) = block {
-                assert_eq!(block_slot, slot);
+            if let Some(block_info) = block {
                 assert!(maybe_block_hash.is_none());
                 maybe_block_hash = Some(block_info.hash);
-                let block_id = (block_slot, block_info.hash);
+                let block_id = (slot, block_info.hash);
                 self.pool
                     .write()
                     .await
@@ -684,7 +683,7 @@ mod tests {
             .expect_add_shred_from_disseminator()
             .times(1)
             .in_sequence(&mut seq)
-            .returning(move |_| Box::pin(async move { Some((slot, block_info)) }));
+            .returning(move |_| Box::pin(async move { Some(block_info) }));
 
         let mut pool = MockPool::new();
         pool.expect_add_block()
@@ -768,7 +767,7 @@ mod tests {
                 Box::pin(async move {
                     // final shred of second slice
                     // block is constructed with the new parent
-                    Some((slot, new_block_info))
+                    Some(new_block_info)
                 })
             });
 

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -360,7 +360,7 @@ where
                 .await
                 .add_shred_from_disseminator(s.into_shred())
                 .await;
-            if let Some(block_info) = block {
+            if let Ok(Some(block_info)) = block {
                 assert!(maybe_block_hash.is_none());
                 maybe_block_hash = Some(block_info.hash);
                 let block_id = (slot, block_info.hash);
@@ -678,12 +678,12 @@ mod tests {
             .expect_add_shred_from_disseminator()
             .times(TOTAL_SHREDS - 1)
             .in_sequence(&mut seq)
-            .returning(move |_| Box::pin(async move { None }));
+            .returning(move |_| Box::pin(async move { Ok(None) }));
         blockstore
             .expect_add_shred_from_disseminator()
             .times(1)
             .in_sequence(&mut seq)
-            .returning(move |_| Box::pin(async move { Some(block_info) }));
+            .returning(move |_| Box::pin(async move { Ok(Some(block_info)) }));
 
         let mut pool = MockPool::new();
         pool.expect_add_block()
@@ -739,7 +739,7 @@ mod tests {
             .expect_add_shred_from_disseminator()
             .times(TOTAL_SHREDS - 1)
             .in_sequence(&mut seq)
-            .returning(move |_| Box::pin(async move { None }));
+            .returning(move |_| Box::pin(async move { Ok(None) }));
         blockstore
             .expect_add_shred_from_disseminator()
             .times(1)
@@ -749,7 +749,7 @@ mod tests {
                     // last shred; wait for the parent ready event to be sent before continuing
                     first_slice_finished_tx.send(()).unwrap();
                     let () = start_second_slice_rx.await.unwrap();
-                    None
+                    Ok(None)
                 })
             });
 
@@ -758,7 +758,7 @@ mod tests {
             .expect_add_shred_from_disseminator()
             .times(TOTAL_SHREDS - 1)
             .in_sequence(&mut seq)
-            .returning(move |_| Box::pin(async move { None }));
+            .returning(move |_| Box::pin(async move { Ok(None) }));
         blockstore
             .expect_add_shred_from_disseminator()
             .times(1)
@@ -767,7 +767,7 @@ mod tests {
                 Box::pin(async move {
                     // final shred of second slice
                     // block is constructed with the new parent
-                    Some(new_block_info)
+                    Ok(Some(new_block_info))
                 })
             });
 

--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -370,6 +370,9 @@ mod tests {
     use crate::shredder::{DATA_SHREDS, ShredIndex, TOTAL_SHREDS};
     use crate::test_utils::{assert_votor_events_match, create_random_block};
 
+    /// Attempts to add all the shreds to the blockstore.
+    ///
+    /// Any resulting [`VotorEvents`] are collected and returned; benign events are ignored; other error events terminate the function and the error is returned.
     fn handle_shreds(
         block_data: &mut BlockData,
         pk: PublicKey,
@@ -394,9 +397,7 @@ mod tests {
         (events, Ok(()))
     }
 
-    /// Deshreds the slice and adds all the shreds to the blockstore.
-    ///
-    /// Any resulting [`VotorEvents`] are collected and returned; benign events are ignored; other error events terminate the function and the error is returned.
+    /// Deshreds the slice and calls [`handle_shreds`].
     fn handle_slice(
         block_data: &mut BlockData,
         slice: Slice,

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -363,7 +363,7 @@ where
                     .await
                     .add_shred_from_repair(block_hash, shred)
                     .await;
-                if let Some((slot, block_info)) = res {
+                if let Some(block_info) = res {
                     assert_eq!(block_info.hash, block_hash);
                     self.pool
                         .write()

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -363,7 +363,7 @@ where
                     .await
                     .add_shred_from_repair(block_hash, shred)
                     .await;
-                if let Some(block_info) = res {
+                if let Ok(Some(block_info)) = res {
                     assert_eq!(block_info.hash, block_hash);
                     self.pool
                         .write()

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -363,7 +363,7 @@ where
                     .await
                     .add_shred_from_repair(block_hash, shred)
                     .await;
-                if let Ok(Some((slot, block_info))) = res {
+                if let Some((slot, block_info)) = res {
                     assert_eq!(block_info.hash, block_hash);
                     self.pool
                         .write()


### PR DESCRIPTION
Part of #85 

- spells out the different scenarios where the leader provably misbehaved and where we got a faulty shred without proof for for who misbehaved
- stops accepting new disseminated shreds when the leader misbehaved
- Improvements to API