### PR TITLE
nit: minor clean ups in `slot_state.rs`

### DIFF
--- a/src/consensus/pool/slot_state.rs
+++ b/src/consensus/pool/slot_state.rs
@@ -497,21 +497,21 @@ impl SlotState {
 
         match (skip, notar) {
             (Some(_), _) => {
-                self.sent_safe_to_notar.insert(block_hash.clone());
                 self.pending_safe_to_notar.remove(&block_hash);
+                self.sent_safe_to_notar.insert(block_hash);
                 SafeToNotarStatus::SafeToNotar
             }
             (_, Some((n, _))) => {
                 if n != &block_hash {
-                    self.sent_safe_to_notar.insert(block_hash.clone());
                     self.pending_safe_to_notar.remove(&block_hash);
+                    self.sent_safe_to_notar.insert(block_hash);
                     SafeToNotarStatus::SafeToNotar
                 } else {
                     SafeToNotarStatus::AwaitingVotes
                 }
             }
             (None, None) => {
-                self.pending_safe_to_notar.insert(block_hash.clone());
+                self.pending_safe_to_notar.insert(block_hash);
                 SafeToNotarStatus::AwaitingVotes
             }
         }


### PR DESCRIPTION
- remove some hidden clones
- use `btree_map::Entry` to eliminate some unwraps and double lookups
- use match instead of if statement