### PR TITLE
feat: stop accepting disseminated shreds for a misbehaving leader

### DIFF
--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -80,8 +80,8 @@ impl SlotBlockData {
     ) -> Result<Option<VotorEvent>, AddShredError> {
         assert_eq!(shred.payload().header.slot, self.slot);
         if self.leader_misbehaved {
-            debug!("recevied shred from equivocating leader, not adding to blockstore");
-            return Err(AddShredError::Equivocation);
+            debug!("recevied shred from misbehaving leader, not adding to blockstore");
+            return Err(AddShredError::InvalidShred);
         }
         self.disseminated
             .add_shred(shred, leader_pk)


### PR DESCRIPTION
previously we were discarding shreds from a leader that showed equivocation.  Now, we also handle leader that misbehaved.

Part of #85 