### PR TITLE
refactor: turn `Hash` and `ShortHash` into newtypes

### DIFF
--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -631,7 +631,7 @@ mod tests {
         // insert shreds with wrong Merkle root
         for shred in slices[0].clone() {
             let mut shred = shred.into_shred();
-            shred.merkle_root = Hash::default().into();
+            shred.merkle_root = Hash::random_for_test().into();
             let res = add_shred_ignore_duplicate(&mut blockstore, shred).await;
             assert!(res.is_err());
             assert_eq!(res.err(), Some(AddShredError::InvalidSignature));

--- a/src/consensus/vote.rs
+++ b/src/consensus/vote.rs
@@ -202,18 +202,18 @@ impl Signable for VoteKind {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crypto::Hash;
+    use crate::crypto::merkle::GENESIS_BLOCK_HASH;
 
     #[test]
     fn basic() {
         let sk = SecretKey::new(&mut rand::rng());
         let pk = sk.to_pk();
 
-        let vote = Vote::new_notar(Slot::new(0), Hash::default().into(), &sk, 0);
+        let vote = Vote::new_notar(Slot::new(0), GENESIS_BLOCK_HASH, &sk, 0);
         assert!(vote.is_notar());
         assert!(vote.check_sig(&pk));
 
-        let vote = Vote::new_notar_fallback(Slot::new(0), Hash::default().into(), &sk, 0);
+        let vote = Vote::new_notar_fallback(Slot::new(0), GENESIS_BLOCK_HASH, &sk, 0);
         assert!(vote.is_notar_fallback());
         assert!(vote.check_sig(&pk));
 

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -7,12 +7,36 @@
 //! throughout the entire library. Currently, SHA-256 is used.
 
 use sha2::{Digest, Sha256};
+use wincode::{SchemaRead, SchemaWrite};
 
 /// Regular hash that should be used in most cases.
 ///
 /// This provides 256-bit resistance against (second) preimage attacks
 /// and 128-bit resistance against collision attacks.
-pub type Hash = [u8; 32];
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, SchemaRead, SchemaWrite)]
+pub struct Hash(pub(super) [u8; 32]);
+
+impl Hash {
+    /// Creates a random hash for testing.
+    #[cfg(test)]
+    pub fn random_for_test() -> Self {
+        let mut bytes = [0; 32];
+        rand::RngCore::fill_bytes(&mut rand::rng(), &mut bytes);
+        Hash(bytes)
+    }
+}
+
+impl AsRef<[u8]> for Hash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::hash::Hash for Hash {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.0);
+    }
+}
 
 /// Short hash that should be used carefully.
 ///
@@ -20,14 +44,27 @@ pub type Hash = [u8; 32];
 /// but only provides 64-bit resistance against collision attacks.
 /// Only use this if you are 100% certain that (second) preimage
 /// resistance is enough for the use case. Otherwise, use `Hash`.
-pub type ShortHash = [u8; 16];
+#[derive(Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
+pub struct ShortHash([u8; 16]);
+
+impl AsRef<[u8]> for ShortHash {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::hash::Hash for ShortHash {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.0);
+    }
+}
 
 /// Hashes the given data using SHA-256.
 #[must_use]
 pub fn hash(data: &[u8]) -> Hash {
     let mut hasher = Sha256::new();
     hasher.update(data);
-    hasher.finalize().into()
+    Hash(hasher.finalize().into())
 }
 
 /// Hashes all the given data slices together using SHA-256.
@@ -37,13 +74,13 @@ pub fn hash_all(data: &[&[u8]]) -> Hash {
     for item in data {
         hasher.update(item);
     }
-    hasher.finalize().into()
+    Hash(hasher.finalize().into())
 }
 
 /// Truncates the given hash into a [`ShortHash`].
 #[must_use]
 pub fn truncate(hash: Hash) -> ShortHash {
-    hash[..16].try_into().expect("wrong length")
+    ShortHash(hash.0[..16].try_into().expect("wrong length"))
 }
 
 #[cfg(test)]

--- a/src/crypto/merkle.rs
+++ b/src/crypto/merkle.rs
@@ -27,6 +27,9 @@ use super::hash::hash_all;
 use crate::shredder::TOTAL_SHREDS;
 use crate::types::slice_index::MAX_SLICES_PER_BLOCK;
 
