### PR TITLE
refactor: use `EpochInfo` in `Turbine`

### DIFF
--- a/benches/disseminator.rs
+++ b/benches/disseminator.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
+use alpenglow::ValidatorInfo;
+use alpenglow::consensus::EpochInfo;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Turbine;
 use alpenglow::network::UdpNetwork;
@@ -21,8 +25,23 @@ fn turbine_tree(bencher: divan::Bencher) {
         .with_inputs(|| {
             let net1 = UdpNetwork::new_with_any_port();
             let net2 = UdpNetwork::new_with_any_port();
-            let turbine1 = Turbine::new(0, Vec::new(), net1);
-            let turbine2 = Turbine::new(1, Vec::new(), net2);
+            let mut rng = rand::rng();
+            let addr = alpenglow::network::dontcare_sockaddr();
+            let validators: Vec<_> = (0..2)
+                .map(|i| ValidatorInfo {
+                    id: i,
+                    stake: 1,
+                    pubkey: SecretKey::new(&mut rng).to_pk(),
+                    voting_pubkey: alpenglow::crypto::aggsig::SecretKey::new(&mut rng).to_pk(),
+                    all2all_address: addr,
+                    disseminator_address: addr,
+                    repair_request_address: addr,
+                    repair_response_address: addr,
+                })
+                .collect();
+            let epoch_info = Arc::new(EpochInfo::new(0, validators));
+            let turbine1 = Turbine::new(net1, epoch_info.clone());
+            let turbine2 = Turbine::new(net2, epoch_info);
 
             let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
             let mut rng = rand::rng();

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -10,12 +10,15 @@
 
 mod weighted_shuffle;
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use moka::future::Cache;
 use rand::prelude::*;
 
 pub(crate) use self::weighted_shuffle::WeightedShuffle;
 use super::Disseminator;
+use crate::consensus::EpochInfo;
 use crate::network::{Network, ShredNetwork};
 use crate::shredder::Shred;
 use crate::{Slot, ValidatorId, ValidatorInfo};
@@ -31,8 +34,7 @@ const MAX_CACHED_TREES: u64 = 65536;
 
 /// Implementation of Solana's Turbine block dissemination protocol.
 pub struct Turbine<N: Network> {
-    validator_id: ValidatorId,
-    validators: Vec<ValidatorInfo>,
+    epoch_info: Arc<EpochInfo>,
     network: N,
     fanout: usize,
     tree_cache: Cache<(Slot, usize), TurbineTree>,
@@ -55,10 +57,9 @@ where
     N: ShredNetwork,
 {
     /// Creates a new Turbine instance, configured with the default fanout.
-    pub fn new(validator_id: ValidatorId, validators: Vec<ValidatorInfo>, network: N) -> Self {
+    pub fn new(network: N, epoch_info: Arc<EpochInfo>) -> Self {
         Self {
-            validator_id,
-            validators,
+            epoch_info,
             network,
             fanout: DEFAULT_FANOUT,
             tree_cache: Cache::new(MAX_CACHED_TREES),
@@ -89,7 +90,7 @@ where
             .get_tree(shred.payload().header.slot, shred.payload().index_in_slot())
             .await;
         let root = tree.get_root();
-        let addr = self.validators[root as usize].disseminator_address;
+        let addr = self.epoch_info.validator(root).disseminator_address;
         self.network.send(shred, addr).await
     }
 
@@ -106,7 +107,7 @@ where
         let addrs = tree
             .get_children()
             .iter()
-            .map(|child| self.validators[*child as usize].disseminator_address);
+            .map(|child| self.epoch_info.validator(*child).disseminator_address);
         self.network.send_to_many(shred, addrs).await?;
         Ok(())
     }
@@ -118,9 +119,9 @@ where
             return tree;
         }
         let tree = TurbineTree::new(
-            &self.validators,
+            &self.epoch_info.validators,
             self.fanout,
-            self.validator_id,
+            self.epoch_info.own_id,
             slot,
             shred,
         );
@@ -271,7 +272,8 @@ mod tests {
         let mut disseminators = Vec::new();
         for i in 0..validators.len() {
             let network = core.join_unlimited(i as ValidatorId).await;
-            let turbine = Turbine::new(i as ValidatorId, validators.to_vec(), network);
+            let epoch_info = Arc::new(EpochInfo::new(i as ValidatorId, validators.to_vec()));
+            let turbine = Turbine::new(network, epoch_info);
             disseminators.push(turbine);
         }
         disseminators


### PR DESCRIPTION
Previously the `Turbine` struct was holding its own `validator_id` and `validators` members, instead of just holding an `Arc<EpochInfo>` like we do in Rotor.