### PR TITLE
refactor: split generic epoch info and validator epoch info

### DIFF
--- a/benches/disseminator.rs
+++ b/benches/disseminator.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use alpenglow::ValidatorInfo;
-use alpenglow::consensus::EpochInfo;
+use alpenglow::consensus::{EpochInfo, ValidatorEpochInfo};
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Turbine;
 use alpenglow::network::UdpNetwork;
@@ -40,9 +40,12 @@ fn turbine_tree(bencher: divan::Bencher) {
                     repair_response_address: addr,
                 })
                 .collect();
-            let epoch_info = Arc::new(EpochInfo::new(0, validators));
-            let turbine1 = Turbine::new(net1, epoch_info.clone());
-            let turbine2 = Turbine::new(net2, epoch_info);
+            let epoch_info = EpochInfo::new(validators);
+            let turbine1 = Turbine::new(
+                net1,
+                Arc::new(ValidatorEpochInfo::new(0, epoch_info.clone())),
+            );
+            let turbine2 = Turbine::new(net2, Arc::new(ValidatorEpochInfo::new(1, epoch_info)));
 
             let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
             let mut rng = rand::rng();

--- a/benches/disseminator.rs
+++ b/benches/disseminator.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use alpenglow::ValidatorInfo;
 use alpenglow::consensus::{EpochInfo, ValidatorEpochInfo};
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Turbine;
@@ -44,9 +43,15 @@ fn turbine_tree(bencher: divan::Bencher) {
             let epoch_info = EpochInfo::new(validators);
             let turbine1 = Turbine::new(
                 net1,
-                Arc::new(ValidatorEpochInfo::new(ValidatorId::new(0), epoch_info.clone())),
+                Arc::new(ValidatorEpochInfo::new(
+                    ValidatorId::new(0),
+                    epoch_info.clone(),
+                )),
             );
-            let turbine2 = Turbine::new(net2, Arc::new(ValidatorEpochInfo::new(ValidatorId::new(1), epoch_info)));
+            let turbine2 = Turbine::new(
+                net2,
+                Arc::new(ValidatorEpochInfo::new(ValidatorId::new(1), epoch_info)),
+            );
 
             let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
             let mut rng = rand::rng();

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -119,7 +119,7 @@ fn create_node(config: ConfigFile) -> Node {
     // turn ConfigFile into an actual node
     let epoch_info = Arc::new(ValidatorEpochInfo::new(
         config.id,
-        Arc::new(EpochInfo::new(config.gossip.clone())),
+        EpochInfo::new(config.gossip.clone()),
     ));
     let start_port = config.port;
     let network = UdpNetwork::new(start_port);

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -8,7 +8,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use alpenglow::all2all::TrivialAll2All;
-use alpenglow::consensus::{Alpenglow, ConsensusMessage, EpochInfo};
+use alpenglow::consensus::{Alpenglow, ConsensusMessage, EpochInfo, ValidatorEpochInfo};
 use alpenglow::crypto::aggsig;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Rotor;
@@ -117,7 +117,10 @@ type Node = Alpenglow<
 
 fn create_node(config: ConfigFile) -> Node {
     // turn ConfigFile into an actual node
-    let epoch_info = Arc::new(EpochInfo::new(config.id, config.gossip.clone()));
+    let epoch_info = Arc::new(ValidatorEpochInfo::new(
+        config.id,
+        Arc::new(EpochInfo::new(config.gossip.clone())),
+    ));
     let start_port = config.port;
     let network = UdpNetwork::new(start_port);
     let all2all = TrivialAll2All::new(config.gossip, network);

--- a/src/bin/performance_test.rs
+++ b/src/bin/performance_test.rs
@@ -101,7 +101,7 @@ async fn create_test_nodes(count: u64) -> Vec<TestNode> {
     }
 
     // turn validator info into actual nodes
-    let shared_epoch = Arc::new(EpochInfo::new(validators.clone()));
+    let shared_epoch = EpochInfo::new(validators.clone());
     validators
         .iter()
         .map(|v| {

--- a/src/bin/performance_test.rs
+++ b/src/bin/performance_test.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use alpenglow::all2all::TrivialAll2All;
-use alpenglow::consensus::{ConsensusMessage, EpochInfo};
+use alpenglow::consensus::{ConsensusMessage, EpochInfo, ValidatorEpochInfo};
 use alpenglow::crypto::aggsig;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Rotor;
@@ -101,10 +101,11 @@ async fn create_test_nodes(count: u64) -> Vec<TestNode> {
     }
 
     // turn validator info into actual nodes
+    let shared_epoch = Arc::new(EpochInfo::new(validators.clone()));
     validators
         .iter()
         .map(|v| {
-            let epoch_info = Arc::new(EpochInfo::new(v.id, validators.clone()));
+            let epoch_info = Arc::new(ValidatorEpochInfo::new(v.id, shared_epoch.clone()));
             let all2all =
                 TrivialAll2All::new(validators.clone(), all2all_networks.pop_front().unwrap());
             let disseminator = Rotor::new(

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -260,7 +260,9 @@ where
     }
 
     pub fn get_info(&self) -> &ValidatorInfo {
-        self.epoch_info.validator(self.epoch_info.own_id())
+        self.epoch_info
+            .epoch_info()
+            .validator(self.epoch_info.own_id())
     }
 
     pub fn get_pool(&self) -> Arc<RwLock<Box<dyn Pool + Send + Sync>>> {
@@ -333,7 +335,7 @@ where
 
         // if we are the leader, we already have the shred
         let slot = shred.payload().header.slot;
-        if self.epoch_info.leader(slot).id == self.epoch_info.own_id() {
+        if self.epoch_info.epoch_info().leader(slot).id == self.epoch_info.own_id() {
             return Ok(());
         }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -40,7 +40,7 @@ use wincode::{SchemaRead, SchemaWrite};
 
 pub use self::blockstore::{BlockInfo, Blockstore, BlockstoreImpl};
 pub use self::cert::{Cert, NotarCert};
-pub use self::epoch_info::EpochInfo;
+pub use self::epoch_info::{EpochInfo, ValidatorEpochInfo};
 pub use self::pool::{AddVoteError, Pool, PoolImpl};
 pub use self::vote::Vote;
 use self::votor::Votor;
@@ -87,7 +87,7 @@ where
     T: TransactionNetwork + 'static,
 {
     /// Other validators' info.
-    epoch_info: Arc<EpochInfo>,
+    epoch_info: Arc<ValidatorEpochInfo>,
 
     /// Blockstore for storing raw block data.
     blockstore: Arc<RwLock<Box<dyn Blockstore + Send + Sync>>>,
@@ -127,7 +127,7 @@ where
         disseminator: D,
         repair_network: RN,
         repair_request_network: RR,
-        epoch_info: Arc<EpochInfo>,
+        epoch_info: Arc<ValidatorEpochInfo>,
         txs_receiver: T,
     ) -> Self
     where

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -514,7 +514,6 @@ mod tests {
     use mockall::{Sequence, predicate};
 
     use super::*;
-    use crate::Transaction;
     use crate::consensus::blockstore::MockBlockstore;
     use crate::consensus::pool::MockPool;
     use crate::consensus::{BlockInfo, ValidatorEpochInfo};
@@ -523,6 +522,7 @@ mod tests {
     use crate::network::{UdpNetwork, localhost_ip_sockaddr};
     use crate::shredder::TOTAL_SHREDS;
     use crate::test_utils::generate_validators;
+    use crate::{Transaction, ValidatorId};
 
     #[tokio::test]
     async fn produce_slice_empty_slices() {
@@ -639,7 +639,7 @@ mod tests {
     ) -> BlockProducer<MockDisseminator, UdpNetwork<Transaction, Transaction>> {
         let secret_key = signature::SecretKey::new(&mut rand::rng());
         let (_, epoch_info) = generate_validators(11);
-        let epoch_info = Arc::new(ValidatorEpochInfo::new(0, epoch_info));
+        let epoch_info = Arc::new(ValidatorEpochInfo::new(ValidatorId::new(0), epoch_info));
         let blockstore: Box<dyn Blockstore + Send + Sync> = Box::new(blockstore);
         let blockstore = Arc::new(RwLock::new(blockstore));
         let pool: Box<dyn Pool + Send + Sync> = Box::new(pool);

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -103,7 +103,7 @@ where
             let last_slot_in_window = first_slot_in_window.last_slot_in_window();
 
             // don't do anything if we are not the leader
-            let leader = self.epoch_info.leader(first_slot_in_window);
+            let leader = self.epoch_info.epoch_info().leader(first_slot_in_window);
             if leader.id != self.epoch_info.own_id() {
                 debug!(
                     "[val {}] not producing in window {first_slot_in_window}..{last_slot_in_window}, not leader",

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -17,7 +17,7 @@ use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 use wincode::config::DefaultConfig;
 
-use crate::consensus::{Blockstore, EpochInfo, Pool};
+use crate::consensus::{Blockstore, Pool, ValidatorEpochInfo};
 use crate::crypto::merkle::{BlockHash, GENESIS_BLOCK_HASH, MerkleRoot};
 use crate::crypto::signature;
 use crate::network::{Network, TransactionNetwork};
@@ -36,7 +36,7 @@ pub(super) struct BlockProducer<D: Disseminator, T: Network> {
     /// This is not the same as the voting secret key, which is held by [`super::Votor`].
     secret_key: signature::SecretKey,
     /// Other validators' info.
-    epoch_info: Arc<EpochInfo>,
+    epoch_info: Arc<ValidatorEpochInfo>,
 
     /// Blockstore for storing raw block data.
     blockstore: Arc<RwLock<Box<dyn Blockstore + Send + Sync>>>,
@@ -67,7 +67,7 @@ where
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         secret_key: signature::SecretKey,
-        epoch_info: Arc<EpochInfo>,
+        epoch_info: Arc<ValidatorEpochInfo>,
         disseminator: Arc<D>,
         txs_receiver: T,
         blockstore: Arc<RwLock<Box<dyn Blockstore + Send + Sync>>>,
@@ -515,9 +515,9 @@ mod tests {
 
     use super::*;
     use crate::Transaction;
-    use crate::consensus::BlockInfo;
     use crate::consensus::blockstore::MockBlockstore;
     use crate::consensus::pool::MockPool;
+    use crate::consensus::{BlockInfo, ValidatorEpochInfo};
     use crate::crypto::Hash;
     use crate::disseminator::MockDisseminator;
     use crate::network::{UdpNetwork, localhost_ip_sockaddr};
@@ -639,6 +639,7 @@ mod tests {
     ) -> BlockProducer<MockDisseminator, UdpNetwork<Transaction, Transaction>> {
         let secret_key = signature::SecretKey::new(&mut rand::rng());
         let (_, epoch_info) = generate_validators(11);
+        let epoch_info = Arc::new(ValidatorEpochInfo::new(0, epoch_info));
         let blockstore: Box<dyn Blockstore + Send + Sync> = Box::new(blockstore);
         let blockstore = Arc::new(RwLock::new(blockstore));
         let pool: Box<dyn Pool + Send + Sync> = Box::new(pool);

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -380,8 +380,7 @@ mod tests {
             repair_response_address: dontcare_sockaddr(),
         };
         let validators = vec![info];
-        let epoch_info = Arc::new(EpochInfo::new(validators));
-        let epoch_info = Arc::new(ValidatorEpochInfo::new(0, epoch_info));
+        let epoch_info = Arc::new(ValidatorEpochInfo::new(0, EpochInfo::new(validators)));
         (sk, BlockstoreImpl::new(epoch_info, tx))
     }
 

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -369,8 +369,9 @@ mod tests {
     fn test_setup(tx: Sender<VotorEvent>) -> (SecretKey, BlockstoreImpl) {
         let sk = SecretKey::new(&mut rand::rng());
         let voting_sk = aggsig::SecretKey::new(&mut rand::rng());
+        let id = ValidatorId::new(0);
         let info = ValidatorInfo {
-            id: ValidatorId::new(0),
+            id,
             stake: Stake::new(1),
             pubkey: sk.to_pk(),
             voting_pubkey: voting_sk.to_pk(),
@@ -380,7 +381,7 @@ mod tests {
             repair_response_address: dontcare_sockaddr(),
         };
         let validators = vec![info];
-        let epoch_info = Arc::new(ValidatorEpochInfo::new(ValidatorId::new(0), EpochInfo::new(validators)));
+        let epoch_info = Arc::new(ValidatorEpochInfo::new(id, EpochInfo::new(validators)));
         (sk, BlockstoreImpl::new(epoch_info, tx))
     }
 

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -14,7 +14,7 @@ use mockall::automock;
 use tokio::sync::mpsc::Sender;
 
 use self::slot_block_data::{AddShredError, SlotBlockData};
-use super::epoch_info::EpochInfo;
+use super::epoch_info::ValidatorEpochInfo;
 use super::votor::VotorEvent;
 use crate::consensus::blockstore::slot_block_data::BlockData;
 use crate::crypto::merkle::{BlockHash, DoubleMerkleProof, MerkleRoot, SliceRoot};
@@ -85,7 +85,7 @@ pub struct BlockstoreImpl {
     /// Event channel for sending notifications to Votor.
     votor_channel: Sender<VotorEvent>,
     /// Information about all active validators.
-    epoch_info: Arc<EpochInfo>,
+    epoch_info: Arc<ValidatorEpochInfo>,
 }
 
 impl BlockstoreImpl {
@@ -95,7 +95,7 @@ impl BlockstoreImpl {
     /// - [`VotorEvent::FirstShred`] when receiving the first shred for a slot
     ///   from the block dissemination protocol
     /// - [`VotorEvent::Block`] for any reconstructed block
-    pub fn new(epoch_info: Arc<EpochInfo>, votor_channel: Sender<VotorEvent>) -> Self {
+    pub fn new(epoch_info: Arc<ValidatorEpochInfo>, votor_channel: Sender<VotorEvent>) -> Self {
         Self {
             block_data: BTreeMap::new(),
             shredders: ShredderPool::with_size(1),
@@ -357,6 +357,7 @@ mod tests {
 
     use super::*;
     use crate::ValidatorInfo;
+    use crate::consensus::EpochInfo;
     use crate::crypto::aggsig;
     use crate::crypto::merkle::DoubleMerkleTree;
     use crate::crypto::signature::SecretKey;
@@ -379,8 +380,9 @@ mod tests {
             repair_response_address: dontcare_sockaddr(),
         };
         let validators = vec![info];
-        let epoch_info = EpochInfo::new(0, validators);
-        (sk, BlockstoreImpl::new(Arc::new(epoch_info), tx))
+        let epoch_info = Arc::new(EpochInfo::new(validators));
+        let epoch_info = Arc::new(ValidatorEpochInfo::new(0, epoch_info));
+        (sk, BlockstoreImpl::new(epoch_info, tx))
     }
 
     async fn add_shred_ignore_duplicate(

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -223,7 +223,7 @@ impl Blockstore for BlockstoreImpl {
         shred: Shred,
     ) -> Result<Option<BlockInfo>, AddShredError> {
         let slot = shred.payload().header.slot;
-        let leader_pk = self.epoch_info.leader(slot).pubkey;
+        let leader_pk = self.epoch_info.epoch_info().leader(slot).pubkey;
         let mut shredder = self
             .shredders
             .checkout()
@@ -257,7 +257,7 @@ impl Blockstore for BlockstoreImpl {
         shred: Shred,
     ) -> Result<Option<BlockInfo>, AddShredError> {
         let slot = shred.payload().header.slot;
-        let leader_pk = self.epoch_info.leader(slot).pubkey;
+        let leader_pk = self.epoch_info.epoch_info().leader(slot).pubkey;
         let mut shredder = self
             .shredders
             .checkout()

--- a/src/consensus/cert.rs
+++ b/src/consensus/cert.rs
@@ -947,7 +947,7 @@ mod tests {
     #[test]
     fn notar_stake_threshold() {
         let (sks, info) = create_signers(11);
-        let epoch = EpochInfo::new(0, info.clone());
+        let epoch = EpochInfo::new(info.clone());
         let hash: BlockHash = Hash::random_for_test().into();
 
         // 7/11 enough for 60% threshold
@@ -968,7 +968,7 @@ mod tests {
     #[test]
     fn notar_fallback_stake_threshold() {
         let (sks, info) = create_signers(11);
-        let epoch = EpochInfo::new(0, info.clone());
+        let epoch = EpochInfo::new(info.clone());
         let hash: BlockHash = Hash::random_for_test().into();
 
         // 7/11 enough for 60% threshold
@@ -1001,7 +1001,7 @@ mod tests {
     #[test]
     fn skip_stake_threshold() {
         let (sks, info) = create_signers(11);
-        let epoch = EpochInfo::new(0, info.clone());
+        let epoch = EpochInfo::new(info.clone());
 
         // 7/11 enough for 60% threshold
         let votes = (0..7)
@@ -1021,7 +1021,7 @@ mod tests {
     #[test]
     fn final_stake_threshold() {
         let (sks, info) = create_signers(11);
-        let epoch = EpochInfo::new(0, info.clone());
+        let epoch = EpochInfo::new(info.clone());
 
         // 7/11 enough for 60% threshold
         let votes = (0..7)
@@ -1041,7 +1041,7 @@ mod tests {
     #[test]
     fn fast_final_stake_threshold() {
         let (sks, info) = create_signers(11);
-        let epoch = EpochInfo::new(0, info.clone());
+        let epoch = EpochInfo::new(info.clone());
         let hash: BlockHash = Hash::random_for_test().into();
 
         // 9/11 enough for 80% threshold

--- a/src/consensus/epoch_info.rs
+++ b/src/consensus/epoch_info.rs
@@ -9,7 +9,7 @@ use crate::{Slot, Stake, ValidatorId, ValidatorInfo};
 /// Shared epoch information, identical across all validators.
 ///
 /// Contains the validator set and derived data for one epoch.
-/// Constructed once per epoch and shared via [`Arc`].
+/// Constructed once per epoch and shared via [`std::sync::Arc`].
 #[derive(Clone, Debug)]
 pub struct EpochInfo {
     pub(crate) validators: Vec<ValidatorInfo>,

--- a/src/consensus/epoch_info.rs
+++ b/src/consensus/epoch_info.rs
@@ -1,20 +1,51 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Deref;
+use std::sync::Arc;
+
 use crate::types::SLOTS_PER_WINDOW;
 use crate::{Slot, Stake, ValidatorId, ValidatorInfo};
 
-/// Epoch-specfic validator information.
+/// Shared epoch information, identical across all validators.
+///
+/// Contains the validator set and derived data for one epoch.
+/// Constructed once per epoch and shared via [`Arc`].
 #[derive(Clone, Debug)]
 pub struct EpochInfo {
-    pub(crate) own_id: ValidatorId,
     pub(crate) validators: Vec<ValidatorInfo>,
+    total_stake: Stake,
+}
+
+/// Per-validator epoch information, wrapping shared [`EpochInfo`].
+///
+/// Adds the node's own identity on top of the shared epoch data.
+/// Cheaply cloneable (just a [`ValidatorId`] + an [`Arc`]).
+#[derive(Clone, Debug)]
+pub struct ValidatorEpochInfo {
+    pub(crate) own_id: ValidatorId,
+    epoch: Arc<EpochInfo>,
 }
 
 impl EpochInfo {
-    /// Creates a new `EpochInfo` instance with the given validators.
-    pub const fn new(own_id: ValidatorId, validators: Vec<ValidatorInfo>) -> Self {
-        Self { own_id, validators }
+    /// Creates a new `EpochInfo` from the given validator set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any validator's `id` does not match its index in the vector.
+    pub fn new(validators: Vec<ValidatorInfo>) -> Self {
+        for (i, v) in validators.iter().enumerate() {
+            assert!(
+                v.id == i as u64,
+                "validator at index {i} has id {}, expected {i}",
+                v.id
+            );
+        }
+        let total_stake = validators.iter().map(|v| v.stake).sum();
+        Self {
+            validators,
+            total_stake,
+        }
     }
 
     /// Gives the validator info for the given validator ID.
@@ -38,6 +69,30 @@ impl EpochInfo {
     /// Gives the total stake over all validators.
     #[must_use]
     pub fn total_stake(&self) -> Stake {
-        self.validators.iter().map(|v| v.stake).sum()
+        self.total_stake
+    }
+}
+
+impl ValidatorEpochInfo {
+    /// Creates a per-validator view of the given epoch info.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `own_id` is not a valid validator index.
+    pub fn new(own_id: ValidatorId, epoch: Arc<EpochInfo>) -> Self {
+        assert!(
+            (own_id as usize) < epoch.validators.len(),
+            "own_id {own_id} is out of range for {} validators",
+            epoch.validators.len()
+        );
+        Self { own_id, epoch }
+    }
+}
+
+impl Deref for ValidatorEpochInfo {
+    type Target = EpochInfo;
+
+    fn deref(&self) -> &EpochInfo {
+        &self.epoch
     }
 }

--- a/src/consensus/epoch_info.rs
+++ b/src/consensus/epoch_info.rs
@@ -110,7 +110,7 @@ impl ValidatorEpochInfo {
     /// Panics if `own_id` is not a valid validator index.
     pub fn new(own_id: ValidatorId, epoch: EpochInfo) -> Self {
         assert!(
-            (own_id as usize) < epoch.validators.len(),
+            own_id.as_index() < epoch.validators.len(),
             "own_id {own_id} is out of range for {} validators",
             epoch.validators.len()
         );

--- a/src/consensus/epoch_info.rs
+++ b/src/consensus/epoch_info.rs
@@ -15,7 +15,7 @@ use crate::{Slot, Stake, ValidatorId, ValidatorInfo};
 /// Constructed once per epoch and shared via [`std::sync::Arc`].
 #[derive(Clone, Debug)]
 pub struct EpochInfo {
-    pub(crate) validators: Vec<ValidatorInfo>,
+    validators: Vec<ValidatorInfo>,
     total_stake: Stake,
 }
 
@@ -24,7 +24,7 @@ pub struct EpochInfo {
 /// Adds the node's own identity on top of the shared epoch data.
 #[derive(Clone, Debug)]
 pub struct ValidatorEpochInfo {
-    pub(crate) own_id: ValidatorId,
+    own_id: ValidatorId,
     epoch: EpochInfo,
 }
 

--- a/src/consensus/epoch_info.rs
+++ b/src/consensus/epoch_info.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::Deref;
-
 use crate::consensus::{
     QUORUM_THRESHOLD, STRONG_QUORUM_THRESHOLD, WEAK_QUORUM_THRESHOLD, WEAKEST_QUORUM_THRESHOLD,
 };
@@ -124,12 +122,10 @@ impl ValidatorEpochInfo {
     pub fn own_id(&self) -> ValidatorId {
         self.own_id
     }
-}
 
-impl Deref for ValidatorEpochInfo {
-    type Target = EpochInfo;
-
-    fn deref(&self) -> &EpochInfo {
+    /// Returns the shared epoch information.
+    #[must_use]
+    pub fn epoch_info(&self) -> &EpochInfo {
         &self.epoch
     }
 }

--- a/src/consensus/epoch_info.rs
+++ b/src/consensus/epoch_info.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::ops::Deref;
-use std::sync::Arc;
 
 use crate::types::SLOTS_PER_WINDOW;
 use crate::{Slot, Stake, ValidatorId, ValidatorInfo};
@@ -20,11 +19,10 @@ pub struct EpochInfo {
 /// Per-validator epoch information, wrapping shared [`EpochInfo`].
 ///
 /// Adds the node's own identity on top of the shared epoch data.
-/// Cheaply cloneable (just a [`ValidatorId`] + an [`Arc`]).
 #[derive(Clone, Debug)]
 pub struct ValidatorEpochInfo {
     pub(crate) own_id: ValidatorId,
-    epoch: Arc<EpochInfo>,
+    epoch: EpochInfo,
 }
 
 impl EpochInfo {
@@ -79,7 +77,7 @@ impl ValidatorEpochInfo {
     /// # Panics
     ///
     /// Panics if `own_id` is not a valid validator index.
-    pub fn new(own_id: ValidatorId, epoch: Arc<EpochInfo>) -> Self {
+    pub fn new(own_id: ValidatorId, epoch: EpochInfo) -> Self {
         assert!(
             (own_id as usize) < epoch.validators.len(),
             "own_id {own_id} is out of range for {} validators",

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -543,7 +543,7 @@ mod tests {
     use crate::types::SLOTS_PER_WINDOW;
 
     /// Wraps shared `EpochInfo` with a `ValidatorEpochInfo` for validator 0.
-    fn wrap_epoch_info(epoch_info: Arc<EpochInfo>) -> Arc<ValidatorEpochInfo> {
+    fn wrap_epoch_info(epoch_info: EpochInfo) -> Arc<ValidatorEpochInfo> {
         Arc::new(ValidatorEpochInfo::new(0, epoch_info))
     }
 

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -376,9 +376,9 @@ impl Pool for PoolImpl {
         }
 
         // verify stake threshold & signature
-        if !cert.check_threshold(&self.epoch_info) {
+        if !cert.check_threshold(self.epoch_info.epoch_info()) {
             return Err(AddCertError::ThresholdNotMet);
-        } else if !cert.check_sig(self.epoch_info.validators()) {
+        } else if !cert.check_sig(self.epoch_info.epoch_info().validators()) {
             return Err(AddCertError::InvalidSignature);
         }
 
@@ -416,14 +416,18 @@ impl Pool for PoolImpl {
         }
 
         // verify signature
-        let pk = &self.epoch_info.validator(vote.signer()).voting_pubkey;
+        let pk = &self
+            .epoch_info
+            .epoch_info()
+            .validator(vote.signer())
+            .voting_pubkey;
         if !vote.check_sig(pk) {
             return Err(AddVoteError::InvalidSignature);
         }
 
         // check if vote is valid and should be counted
         let voter = vote.signer();
-        let voter_stake = self.epoch_info.validator(voter).stake;
+        let voter_stake = self.epoch_info.epoch_info().validator(voter).stake;
         if let Some(offence) = self.slot_state(slot).check_slashable_offence(&vote) {
             return Err(AddVoteError::Slashable(offence));
         } else if self.slot_state(slot).should_ignore_vote(&vote) {
@@ -850,7 +854,7 @@ mod tests {
         for v in 0..7 {
             votes.push(Vote::new_notar(slot1, hash1.clone(), &sks[v as usize], v));
         }
-        let cert = NotarCert::try_new(&votes, epoch_info.validators()).unwrap();
+        let cert = NotarCert::try_new(&votes, epoch_info.epoch_info().validators()).unwrap();
         pool.add_cert(Cert::Notar(cert)).await.unwrap();
 
         // branch can only be certified once we saw votes for parent
@@ -1126,7 +1130,7 @@ mod tests {
                 v,
             ));
         }
-        let notar_cert = NotarCert::try_new(&votes, epoch_info.validators()).unwrap();
+        let notar_cert = NotarCert::try_new(&votes, epoch_info.epoch_info().validators()).unwrap();
         assert_eq!(pool.add_cert(Cert::Notar(notar_cert.clone())).await, Ok(()));
 
         // insert a skip cert for slot 1
@@ -1135,7 +1139,7 @@ mod tests {
         for v in 0..11 {
             votes.push(Vote::new_skip(second_slot, &sks[v as usize], v));
         }
-        let skip_cert = SkipCert::try_new(&votes, epoch_info.validators()).unwrap();
+        let skip_cert = SkipCert::try_new(&votes, epoch_info.epoch_info().validators()).unwrap();
         assert_eq!(pool.add_cert(Cert::Skip(skip_cert.clone())).await, Ok(()));
 
         // inserting same certs again should fail
@@ -1206,7 +1210,7 @@ mod tests {
                 v,
             ));
         }
-        let ff_cert = FastFinalCert::try_new(&votes, epoch_info.validators()).unwrap();
+        let ff_cert = FastFinalCert::try_new(&votes, epoch_info.epoch_info().validators()).unwrap();
         assert_eq!(
             pool.add_cert(Cert::FastFinal(ff_cert.clone())).await,
             Ok(())
@@ -1218,7 +1222,8 @@ mod tests {
             for v in 0..11 {
                 votes.push(Vote::new_skip(Slot::new(slot), &sks[v as usize], v));
             }
-            let skip_cert = SkipCert::try_new(&votes, epoch_info.validators()).unwrap();
+            let skip_cert =
+                SkipCert::try_new(&votes, epoch_info.epoch_info().validators()).unwrap();
             assert_eq!(
                 pool.add_cert(Cert::Skip(skip_cert.clone())).await,
                 Err(AddCertError::SlotOutOfBounds)
@@ -1231,7 +1236,7 @@ mod tests {
         for v in 0..11 {
             votes.push(Vote::new_skip(slot, &sks[v as usize], v));
         }
-        let skip_cert = SkipCert::try_new(&votes, epoch_info.validators()).unwrap();
+        let skip_cert = SkipCert::try_new(&votes, epoch_info.epoch_info().validators()).unwrap();
         assert_eq!(
             pool.add_cert(Cert::Skip(skip_cert.clone())).await,
             Err(AddCertError::SlotOutOfBounds)

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -26,7 +26,7 @@ use self::finality_tracker::FinalityTracker;
 use self::parent_ready_tracker::ParentReadyTracker;
 use self::slot_state::SlotState;
 use super::votor::VotorEvent;
-use super::{Cert, EpochInfo, Vote};
+use super::{Cert, ValidatorEpochInfo, Vote};
 use crate::consensus::cert::NotarCert;
 use crate::consensus::pool::finality_tracker::FinalizationEvent;
 use crate::crypto::merkle::{BlockHash, MerkleRoot};
@@ -103,7 +103,7 @@ pub struct PoolImpl {
     s2n_waiting_parent_cert: BTreeMap<BlockId, BlockId>,
 
     /// Information about all active validators.
-    epoch_info: Arc<EpochInfo>,
+    epoch_info: Arc<ValidatorEpochInfo>,
     /// Channel for sending events related to voting logic to Votor.
     votor_event_channel: Sender<VotorEvent>,
     /// Channel for sending repair requests to the repair loop.
@@ -115,7 +115,7 @@ impl PoolImpl {
     ///
     /// Any later emitted events will be sent on provided `votor_event_channel`.
     pub fn new(
-        epoch_info: Arc<EpochInfo>,
+        epoch_info: Arc<ValidatorEpochInfo>,
         votor_event_channel: Sender<VotorEvent>,
         repair_channel: Sender<BlockId>,
     ) -> Self {
@@ -533,6 +533,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::*;
+    use crate::consensus::EpochInfo;
     use crate::consensus::cert::{FastFinalCert, NotarCert, SkipCert};
     use crate::consensus::vote::VoteKind;
     use crate::crypto::Hash;
@@ -541,9 +542,15 @@ mod tests {
     use crate::test_utils::generate_validators;
     use crate::types::SLOTS_PER_WINDOW;
 
+    /// Wraps shared `EpochInfo` with a `ValidatorEpochInfo` for validator 0.
+    fn wrap_epoch_info(epoch_info: Arc<EpochInfo>) -> Arc<ValidatorEpochInfo> {
+        Arc::new(ValidatorEpochInfo::new(0, epoch_info))
+    }
+
     #[tokio::test]
     async fn handle_invalid_votes() {
         let (_, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -559,6 +566,7 @@ mod tests {
     #[tokio::test]
     async fn notarize_block() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -591,6 +599,7 @@ mod tests {
     #[tokio::test]
     async fn skip_block() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -623,6 +632,7 @@ mod tests {
     #[tokio::test]
     async fn finalize_block() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -679,6 +689,7 @@ mod tests {
     #[tokio::test]
     async fn fast_finalize_block() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -714,6 +725,7 @@ mod tests {
     #[tokio::test]
     async fn simple_branch_certified() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -742,6 +754,7 @@ mod tests {
     #[tokio::test]
     async fn branch_certified_notar_fallback() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -773,6 +786,7 @@ mod tests {
     #[tokio::test]
     async fn branch_certified_out_of_order() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -810,6 +824,7 @@ mod tests {
     #[tokio::test]
     async fn branch_certified_late_cert() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
@@ -845,6 +860,7 @@ mod tests {
     #[tokio::test]
     async fn regular_handover() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -874,6 +890,7 @@ mod tests {
     #[tokio::test]
     async fn one_skip_handover() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -913,6 +930,7 @@ mod tests {
     #[tokio::test]
     async fn two_skip_handover() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -956,6 +974,7 @@ mod tests {
     #[tokio::test]
     async fn skip_window_handover() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -997,6 +1016,7 @@ mod tests {
     #[tokio::test]
     async fn pruning() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -1066,6 +1086,7 @@ mod tests {
     #[tokio::test]
     async fn duplicate_votes() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -1088,6 +1109,7 @@ mod tests {
     #[tokio::test]
     async fn duplicate_certs() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
@@ -1130,6 +1152,7 @@ mod tests {
     #[tokio::test]
     async fn out_of_bounds_votes() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -1167,6 +1190,7 @@ mod tests {
     #[tokio::test]
     async fn out_of_bounds_certs() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, _votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
@@ -1217,6 +1241,7 @@ mod tests {
     #[tokio::test]
     async fn standstill_recovery() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, mut votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
@@ -1286,6 +1311,7 @@ mod tests {
     #[tokio::test]
     async fn parent_ready_upon_finalization() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, mut votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
         let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -549,7 +549,7 @@ mod tests {
 
     /// Wraps shared `EpochInfo` with a `ValidatorEpochInfo` for validator 0.
     fn wrap_epoch_info(epoch_info: EpochInfo) -> Arc<ValidatorEpochInfo> {
-        Arc::new(ValidatorEpochInfo::new(0, epoch_info))
+        Arc::new(ValidatorEpochInfo::new(ValidatorId::new(0), epoch_info))
     }
 
     #[tokio::test]

--- a/src/consensus/pool/slot_state.rs
+++ b/src/consensus/pool/slot_state.rs
@@ -590,7 +590,7 @@ mod tests {
     use crate::test_utils::generate_validators;
 
     /// Wraps shared `EpochInfo` with a `ValidatorEpochInfo` for validator 0.
-    fn wrap_epoch_info(epoch_info: Arc<EpochInfo>) -> Arc<ValidatorEpochInfo> {
+    fn wrap_epoch_info(epoch_info: EpochInfo) -> Arc<ValidatorEpochInfo> {
         Arc::new(ValidatorEpochInfo::new(0, epoch_info))
     }
 

--- a/src/consensus/pool/slot_state.rs
+++ b/src/consensus/pool/slot_state.rs
@@ -19,7 +19,7 @@ use super::SlashableOffence;
 use crate::consensus::cert::{FastFinalCert, FinalCert, NotarCert, NotarFallbackCert, SkipCert};
 use crate::consensus::vote::VoteKind;
 use crate::consensus::votor::VotorEvent;
-use crate::consensus::{Cert, EpochInfo, Vote};
+use crate::consensus::{Cert, ValidatorEpochInfo, Vote};
 use crate::crypto::merkle::BlockHash;
 use crate::{BlockId, Slot, Stake};
 
@@ -44,7 +44,7 @@ pub struct SlotState {
     /// The slot this state is for.
     slot: Slot,
     /// Information about all validators active in this slot.
-    pub(super) epoch_info: Arc<EpochInfo>,
+    pub(super) epoch_info: Arc<ValidatorEpochInfo>,
 }
 
 // PERF: replace storing Votes (50% size overhead) with storing only signatures?
@@ -117,7 +117,7 @@ impl SlotState {
     /// Creates a new container for votes and certificates for a single slot.
     ///
     /// Initially, it is completely empty.
-    pub fn new(slot: Slot, epoch_info: Arc<EpochInfo>) -> Self {
+    pub fn new(slot: Slot, epoch_info: Arc<ValidatorEpochInfo>) -> Self {
         Self {
             votes: SlotVotes::new(epoch_info.validators.len()),
             voted_stakes: SlotVotedStake::default(),
@@ -585,12 +585,19 @@ impl SlotVotes {
 mod tests {
     use super::*;
     use crate::ValidatorId;
+    use crate::consensus::EpochInfo;
     use crate::crypto::Hash;
     use crate::test_utils::generate_validators;
+
+    /// Wraps shared `EpochInfo` with a `ValidatorEpochInfo` for validator 0.
+    fn wrap_epoch_info(epoch_info: Arc<EpochInfo>) -> Arc<ValidatorEpochInfo> {
+        Arc::new(ValidatorEpochInfo::new(0, epoch_info))
+    }
 
     #[test]
     fn quorums() {
         let (_, epoch_info) = generate_validators(6);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let slot_state = SlotState::new(Slot::new(0), epoch_info);
         assert!(slot_state.is_weak_quorum(3));
         assert!(!slot_state.is_quorum(3));
@@ -599,6 +606,7 @@ mod tests {
         assert!(slot_state.is_strong_quorum(5));
 
         let (_, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let slot_state = SlotState::new(Slot::new(0), epoch_info);
         assert!(slot_state.is_weak_quorum(5));
         assert!(!slot_state.is_quorum(5));
@@ -610,6 +618,7 @@ mod tests {
     #[test]
     fn add_cert() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (slot, hash): BlockId = (Slot::new(1), Hash::random_for_test().into());
         let mut slot_state = SlotState::new(slot, epoch_info.clone());
         let votes: Vec<_> = sks
@@ -626,6 +635,7 @@ mod tests {
     #[test]
     fn add_vote() {
         let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (slot, hash): BlockId = (Slot::new(1), Hash::random_for_test().into());
         let mut slot_state = SlotState::new(slot, epoch_info.clone());
         for (i, sk) in sks.iter().enumerate() {
@@ -646,6 +656,7 @@ mod tests {
     #[test]
     fn safe_to_notar() {
         let (sks, epoch_info) = generate_validators(3);
+        let epoch_info = wrap_epoch_info(epoch_info);
         let (slot, hash): BlockId = (Slot::new(1), Hash::random_for_test().into());
         let mut slot_state = SlotState::new(slot, epoch_info.clone());
 

--- a/src/consensus/pool/slot_state.rs
+++ b/src/consensus/pool/slot_state.rs
@@ -617,7 +617,7 @@ mod tests {
 
     /// Wraps shared `EpochInfo` with a `ValidatorEpochInfo` for validator 0.
     fn wrap_epoch_info(epoch_info: EpochInfo) -> Arc<ValidatorEpochInfo> {
-        Arc::new(ValidatorEpochInfo::new(0, epoch_info))
+        Arc::new(ValidatorEpochInfo::new(ValidatorId::new(0), epoch_info))
     }
 
     #[test]
@@ -645,7 +645,10 @@ mod tests {
         let mut slot_state = SlotState::new(slot, epoch_info.clone());
         for (i, sk) in sks.iter().enumerate() {
             let vote = Vote::new_notar(slot, hash.clone(), sk, ValidatorId::new(i as u64));
-            let voter_stake = epoch_info.epoch_info().validator(ValidatorId::new(i as u64)).stake;
+            let voter_stake = epoch_info
+                .epoch_info()
+                .validator(ValidatorId::new(i as u64))
+                .stake;
             assert!(slot_state.votes.notar[i].is_none());
             slot_state.add_vote(vote.clone(), voter_stake);
             let notar_vote = &slot_state.votes.notar[i];

--- a/src/consensus/pool/slot_state.rs
+++ b/src/consensus/pool/slot_state.rs
@@ -119,7 +119,7 @@ impl SlotState {
     /// Initially, it is completely empty.
     pub fn new(slot: Slot, epoch_info: Arc<ValidatorEpochInfo>) -> Self {
         Self {
-            votes: SlotVotes::new(epoch_info.validators().len()),
+            votes: SlotVotes::new(epoch_info.epoch_info().validators().len()),
             voted_stakes: SlotVotedStake::default(),
             certificates: SlotCertificates::default(),
             parents: BTreeMap::new(),
@@ -276,6 +276,7 @@ impl SlotState {
         if !self.sent_safe_to_skip
             && self
                 .epoch_info
+                .epoch_info()
                 .is_weak_quorum(self.voted_stakes.notar_or_skip - self.voted_stakes.top_notar)
             && self.votes.notar[self.epoch_info.own_id() as usize].is_some()
         {
@@ -287,23 +288,30 @@ impl SlotState {
             .notar_fallback
             .get(block_hash)
             .unwrap_or(&Stake::default());
-        if self.epoch_info.is_quorum(nf_stake + notar_stake) && !self.is_notar_fallback(block_hash)
+        if self
+            .epoch_info
+            .epoch_info()
+            .is_quorum(nf_stake + notar_stake)
+            && !self.is_notar_fallback(block_hash)
         {
             let mut votes = self.votes.notar_votes(block_hash);
             votes.extend(self.votes.notar_fallback_votes(block_hash));
-            let cert = NotarFallbackCert::new_unchecked(&votes, self.epoch_info.validators());
+            let cert =
+                NotarFallbackCert::new_unchecked(&votes, self.epoch_info.epoch_info().validators());
             new_certs.push(Cert::NotarFallback(cert));
         }
-        if self.epoch_info.is_quorum(notar_stake) && self.certificates.notar.is_none() {
+        if self.epoch_info.epoch_info().is_quorum(notar_stake) && self.certificates.notar.is_none()
+        {
             let votes = self.votes.notar_votes(block_hash);
-            let cert = NotarCert::new_unchecked(&votes, self.epoch_info.validators());
+            let cert = NotarCert::new_unchecked(&votes, self.epoch_info.epoch_info().validators());
             new_certs.push(Cert::Notar(cert));
         }
-        if self.epoch_info.is_strong_quorum(notar_stake)
+        if self.epoch_info.epoch_info().is_strong_quorum(notar_stake)
             && self.certificates.fast_finalize.is_none()
         {
             let votes = self.votes.notar_votes(block_hash);
-            let cert = FastFinalCert::new_unchecked(&votes, self.epoch_info.validators());
+            let cert =
+                FastFinalCert::new_unchecked(&votes, self.epoch_info.epoch_info().validators());
             new_certs.push(Cert::FastFinal(cert));
         }
 
@@ -329,11 +337,16 @@ impl SlotState {
             .notar
             .get(block_hash)
             .unwrap_or(&Stake::default());
-        if self.epoch_info.is_quorum(nf_stake + notar_stake) && !self.is_notar_fallback(block_hash)
+        if self
+            .epoch_info
+            .epoch_info()
+            .is_quorum(nf_stake + notar_stake)
+            && !self.is_notar_fallback(block_hash)
         {
             let mut votes = self.votes.notar_votes(block_hash);
             votes.extend(self.votes.notar_fallback_votes(block_hash));
-            let cert = NotarFallbackCert::new_unchecked(&votes, self.epoch_info.validators());
+            let cert =
+                NotarFallbackCert::new_unchecked(&votes, self.epoch_info.epoch_info().validators());
             new_certs.push(Cert::NotarFallback(cert));
         }
         (new_certs, SmallVec::new(), SmallVec::new())
@@ -366,15 +379,18 @@ impl SlotState {
             }
         }
         let total_skip_stake = self.voted_stakes.skip + self.voted_stakes.skip_fallback;
-        if self.epoch_info.is_quorum(total_skip_stake) && self.certificates.skip.is_none() {
+        if self.epoch_info.epoch_info().is_quorum(total_skip_stake)
+            && self.certificates.skip.is_none()
+        {
             let mut votes = self.votes.skip_votes();
             votes.extend(self.votes.skip_fallback_votes());
-            let cert = SkipCert::new_unchecked(&votes, self.epoch_info.validators());
+            let cert = SkipCert::new_unchecked(&votes, self.epoch_info.epoch_info().validators());
             new_certs.push(Cert::Skip(cert));
         }
         if !self.sent_safe_to_skip
             && self
                 .epoch_info
+                .epoch_info()
                 .is_weak_quorum(self.voted_stakes.notar_or_skip - self.voted_stakes.top_notar)
             && self.votes.notar[self.epoch_info.own_id() as usize].is_some()
         {
@@ -391,11 +407,14 @@ impl SlotState {
     fn count_finalize_stake(&mut self, stake: Stake) -> SlotStateOutputs {
         let mut new_certs = SmallVec::new();
         self.voted_stakes.finalize += stake;
-        if self.epoch_info.is_quorum(self.voted_stakes.finalize)
+        if self
+            .epoch_info
+            .epoch_info()
+            .is_quorum(self.voted_stakes.finalize)
             && self.certificates.finalize.is_none()
         {
             let votes: Vec<_> = self.votes.final_votes();
-            let cert = FinalCert::new_unchecked(&votes, self.epoch_info.validators());
+            let cert = FinalCert::new_unchecked(&votes, self.epoch_info.epoch_info().validators());
             new_certs.push(Cert::Final(cert));
         }
         (new_certs, SmallVec::new(), SmallVec::new())
@@ -474,11 +493,14 @@ impl SlotState {
             .get(&block_hash)
             .unwrap_or(&Stake::default());
         let skip_stake = self.voted_stakes.skip;
-        if !self.epoch_info.is_weakest_quorum(notar_stake) {
+        if !self.epoch_info.epoch_info().is_weakest_quorum(notar_stake) {
             return SafeToNotarStatus::AwaitingVotes;
         }
-        if !self.epoch_info.is_weak_quorum(notar_stake)
-            && !self.epoch_info.is_quorum(notar_stake + skip_stake)
+        if !self.epoch_info.epoch_info().is_weak_quorum(notar_stake)
+            && !self
+                .epoch_info
+                .epoch_info()
+                .is_quorum(notar_stake + skip_stake)
         {
             self.pending_safe_to_notar.insert(block_hash);
             return SafeToNotarStatus::AwaitingVotes;
@@ -609,7 +631,7 @@ mod tests {
             .enumerate()
             .map(|(i, sk)| Vote::new_notar(slot, hash.clone(), sk, i as ValidatorId))
             .collect();
-        let cert = NotarCert::try_new(&votes, epoch_info.validators()).unwrap();
+        let cert = NotarCert::try_new(&votes, epoch_info.epoch_info().validators()).unwrap();
         assert!(slot_state.certificates.notar.is_none());
         slot_state.add_cert(Cert::Notar(cert));
         assert!(slot_state.certificates.notar.is_some());
@@ -623,7 +645,7 @@ mod tests {
         let mut slot_state = SlotState::new(slot, epoch_info.clone());
         for (i, sk) in sks.iter().enumerate() {
             let vote = Vote::new_notar(slot, hash.clone(), sk, i as ValidatorId);
-            let voter_stake = epoch_info.validator(i as ValidatorId).stake;
+            let voter_stake = epoch_info.epoch_info().validator(i as ValidatorId).stake;
             assert!(slot_state.votes.notar[i].is_none());
             slot_state.add_vote(vote.clone(), voter_stake);
             let notar_vote = &slot_state.votes.notar[i];
@@ -648,7 +670,7 @@ mod tests {
 
         // 33% notar alone has no effect
         let vote = Vote::new_notar(slot, hash.clone(), &sks[1], 1);
-        let voter_stake = epoch_info.validator(1).stake;
+        let voter_stake = epoch_info.epoch_info().validator(1).stake;
         let (certs, events, blocks) = slot_state.add_vote(vote.clone(), voter_stake);
         assert!(certs.is_empty());
         assert!(events.is_empty());
@@ -656,7 +678,7 @@ mod tests {
 
         // additional 33% skip should lead to safe-to-notar
         let vote = Vote::new_skip(slot, &sks[0], 0);
-        let voter_stake = epoch_info.validator(0).stake;
+        let voter_stake = epoch_info.epoch_info().validator(0).stake;
         let (certs, events, blocks) = slot_state.add_vote(vote.clone(), voter_stake);
         assert!(certs.is_empty());
         assert_eq!(events.len(), 1);

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -375,7 +375,7 @@ mod tests {
 
     type A2A = TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>;
 
-    async fn start_votor() -> (A2A, mpsc::Sender<VotorEvent>, Arc<EpochInfo>) {
+    async fn start_votor() -> (A2A, mpsc::Sender<VotorEvent>, EpochInfo) {
         let (sks, epoch_info) = generate_validators(2);
         let mut a2a = generate_all2all_instances(epoch_info.validators.clone()).await;
         let (tx, rx) = mpsc::channel(100);

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -176,7 +176,7 @@ mod tests {
             });
         }
 
-        let epoch_info = Arc::new(EpochInfo::new(validators.clone()));
+        let epoch_info = EpochInfo::new(validators.clone());
         let mut rotors = Vec::new();
         for i in 0..count {
             let validator_epoch_info = Arc::new(ValidatorEpochInfo::new(i, epoch_info.clone()));

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -22,7 +22,7 @@ use rand::prelude::*;
 use self::sampling_strategy::PartitionSampler;
 pub use self::sampling_strategy::{FaitAccompli1Sampler, SamplingStrategy, StakeWeightedSampler};
 use super::Disseminator;
-use crate::consensus::EpochInfo;
+use crate::consensus::ValidatorEpochInfo;
 use crate::network::{Network, ShredNetwork};
 use crate::shredder::{Shred, TOTAL_SHREDS};
 use crate::{Slot, ValidatorId};
@@ -31,7 +31,7 @@ use crate::{Slot, ValidatorId};
 pub struct Rotor<N: Network, S: SamplingStrategy> {
     network: N,
     sampler: S,
-    epoch_info: Arc<EpochInfo>,
+    epoch_info: Arc<ValidatorEpochInfo>,
 }
 
 impl<N: Network> Rotor<N, StakeWeightedSampler> {
@@ -39,7 +39,7 @@ impl<N: Network> Rotor<N, StakeWeightedSampler> {
     ///
     /// Contact information for all validators is provided in `validators`.
     /// Provided `network` will be used to send and receive shreds.
-    pub fn new(network: N, epoch_info: Arc<EpochInfo>) -> Self {
+    pub fn new(network: N, epoch_info: Arc<ValidatorEpochInfo>) -> Self {
         let validators = epoch_info.validators.clone();
         let sampler = StakeWeightedSampler::new(validators);
         Self {
@@ -55,7 +55,7 @@ impl<N: Network> Rotor<N, FaitAccompli1Sampler<PartitionSampler>> {
     ///
     /// Contact information for all validators is provided in `validators`.
     /// Provided `network` will be used to send and receive shreds.
-    pub fn new_fa1(network: N, epoch_info: Arc<EpochInfo>) -> Self {
+    pub fn new_fa1(network: N, epoch_info: Arc<ValidatorEpochInfo>) -> Self {
         let validators = epoch_info.validators.clone();
         let sampler =
             FaitAccompli1Sampler::new_with_partition_fallback(validators, TOTAL_SHREDS as u64);
@@ -148,6 +148,7 @@ mod tests {
 
     use super::*;
     use crate::ValidatorInfo;
+    use crate::consensus::EpochInfo;
     use crate::crypto::aggsig;
     use crate::crypto::signature::SecretKey;
     use crate::network::{UdpNetwork, dontcare_sockaddr, localhost_ip_sockaddr};
@@ -175,11 +176,12 @@ mod tests {
             });
         }
 
+        let epoch_info = Arc::new(EpochInfo::new(validators.clone()));
         let mut rotors = Vec::new();
         for i in 0..count {
-            let epoch_info = Arc::new(EpochInfo::new(i, validators.clone()));
+            let validator_epoch_info = Arc::new(ValidatorEpochInfo::new(i, epoch_info.clone()));
             let network = UdpNetwork::new(base_port + i as u16);
-            rotors.push(Rotor::new(network, epoch_info));
+            rotors.push(Rotor::new(network, validator_epoch_info));
         }
         (sks, rotors)
     }

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -184,7 +184,8 @@ mod tests {
         let epoch_info = EpochInfo::new(validators.clone());
         let mut rotors = Vec::new();
         for i in 0..count {
-            let validator_epoch_info = Arc::new(ValidatorEpochInfo::new(ValidatorId::new(i, epoch_info.clone()));
+            let v = ValidatorId::new(i);
+            let validator_epoch_info = Arc::new(ValidatorEpochInfo::new(v, epoch_info.clone()));
             let network = UdpNetwork::new(base_port + i as u16);
             rotors.push(Rotor::new(network, validator_epoch_info));
         }

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -40,7 +40,7 @@ impl<N: Network> Rotor<N, StakeWeightedSampler> {
     /// Contact information for all validators is provided in `validators`.
     /// Provided `network` will be used to send and receive shreds.
     pub fn new(network: N, epoch_info: Arc<ValidatorEpochInfo>) -> Self {
-        let validators = epoch_info.validators().to_vec();
+        let validators = epoch_info.epoch_info().validators().to_vec();
         let sampler = StakeWeightedSampler::new(validators);
         Self {
             network,
@@ -56,7 +56,7 @@ impl<N: Network> Rotor<N, FaitAccompli1Sampler<PartitionSampler>> {
     /// Contact information for all validators is provided in `validators`.
     /// Provided `network` will be used to send and receive shreds.
     pub fn new_fa1(network: N, epoch_info: Arc<ValidatorEpochInfo>) -> Self {
-        let validators = epoch_info.validators().to_vec();
+        let validators = epoch_info.epoch_info().validators().to_vec();
         let sampler =
             FaitAccompli1Sampler::new_with_partition_fallback(validators, TOTAL_SHREDS as u64);
         Self {
@@ -80,14 +80,18 @@ where
     /// Sends the shred to the correct relay.
     async fn send_as_leader(&self, shred: &Shred) -> std::io::Result<()> {
         let relay = self.sample_relay(shred.payload().header.slot, shred.payload().index_in_slot());
-        let v = self.epoch_info.validator(relay);
+        let v = self.epoch_info.epoch_info().validator(relay);
         self.network.send(shred, v.disseminator_address).await
     }
 
     /// Broadcasts a shred to all validators except for the leader and itself.
     /// Does nothing if we are not the dedicated relay for this shred.
     async fn broadcast_if_relay(&self, shred: &Shred) -> std::io::Result<()> {
-        let leader = self.epoch_info.leader(shred.payload().header.slot).id;
+        let leader = self
+            .epoch_info
+            .epoch_info()
+            .leader(shred.payload().header.slot)
+            .id;
 
         // do nothing if we are not the relay
         let relay = self.sample_relay(shred.payload().header.slot, shred.payload().index_in_slot());
@@ -98,6 +102,7 @@ where
         // otherwise, broadcast
         let to = self
             .epoch_info
+            .epoch_info()
             .validators()
             .iter()
             .filter(|v| v.id != leader && v.id != relay)

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -90,7 +90,11 @@ where
             .get_tree(shred.payload().header.slot, shred.payload().index_in_slot())
             .await;
         let root = tree.get_root();
-        let addr = self.epoch_info.validator(root).disseminator_address;
+        let addr = self
+            .epoch_info
+            .epoch_info()
+            .validator(root)
+            .disseminator_address;
         self.network.send(shred, addr).await
     }
 
@@ -104,10 +108,12 @@ where
         let tree = self
             .get_tree(shred.payload().header.slot, shred.payload().index_in_slot())
             .await;
-        let addrs = tree
-            .get_children()
-            .iter()
-            .map(|child| self.epoch_info.validator(*child).disseminator_address);
+        let addrs = tree.get_children().iter().map(|child| {
+            self.epoch_info
+                .epoch_info()
+                .validator(*child)
+                .disseminator_address
+        });
         self.network.send_to_many(shred, addrs).await?;
         Ok(())
     }
@@ -119,7 +125,7 @@ where
             return tree;
         }
         let tree = TurbineTree::new(
-            self.epoch_info.validators(),
+            self.epoch_info.epoch_info().validators(),
             self.fanout,
             self.epoch_info.own_id(),
             slot,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use self::disseminator::Disseminator;
 use self::types::Slot;
 pub use self::validator::Validator;
 use crate::all2all::TrivialAll2All;
-use crate::consensus::{ConsensusMessage, EpochInfo};
+use crate::consensus::{ConsensusMessage, EpochInfo, ValidatorEpochInfo};
 use crate::crypto::merkle::BlockHash;
 use crate::crypto::signature::SecretKey;
 use crate::disseminator::Rotor;
@@ -152,11 +152,12 @@ pub fn create_test_nodes(count: u64) -> Vec<TestNode> {
     }
 
     // turn validator info into actual nodes
+    let shared_epoch = Arc::new(EpochInfo::new(validators.clone()));
     networks
         .into_iter()
         .enumerate()
         .map(|(id, network)| {
-            let epoch_info = Arc::new(EpochInfo::new(id as u64, validators.clone()));
+            let epoch_info = Arc::new(ValidatorEpochInfo::new(id as u64, shared_epoch.clone()));
             let all2all = TrivialAll2All::new(validators.clone(), network.all2all);
             let disseminator = Rotor::new(network.disseminator, epoch_info.clone());
             let repair_network = network.repair;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub fn create_test_nodes(count: u64) -> Vec<TestNode> {
     }
 
     // turn validator info into actual nodes
-    let shared_epoch = Arc::new(EpochInfo::new(validators.clone()));
+    let shared_epoch = EpochInfo::new(validators.clone());
     networks
         .into_iter()
         .enumerate()

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -179,7 +179,11 @@ where
         response: RepairResponse,
         validator: ValidatorId,
     ) -> std::io::Result<()> {
-        let to = self.epoch_info.validator(validator).repair_response_address;
+        let to = self
+            .epoch_info
+            .epoch_info()
+            .validator(validator)
+            .repair_response_address;
         self.network.send(&response, to).await
     }
 }
@@ -213,7 +217,7 @@ where
         network: N,
         epoch_info: Arc<ValidatorEpochInfo>,
     ) -> Self {
-        let validators = epoch_info.validators().to_vec();
+        let validators = epoch_info.epoch_info().validators().to_vec();
         let sampler = StakeWeightedSampler::new(validators);
         Self {
             blockstore,

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -18,7 +18,7 @@ use log::{debug, trace, warn};
 use tokio::sync::RwLock;
 use wincode::{SchemaRead, SchemaWrite};
 
-use crate::consensus::{Blockstore, DELTA, EpochInfo, Pool};
+use crate::consensus::{Blockstore, DELTA, Pool, ValidatorEpochInfo};
 use crate::crypto::merkle::{DoubleMerkleProof, DoubleMerkleTree, MerkleRoot, SliceRoot};
 use crate::crypto::{Hash, hash};
 use crate::disseminator::rotor::{SamplingStrategy, StakeWeightedSampler};
@@ -96,7 +96,7 @@ impl RepairResponse {
 /// This is separated from [`Repair`] to handle repair requests and responses on separate sockets and tokio tasks.
 /// This allows us to prioritise repairing blocks for ourselves over serving repair requests for other nodes.
 pub struct RepairRequestHandler<N: Network> {
-    epoch_info: Arc<EpochInfo>,
+    epoch_info: Arc<ValidatorEpochInfo>,
     blockstore: Arc<RwLock<Box<dyn Blockstore + Send + Sync>>>,
     network: N,
 }
@@ -110,7 +110,7 @@ where
     /// Given `network` instance will be used for receiving repair requests and sending repair responses.
     /// The blockstore will be used to handle the repair requests.
     pub fn new(
-        epoch_info: Arc<EpochInfo>,
+        epoch_info: Arc<ValidatorEpochInfo>,
         blockstore: Arc<RwLock<Box<dyn Blockstore + Send + Sync>>>,
         network: N,
     ) -> Self {
@@ -196,7 +196,7 @@ pub struct Repair<N: Network> {
     request_timeouts: BinaryHeap<(Instant, Hash)>,
     network: N,
     sampler: StakeWeightedSampler,
-    epoch_info: Arc<EpochInfo>,
+    epoch_info: Arc<ValidatorEpochInfo>,
 }
 
 impl<N> Repair<N>
@@ -211,7 +211,7 @@ where
         blockstore: Arc<RwLock<Box<dyn Blockstore + Send + Sync>>>,
         pool: Arc<RwLock<Box<dyn Pool + Send + Sync>>>,
         network: N,
-        epoch_info: Arc<EpochInfo>,
+        epoch_info: Arc<ValidatorEpochInfo>,
     ) -> Self {
         let validators = epoch_info.validators.clone();
         let sampler = StakeWeightedSampler::new(validators);
@@ -477,7 +477,6 @@ mod tests {
         let v1 = epoch_info.validators.get_mut(1).unwrap();
         v1.repair_request_address = localhost_ip_sockaddr(2);
         v1.repair_response_address = localhost_ip_sockaddr(3);
-        epoch_info.own_id = 1;
 
         let v1_repair_request_network = core
             .join_unlimited(v1.repair_request_address.port() as u64)
@@ -487,6 +486,7 @@ mod tests {
             .await;
 
         let epoch_info = Arc::new(epoch_info);
+        let epoch_info = Arc::new(ValidatorEpochInfo::new(1, epoch_info));
 
         // set up blockstore
         let (votor_tx, votor_rx) = tokio::sync::mpsc::channel(100);

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -458,8 +458,7 @@ mod tests {
         SecretKey,
     ) {
         // create EpochInfo for 2 validators and the corresponding network
-        let (_, epoch_info) = generate_validators(2);
-        let mut epoch_info = Arc::try_unwrap(epoch_info).unwrap();
+        let (_, mut epoch_info) = generate_validators(2);
         let leader_key = SecretKey::new(&mut rand::rng());
         let v0 = epoch_info.validators.get_mut(0).unwrap();
         v0.pubkey = leader_key.to_pk();
@@ -485,7 +484,6 @@ mod tests {
             .join_unlimited(v1.repair_response_address.port() as u64)
             .await;
 
-        let epoch_info = Arc::new(epoch_info);
         let epoch_info = Arc::new(ValidatorEpochInfo::new(1, epoch_info));
 
         // set up blockstore

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -58,7 +58,7 @@ pub fn generate_validators(num_validators: u64) -> (Vec<SecretKey>, Arc<EpochInf
             repair_response_address: localhost_ip_sockaddr(0),
         });
     }
-    let epoch_info = Arc::new(EpochInfo::new(0, validators));
+    let epoch_info = Arc::new(EpochInfo::new(validators));
     (voting_sks, epoch_info)
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -38,8 +38,8 @@ pub enum PingOrPong {
 
 /// Generates [`ValidatorInfo`] for the given number of validators.
 ///
-/// Returns the voting secret keys of all validators and the [`EpochInfo`] of validator 0.
-pub fn generate_validators(num_validators: u64) -> (Vec<SecretKey>, Arc<EpochInfo>) {
+/// Returns the voting secret keys of all validators and the shared [`EpochInfo`].
+pub fn generate_validators(num_validators: u64) -> (Vec<SecretKey>, EpochInfo) {
     let mut rng = rand::rng();
     let mut sks = Vec::new();
     let mut voting_sks = Vec::new();
@@ -58,7 +58,7 @@ pub fn generate_validators(num_validators: u64) -> (Vec<SecretKey>, Arc<EpochInf
             repair_response_address: localhost_ip_sockaddr(0),
         });
     }
-    let epoch_info = Arc::new(EpochInfo::new(validators));
+    let epoch_info = EpochInfo::new(validators);
     (voting_sks, epoch_info)
 }
 


### PR DESCRIPTION
So far, we only had a type `EpochInfo` that contains the global state of the validator set for a specific epoch, but also always requires an `own_id` to be set. We split this into an `EpochInfo` type that only holds the global state and a `ValidatorEpochInfo` type that wraps the `EpochInfo` and corresponds to a specific validator.