+/// The hash of the genesis block.
+pub const GENESIS_BLOCK_HASH: BlockHash = DoubleMerkleRoot(Hash([0; 32]));
+
 /// Maximum height of Merkle trees currently supported.
 pub const MAX_MERKLE_TREE_HEIGHT: usize = 32;
 /// Maximum number of leaf nodes in the Merkle trees currently supported.
@@ -57,38 +60,102 @@ const RIGHT_LABEL: [u8; 32] = *b"ALPENGLOW-MERKLE-TREE RIGHT-NODE";
 ///
 /// Used for efficient check whether leaf is last in [`MerkleTree::check_proof_last`].
 const EMPTY_ROOTS: [Hash; MAX_MERKLE_TREE_HEIGHT] = [
-    hex!("50c4672b7a309041b109458b1f3a11f82c225970975a95cd1025209301fcbcab"),
-    hex!("2aa0cc78c82100f0fa3a26606a9794a928d5ddd0f5d381f93d6b0d64d065aa6f"),
-    hex!("be22d038e2a34ff9386f4df7241c0a381ff433c98e36e2e0a59b3cfef7950c5b"),
-    hex!("afc22402352574edbbfa7e3fd5221c7f1ab256c70ed826c8e2b8adc5b0b56ae9"),
-    hex!("83831b4f0df87b978810491c31fd670c90e8e223e1a1f2876a96ab30c29161a4"),
-    hex!("800e9e154844513cdbf5e11bec487c8953bcf2951d98eb5ef39cae18520d5e1b"),
-    hex!("6c5328d45f1d420776a56188732b2ae0eba2956008148e4f0383eb8de65c65fe"),
-    hex!("c356e3d71c9aae22fb8e449ad2d37b795b9861bb8fbb028c2378c86eff2e0a26"),
-    hex!("89c79a35bdbb8aa17e08560fdbc0bbc3f2fc6ba882deedf81a3f37c4534e9e3d"),
-    hex!("e5fefbb76548773dd0ba0765286fe98d1b6560bafd1abc071120380f4fb0bb78"),
-    hex!("24a72454e312eddaee4f4504e04e309152f27dd9848bb5c648f5f6a0aa960cb1"),
-    hex!("1be1a1ccce5c9dee569c7560033f41414c10792939408d857f35cb2c4273877d"),
-    hex!("b43f0ce6212391b7c57b2452a6d989db222ae6f274d8cdfafc28afd98d267e23"),
-    hex!("3f346c4f375fe9a9a9d41ad270bd36d69409e2c7d8b4c38653b6d7d225a6add5"),
-    hex!("3c4120e345597ad037337dd72d2c536553e2b52242f4ef81ce8def38d17b38af"),
-    hex!("4396524427a665c659fea115ce68d3357ce1d6a04ca5b8eeb69d76e439ea2247"),
-    hex!("68eb4a1c412f67ef86dadaa6c5b6cf2ba5e7bd266645b69bb12a1d10704487f7"),
-    hex!("75271d1c9e8b79fdeaceb051cfd29ed03350e4808b262e3a750277c82a2a5206"),
-    hex!("b99c05ba6039ddcb754abcf9e66aeb529348e708220569fe20cc4d587ddbd267"),
-    hex!("a0f8ea088f640460978534c9821ae114231e0730bff2c361b64a5824a3237341"),
-    hex!("b50f9fa20d9df525a29ccfe4cbe9b014142275e7e5ac9ef81a6c20112774418c"),
-    hex!("b48a3973c4e0c5bad395ecd1c0cd430adc9680c7fd574460bf21c45f74840662"),
-    hex!("826bfb27619fbf799f6000e4a3acdec264a13661e9c730e265c1c74c63501cb3"),
-    hex!("720d56bf703cd7677805d33e73d2e7cb6104c932b62458ac3ae2f9d7469a1f38"),
-    hex!("ab2960c67fdd892b5eb1e63ac0c182c8d174671fd0f8065363895b5a3f7f0a88"),
-    hex!("ab7f4126b993ca5037a84190933bb8b97b9427a977d6872ca0b5d61470ea1834"),
-    hex!("dfaae89b54a08d497b2e8251de039fb38a7137b802d2d6c2554540c7b027721a"),
-    hex!("9451a516e349a64cd75fde5558bc92d3f359d3d49b560d2414b7eaa1e6889b1e"),
-    hex!("1c78453e429f9dbeaa70097b76abe42ad3da19a2ec5cda345aa77d713b930145"),
-    hex!("ee4878f4417f8dea52e54aaad49962a9fab5b746e54d6c49a5125e41e3ed6511"),
-    hex!("0cca41b299cd9be76a4b810fcbfff766e3f93ae2d8c7d761c0af2b524af97b56"),
-    hex!("33ebfb34d3aa119cb665d564acdd77b318dc86aa6a97744edb3bc03e97d776ca"),
+    Hash(hex!(
+        "50c4672b7a309041b109458b1f3a11f82c225970975a95cd1025209301fcbcab"
+    )),
+    Hash(hex!(
+        "2aa0cc78c82100f0fa3a26606a9794a928d5ddd0f5d381f93d6b0d64d065aa6f"
+    )),
+    Hash(hex!(
+        "be22d038e2a34ff9386f4df7241c0a381ff433c98e36e2e0a59b3cfef7950c5b"
+    )),
+    Hash(hex!(
+        "afc22402352574edbbfa7e3fd5221c7f1ab256c70ed826c8e2b8adc5b0b56ae9"
+    )),
+    Hash(hex!(
+        "83831b4f0df87b978810491c31fd670c90e8e223e1a1f2876a96ab30c29161a4"
+    )),
+    Hash(hex!(
+        "800e9e154844513cdbf5e11bec487c8953bcf2951d98eb5ef39cae18520d5e1b"
+    )),
+    Hash(hex!(
+        "6c5328d45f1d420776a56188732b2ae0eba2956008148e4f0383eb8de65c65fe"
+    )),
+    Hash(hex!(
+        "c356e3d71c9aae22fb8e449ad2d37b795b9861bb8fbb028c2378c86eff2e0a26"
+    )),
+    Hash(hex!(
+        "89c79a35bdbb8aa17e08560fdbc0bbc3f2fc6ba882deedf81a3f37c4534e9e3d"
+    )),
+    Hash(hex!(
+        "e5fefbb76548773dd0ba0765286fe98d1b6560bafd1abc071120380f4fb0bb78"
+    )),
+    Hash(hex!(
+        "24a72454e312eddaee4f4504e04e309152f27dd9848bb5c648f5f6a0aa960cb1"
+    )),
+    Hash(hex!(
+        "1be1a1ccce5c9dee569c7560033f41414c10792939408d857f35cb2c4273877d"
+    )),
+    Hash(hex!(
+        "b43f0ce6212391b7c57b2452a6d989db222ae6f274d8cdfafc28afd98d267e23"
+    )),
+    Hash(hex!(
+        "3f346c4f375fe9a9a9d41ad270bd36d69409e2c7d8b4c38653b6d7d225a6add5"
+    )),
+    Hash(hex!(
+        "3c4120e345597ad037337dd72d2c536553e2b52242f4ef81ce8def38d17b38af"
+    )),
+    Hash(hex!(
+        "4396524427a665c659fea115ce68d3357ce1d6a04ca5b8eeb69d76e439ea2247"
+    )),
+    Hash(hex!(
+        "68eb4a1c412f67ef86dadaa6c5b6cf2ba5e7bd266645b69bb12a1d10704487f7"
+    )),
+    Hash(hex!(
+        "75271d1c9e8b79fdeaceb051cfd29ed03350e4808b262e3a750277c82a2a5206"
+    )),
+    Hash(hex!(
+        "b99c05ba6039ddcb754abcf9e66aeb529348e708220569fe20cc4d587ddbd267"
+    )),
+    Hash(hex!(
+        "a0f8ea088f640460978534c9821ae114231e0730bff2c361b64a5824a3237341"
+    )),
+    Hash(hex!(
+        "b50f9fa20d9df525a29ccfe4cbe9b014142275e7e5ac9ef81a6c20112774418c"
+    )),
+    Hash(hex!(
+        "b48a3973c4e0c5bad395ecd1c0cd430adc9680c7fd574460bf21c45f74840662"
+    )),
+    Hash(hex!(
+        "826bfb27619fbf799f6000e4a3acdec264a13661e9c730e265c1c74c63501cb3"
+    )),
+    Hash(hex!(
+        "720d56bf703cd7677805d33e73d2e7cb6104c932b62458ac3ae2f9d7469a1f38"
+    )),
+    Hash(hex!(
+        "ab2960c67fdd892b5eb1e63ac0c182c8d174671fd0f8065363895b5a3f7f0a88"
+    )),
+    Hash(hex!(
+        "ab7f4126b993ca5037a84190933bb8b97b9427a977d6872ca0b5d61470ea1834"
+    )),
+    Hash(hex!(
+        "dfaae89b54a08d497b2e8251de039fb38a7137b802d2d6c2554540c7b027721a"
+    )),
+    Hash(hex!(
+        "9451a516e349a64cd75fde5558bc92d3f359d3d49b560d2414b7eaa1e6889b1e"
+    )),
+    Hash(hex!(
+        "1c78453e429f9dbeaa70097b76abe42ad3da19a2ec5cda345aa77d713b930145"
+    )),
+    Hash(hex!(
+        "ee4878f4417f8dea52e54aaad49962a9fab5b746e54d6c49a5125e41e3ed6511"
+    )),
+    Hash(hex!(
+        "0cca41b299cd9be76a4b810fcbfff766e3f93ae2d8c7d761c0af2b524af97b56"
+    )),
+    Hash(hex!(
+        "33ebfb34d3aa119cb665d564acdd77b318dc86aa6a97744edb3bc03e97d776ca"
+    )),
 ];
 
 /// Marker trait for the leaf nodes of a Merkle tree.
