### PR TITLE
refactor: simply `reed_solomon_[de]shred()` api

### DIFF
--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -268,8 +268,7 @@ impl Shredder for RegularShredder {
     fn deshred_validated_shreds(
         shreds: &[Option<ValidatedShred>; TOTAL_SHREDS],
     ) -> Result<(Slice, [ValidatedShred; TOTAL_SHREDS]), DeshredError> {
-        let payload =
-            reed_solomon_deshred(shreds, DATA_SHREDS, TOTAL_SHREDS - DATA_SHREDS, DATA_SHREDS)?;
+        let payload = reed_solomon_deshred(shreds, TOTAL_SHREDS - DATA_SHREDS)?;
 
         // deshreding succeeded above, there should be at least one shred in the array so the unwrap() below should be safe
         let any_shred = shreds.iter().find_map(|s| s.as_ref()).unwrap();
@@ -313,7 +312,7 @@ impl Shredder for CodingOnlyShredder {
     fn deshred_validated_shreds(
         shreds: &[Option<ValidatedShred>; TOTAL_SHREDS],
     ) -> Result<(Slice, [ValidatedShred; TOTAL_SHREDS]), DeshredError> {
-        let payload = reed_solomon_deshred(shreds, DATA_SHREDS, TOTAL_SHREDS, 0)?;
+        let payload = reed_solomon_deshred(shreds, TOTAL_SHREDS)?;
 
         // deshreding succeeded above, there should be at least one shred in the array so the unwrap() below should be safe
         let any_shred = shreds.iter().find_map(|s| s.as_ref()).unwrap();
@@ -378,12 +377,7 @@ impl Shredder for PetsShredder {
     fn deshred_validated_shreds(
         shreds: &[Option<ValidatedShred>; TOTAL_SHREDS],
     ) -> Result<(Slice, [ValidatedShred; TOTAL_SHREDS]), DeshredError> {
-        let mut buffer = reed_solomon_deshred(
-            shreds,
-            DATA_SHREDS,
-            TOTAL_SHREDS - DATA_SHREDS + 1,
-            DATA_SHREDS - 1,
-        )?;
+        let mut buffer = reed_solomon_deshred(shreds, TOTAL_SHREDS - DATA_SHREDS + 1)?;
         if buffer.len() < 16 {
             return Err(DeshredError::BadEncoding);
         }
@@ -460,8 +454,7 @@ impl Shredder for AontShredder {
     fn deshred_validated_shreds(
         shreds: &[Option<ValidatedShred>; TOTAL_SHREDS],
     ) -> Result<(Slice, [ValidatedShred; TOTAL_SHREDS]), DeshredError> {
-        let mut buffer =
-            reed_solomon_deshred(shreds, DATA_SHREDS, TOTAL_SHREDS - DATA_SHREDS, DATA_SHREDS)?;
+        let mut buffer = reed_solomon_deshred(shreds, TOTAL_SHREDS - DATA_SHREDS)?;
         if buffer.len() < 16 {
             return Err(DeshredError::BadEncoding);
         }

--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -260,15 +260,14 @@ impl Shredder for RegularShredder {
 
     fn shred(slice: Slice, sk: &SecretKey) -> Result<[ValidatedShred; TOTAL_SHREDS], ShredError> {
         let (header, payload) = slice.deconstruct();
-        let raw_shreds =
-            reed_solomon_shred(payload.into(), DATA_SHREDS, TOTAL_SHREDS - DATA_SHREDS)?;
+        let raw_shreds = reed_solomon_shred(payload.into(), Self::CODING_OUTPUT_SHREDS)?;
         Ok(data_and_coding_to_output_shreds(header, raw_shreds, sk))
     }
 
     fn deshred_validated_shreds(
         shreds: &[Option<ValidatedShred>; TOTAL_SHREDS],
     ) -> Result<(Slice, [ValidatedShred; TOTAL_SHREDS]), DeshredError> {
-        let payload = reed_solomon_deshred(shreds, TOTAL_SHREDS - DATA_SHREDS)?;
+        let payload = reed_solomon_deshred(shreds, Self::CODING_OUTPUT_SHREDS)?;
 
         // deshreding succeeded above, there should be at least one shred in the array so the unwrap() below should be safe
         let any_shred = shreds.iter().find_map(|s| s.as_ref()).unwrap();
@@ -277,8 +276,7 @@ impl Shredder for RegularShredder {
         // additional Merkle tree validity check
         let merkle_root = any_shred.merkle_root;
         let (header, payload) = slice.clone().deconstruct();
-        let raw_shreds =
-            reed_solomon_shred(payload.into(), DATA_SHREDS, TOTAL_SHREDS - DATA_SHREDS)?;
+        let raw_shreds = reed_solomon_shred(payload.into(), Self::CODING_OUTPUT_SHREDS)?;
         let tree = build_merkle_tree(&raw_shreds);
         if tree.get_root() != merkle_root {
             return Err(DeshredError::InvalidMerkleTree);
@@ -304,7 +302,7 @@ impl Shredder for CodingOnlyShredder {
 
     fn shred(slice: Slice, sk: &SecretKey) -> Result<[ValidatedShred; TOTAL_SHREDS], ShredError> {
         let (header, payload) = slice.deconstruct();
-        let mut raw_shreds = reed_solomon_shred(payload.into(), DATA_SHREDS, TOTAL_SHREDS)?;
+        let mut raw_shreds = reed_solomon_shred(payload.into(), Self::CODING_OUTPUT_SHREDS)?;
         raw_shreds.data = vec![];
         Ok(data_and_coding_to_output_shreds(header, raw_shreds, sk))
     }
@@ -312,7 +310,7 @@ impl Shredder for CodingOnlyShredder {
     fn deshred_validated_shreds(
         shreds: &[Option<ValidatedShred>; TOTAL_SHREDS],
     ) -> Result<(Slice, [ValidatedShred; TOTAL_SHREDS]), DeshredError> {
-        let payload = reed_solomon_deshred(shreds, TOTAL_SHREDS)?;
+        let payload = reed_solomon_deshred(shreds, Self::CODING_OUTPUT_SHREDS)?;
 
         // deshreding succeeded above, there should be at least one shred in the array so the unwrap() below should be safe
         let any_shred = shreds.iter().find_map(|s| s.as_ref()).unwrap();
@@ -321,7 +319,7 @@ impl Shredder for CodingOnlyShredder {
         // additional Merkle tree validity check
         let merkle_root = any_shred.merkle_root;
         let (header, payload) = slice.clone().deconstruct();
-        let mut raw_shreds = reed_solomon_shred(payload.into(), DATA_SHREDS, TOTAL_SHREDS)?;
+        let mut raw_shreds = reed_solomon_shred(payload.into(), Self::CODING_OUTPUT_SHREDS)?;
         raw_shreds.data = vec![];
         let tree = build_merkle_tree(&raw_shreds);
         if tree.get_root() != merkle_root {
@@ -366,8 +364,7 @@ impl Shredder for PetsShredder {
         cipher.apply_keystream(&mut payload);
 
         payload.extend_from_slice(&key);
-        let mut raw_shreds =
-            reed_solomon_shred(payload, DATA_SHREDS, TOTAL_SHREDS - DATA_SHREDS + 1)?;
+        let mut raw_shreds = reed_solomon_shred(payload, Self::CODING_OUTPUT_SHREDS)?;
         // delete data shred containing key
         raw_shreds.data.pop();
 
@@ -377,7 +374,7 @@ impl Shredder for PetsShredder {
     fn deshred_validated_shreds(
         shreds: &[Option<ValidatedShred>; TOTAL_SHREDS],
     ) -> Result<(Slice, [ValidatedShred; TOTAL_SHREDS]), DeshredError> {
-        let mut buffer = reed_solomon_deshred(shreds, TOTAL_SHREDS - DATA_SHREDS + 1)?;
+        let mut buffer = reed_solomon_deshred(shreds, Self::CODING_OUTPUT_SHREDS)?;
         if buffer.len() < 16 {
             return Err(DeshredError::BadEncoding);
         }
@@ -388,8 +385,7 @@ impl Shredder for PetsShredder {
         // additional Merkle tree validity check
         let merkle_root = any_shred.merkle_root;
         let header = any_shred.payload().header.clone();
-        let mut raw_shreds =
-            reed_solomon_shred(buffer.clone(), DATA_SHREDS, TOTAL_SHREDS - DATA_SHREDS + 1)?;
+        let mut raw_shreds = reed_solomon_shred(buffer.clone(), Self::CODING_OUTPUT_SHREDS)?;
         raw_shreds.data.pop();
         let tree = build_merkle_tree(&raw_shreds);
         if tree.get_root() != merkle_root {
@@ -447,14 +443,14 @@ impl Shredder for AontShredder {
             payload.push(hash[i] ^ key[i]);
         }
 
-        let raw_shreds = reed_solomon_shred(payload, DATA_SHREDS, TOTAL_SHREDS - DATA_SHREDS)?;
+        let raw_shreds = reed_solomon_shred(payload, Self::CODING_OUTPUT_SHREDS)?;
         Ok(data_and_coding_to_output_shreds(header, raw_shreds, sk))
     }
 
     fn deshred_validated_shreds(
         shreds: &[Option<ValidatedShred>; TOTAL_SHREDS],
     ) -> Result<(Slice, [ValidatedShred; TOTAL_SHREDS]), DeshredError> {
-        let mut buffer = reed_solomon_deshred(shreds, TOTAL_SHREDS - DATA_SHREDS)?;
+        let mut buffer = reed_solomon_deshred(shreds, Self::CODING_OUTPUT_SHREDS)?;
         if buffer.len() < 16 {
             return Err(DeshredError::BadEncoding);
         }
@@ -465,8 +461,7 @@ impl Shredder for AontShredder {
         // additional Merkle tree validity check
         let merkle_root = any_shred.merkle_root;
         let header = any_shred.payload().header.clone();
-        let raw_shreds =
-            reed_solomon_shred(buffer.clone(), DATA_SHREDS, TOTAL_SHREDS - DATA_SHREDS)?;
+        let raw_shreds = reed_solomon_shred(buffer.clone(), Self::CODING_OUTPUT_SHREDS)?;
         let tree = build_merkle_tree(&raw_shreds);
         if tree.get_root() != merkle_root {
             return Err(DeshredError::InvalidMerkleTree);

--- a/src/shredder/reed_solomon.rs
+++ b/src/shredder/reed_solomon.rs
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn shred_too_much_data() {
         let payload = vec![0; MAX_DATA_PER_SLICE + 1];
-        let res = reed_solomon_shred(payload, DATA_SHREDS);
+        let res = reed_solomon_shred(payload, TOTAL_SHREDS - DATA_SHREDS);
         assert!(res.is_err());
         assert_eq!(res.err().unwrap(), ReedSolomonShredError::TooMuchData);
     }
@@ -173,7 +173,8 @@ mod tests {
     #[test]
     fn deshred_not_enough_shreds() {
         let (header, payload) = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE).deconstruct();
-        let shreds = reed_solomon_shred(payload.clone().into(), DATA_SHREDS).unwrap();
+        let shreds =
+            reed_solomon_shred(payload.clone().into(), TOTAL_SHREDS - DATA_SHREDS).unwrap();
         let sk = SecretKey::new(&mut rand::rng());
         let mut shreds = data_and_coding_to_output_shreds(header, shreds, &sk).map(Some);
         for shred in shreds.iter_mut().skip(DATA_SHREDS - 1) {
@@ -185,7 +186,7 @@ mod tests {
     }
 
     fn shred_deshred_restore(header: SliceHeader, payload: Vec<u8>) {
-        let shreds = reed_solomon_shred(payload.clone(), DATA_SHREDS).unwrap();
+        let shreds = reed_solomon_shred(payload.clone(), TOTAL_SHREDS - DATA_SHREDS).unwrap();
         let shreds = take_and_map_enough_shreds(header, shreds);
         let restored = reed_solomon_deshred(&shreds, DATA_SHREDS).unwrap();
         assert_eq!(restored, payload);


### PR DESCRIPTION
If we assume that:
- we will always have `DATA_SHREDS`
- the array of shreds will always put data shreds before coding shreds

We can simplify the API for `reed_solomon_shred()` and `reed_solomon_deshred()`.  It just needs to know how many of the shreds are coding.


Closes: #227 