@@ -227,11 +294,11 @@ impl<Leaf: MerkleLeaf, Root: MerkleRoot, Proof: MerkleProof> MerkleTree<Leaf, Ro
                 if i == right {
                     break;
                 } else if i + 1 == right {
-                    let inner_node = Self::hash_pair(nodes[i], EMPTY_ROOTS[h]);
+                    let inner_node = Self::hash_pair(&nodes[i], &EMPTY_ROOTS[h]);
                     nodes.push(inner_node);
                     break;
                 }
-                let inner_node = Self::hash_pair(nodes[i], nodes[i + 1]);
+                let inner_node = Self::hash_pair(&nodes[i], &nodes[i + 1]);
                 nodes.push(inner_node);
             }
 
@@ -252,7 +319,7 @@ impl<Leaf: MerkleLeaf, Root: MerkleRoot, Proof: MerkleProof> MerkleTree<Leaf, Ro
     /// Gives the root hash of the tree.
     #[must_use]
     pub fn get_root(&self) -> Root {
-        let root_hash = *self.nodes.last().expect("empty tree");
+        let root_hash = self.nodes.last().expect("empty tree").clone();
         root_hash.into()
     }
 
@@ -274,9 +341,9 @@ impl<Leaf: MerkleLeaf, Root: MerkleRoot, Proof: MerkleProof> MerkleTree<Leaf, Ro
 
         for (h, (offset, len)) in self.levels.iter().enumerate().take(self.height()) {
             if i ^ 1 >= *len as usize {
-                proof.push(EMPTY_ROOTS[h]);
+                proof.push(EMPTY_ROOTS[h].clone());
             } else {
-                proof.push(self.nodes[*offset as usize + (i ^ 1)]);
+                proof.push(self.nodes[*offset as usize + (i ^ 1)].clone());
             }
             i /= 2;
         }
@@ -304,8 +371,8 @@ impl<Leaf: MerkleLeaf, Root: MerkleRoot, Proof: MerkleProof> MerkleTree<Leaf, Ro
         let mut node = hash;
         for h in proof.as_ref() {
             node = match i % 2 {
-                0 => Self::hash_pair(node, *h),
-                _ => Self::hash_pair(*h, node),
+                0 => Self::hash_pair(&node, h),
+                _ => Self::hash_pair(h, &node),
             };
             i /= 2;
         }
@@ -331,8 +398,8 @@ impl<Leaf: MerkleLeaf, Root: MerkleRoot, Proof: MerkleProof> MerkleTree<Leaf, Ro
         let mut node = hash;
         for (height, h) in proof.as_ref().iter().enumerate() {
             node = match i % 2 {
-                0 => Self::hash_pair(node, EMPTY_ROOTS[height]),
-                _ => Self::hash_pair(*h, node),
+                0 => Self::hash_pair(&node, &EMPTY_ROOTS[height]),
+                _ => Self::hash_pair(h, &node),
             };
             i /= 2;
         }
@@ -352,8 +419,8 @@ impl<Leaf: MerkleLeaf, Root: MerkleRoot, Proof: MerkleProof> MerkleTree<Leaf, Ro
     ///
     /// The labels prevent the possibility to claim an intermediate node was a leaf.
     /// They also make the Merkle tree more robust against pre-calculation attacks.
-    fn hash_pair(left: Hash, right: Hash) -> Hash {
-        hash_all(&[&LEFT_LABEL, &left, &RIGHT_LABEL, &right])
+    fn hash_pair(left: &Hash, right: &Hash) -> Hash {
+        hash_all(&[&LEFT_LABEL, left.as_ref(), &RIGHT_LABEL, right.as_ref()])
     }
 }
 
@@ -378,7 +445,7 @@ mod tests {
         // calculate expected root hash manually
         let leaf1 = PlainMerkleTree::hash_leaf(&data[0]);
         let leaf2 = PlainMerkleTree::hash_leaf(&data[1]);
-        let expected_root = PlainMerkleTree::hash_pair(leaf1, leaf2);
+        let expected_root = PlainMerkleTree::hash_pair(&leaf1, &leaf2);
 
         assert_eq!(tree.get_root(), expected_root);
     }
@@ -502,7 +569,7 @@ mod tests {
         for height in 0..MAX_MERKLE_TREE_HEIGHT {
             let mut node = PlainMerkleTree::hash_leaf(&vec![]);
             for _ in 0..height {
-                node = PlainMerkleTree::hash_pair(node, node);
+                node = PlainMerkleTree::hash_pair(&node, &node);
             }
             println!("{}", hex::encode(node));
         }

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -390,7 +390,8 @@ where
         let hash = req_type.hash();
 
         let expiry = Instant::now() + REPAIR_TIMEOUT;
-        self.outstanding_requests.insert(hash, req_type.clone());
+        self.outstanding_requests
+            .insert(hash.clone(), req_type.clone());
         self.request_timeouts.retain(|(_, h)| h != &hash);
         self.request_timeouts.push((expiry, hash));
 

--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -482,7 +482,7 @@ impl Shredder for AontShredder {
 
         let hash = hash(&payload);
         for i in 0..16 {
-            payload.push(hash[i] ^ key[i]);
+            payload.push(hash.as_ref()[i] ^ key[i]);
         }
 
         let raw_shreds = self.0.shred(&payload)?;
@@ -517,7 +517,7 @@ impl Shredder for AontShredder {
         let iv = Array::from([0; 16]);
         let mut key = Array::try_from(tail.as_slice()).unwrap();
         for i in 0..16 {
-            key[i] ^= hash[i];
+            key[i] ^= hash.as_ref()[i];
         }
 
         let mut cipher = Ctr64LE::<Aes128>::new(&key, &iv);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -118,7 +118,7 @@ pub fn create_random_block(slot: Slot, num_slices: usize) -> Vec<Slice> {
     let mut slices = Vec::new();
     for slice_index in final_slice_index.until() {
         let parent = if slice_index.is_first() {
-            Some((parent_slot, Hash::default().into()))
+            Some((parent_slot, Hash::random_for_test().into()))
         } else {
             None
         };


### PR DESCRIPTION
Replaces the type aliases `Hash` and `ShortHash` with newtypes, as follows:
- `type Hash = [u8; 32]` becomes `struct Hash([u8; 32])`, and
- `type ShortHash = [u8; 16]` becomes `struct ShortHash([u8; 16])`.

Along the way we also introduce a `const GENESIS_BLOCK_HASH`, which was previously hardcoded as `Hash::default()` in various places.

Part of #292.