### PR TITLE
refactor: cleanup sampling strategies API

### DIFF
--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -12,7 +12,7 @@ use alpenglow::consensus::{Alpenglow, ConsensusMessage, EpochInfo, ValidatorEpoc
 use alpenglow::crypto::aggsig;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Rotor;
-use alpenglow::disseminator::rotor::StakeWeightedSampler;
+use alpenglow::disseminator::rotor::{IidQuorumSampler, StakeWeightedSampler};
 use alpenglow::network::UdpNetwork;
 use alpenglow::shredder::Shred;
 use alpenglow::{Stake, Transaction, ValidatorId, ValidatorInfo, logging};
@@ -111,7 +111,7 @@ async fn main() -> Result<()> {
 
 type Node = Alpenglow<
     TrivialAll2All<UdpNetwork<ConsensusMessage, ConsensusMessage>>,
-    Rotor<UdpNetwork<Shred, Shred>, StakeWeightedSampler>,
+    Rotor<UdpNetwork<Shred, Shred>, IidQuorumSampler<StakeWeightedSampler>>,
     UdpNetwork<Transaction, Transaction>,
 >;
 

--- a/src/bin/performance_test.rs
+++ b/src/bin/performance_test.rs
@@ -10,7 +10,7 @@ use alpenglow::consensus::{ConsensusMessage, EpochInfo, ValidatorEpochInfo};
 use alpenglow::crypto::aggsig;
 use alpenglow::crypto::signature::SecretKey;
 use alpenglow::disseminator::Rotor;
-use alpenglow::disseminator::rotor::StakeWeightedSampler;
+use alpenglow::disseminator::rotor::{IidQuorumSampler, StakeWeightedSampler};
 use alpenglow::network::simulated::SimulatedNetworkCore;
 use alpenglow::network::{SimulatedNetwork, UdpNetwork, localhost_ip_sockaddr};
 use alpenglow::shredder::Shred;
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
 
 type TestNode = Alpenglow<
     TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>,
-    Rotor<SimulatedNetwork<Shred, Shred>, StakeWeightedSampler>,
+    Rotor<SimulatedNetwork<Shred, Shred>, IidQuorumSampler<StakeWeightedSampler>>,
     UdpNetwork<Transaction, Transaction>,
 >;
 

--- a/src/bin/simulations/alpenglow/bandwidth.rs
+++ b/src/bin/simulations/alpenglow/bandwidth.rs
@@ -19,7 +19,7 @@ use std::fs::File;
 use std::sync::{Arc, Mutex};
 
 use alpenglow::ValidatorInfo;
-use alpenglow::disseminator::rotor::SamplingStrategy;
+use alpenglow::disseminator::rotor::{QuorumSamplingStrategy, SamplingStrategy};
 use alpenglow::shredder::MAX_DATA_PER_SHRED;
 use rand::prelude::*;
 
@@ -27,7 +27,7 @@ use rand::prelude::*;
 ///
 /// This is a wrapper around [`WorkloadTest`].
 /// It augments the workload test with bandwidth information.
-pub struct BandwidthTest<L: SamplingStrategy, R: SamplingStrategy> {
+pub struct BandwidthTest<L: SamplingStrategy, R: QuorumSamplingStrategy> {
     leader_bandwidth: u64,
     bandwidths: Vec<u64>,
     workload_test: WorkloadTest<L, R>,
@@ -37,17 +37,16 @@ pub struct BandwidthTest<L: SamplingStrategy, R: SamplingStrategy> {
 ///
 /// This simulates the distribution of shreds via Rotor.
 /// It tracks the workload (number of shreds/datagrams sent) for each validator.
-pub struct WorkloadTest<L: SamplingStrategy, R: SamplingStrategy> {
+pub struct WorkloadTest<L: SamplingStrategy, R: QuorumSamplingStrategy> {
     validators: Vec<ValidatorInfo>,
     leader_sampler: L,
     rotor_sampler: R,
-    num_shreds: usize,
 
     leader_workload: u64,
     workload: Vec<u64>,
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> BandwidthTest<L, R> {
+impl<L: SamplingStrategy, R: QuorumSamplingStrategy> BandwidthTest<L, R> {
     /// Creates a new instance with the given stake and bandwidth distribution.
     pub fn new(
         validators: &[ValidatorInfo],
@@ -55,10 +54,9 @@ impl<L: SamplingStrategy, R: SamplingStrategy> BandwidthTest<L, R> {
         bandwidths: Vec<u64>,
         leader_sampler: L,
         rotor_sampler: R,
-        num_shreds: usize,
     ) -> Self {
         let workload_test =
-            WorkloadTest::new(validators, leader_sampler, rotor_sampler, num_shreds);
+            WorkloadTest::new(validators, leader_sampler, rotor_sampler);
         Self::from_workload_test(validators, leader_bandwidth, bandwidths, workload_test)
     }
 
@@ -76,11 +74,9 @@ impl<L: SamplingStrategy, R: SamplingStrategy> BandwidthTest<L, R> {
         }
     }
 
-    /// Sets the number of shreds per slice to `num_shreds`.
-    ///
-    /// Should usually call [`BandwidthTest::reset`] after this.
-    pub fn set_num_shreds(&mut self, num_shreds: usize) {
-        self.workload_test.set_num_shreds(num_shreds);
+    /// Returns the number of shreds per slice (quorum size from the sampler).
+    pub fn num_shreds(&self) -> usize {
+        self.workload_test.num_shreds()
     }
 
     /// Runs multiple iterations of the workload test.
@@ -120,7 +116,7 @@ impl<L: SamplingStrategy, R: SamplingStrategy> BandwidthTest<L, R> {
                 stake_distribution.to_string(),
                 sampling_strategy.to_string(),
                 self.leader_bandwidth.to_string(),
-                self.workload_test.num_shreds.to_string(),
+                self.workload_test.num_shreds().to_string(),
                 (min_supported_bandwidth / 2.0).to_string(),
             ])
             .unwrap();
@@ -162,7 +158,7 @@ impl<L: SamplingStrategy, R: SamplingStrategy> BandwidthTest<L, R> {
                     stake_distribution.to_string(),
                     sampling_strategy.to_string(),
                     self.leader_bandwidth.to_string(),
-                    self.workload_test.num_shreds.to_string(),
+                    self.workload_test.num_shreds().to_string(),
                     validator.to_string(),
                     32_270_000.0.to_string(),
                     bandwidth.to_string(),
@@ -180,31 +176,27 @@ impl<L: SamplingStrategy, R: SamplingStrategy> BandwidthTest<L, R> {
     }
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> WorkloadTest<L, R> {
+impl<L: SamplingStrategy, R: QuorumSamplingStrategy> WorkloadTest<L, R> {
     /// Creates a new instance with the given stake distribution.
     pub fn new(
         validators: &[ValidatorInfo],
         leader_sampler: L,
         rotor_sampler: R,
-        num_shreds: usize,
     ) -> Self {
         let num_val = validators.len();
         Self {
             validators: validators.to_vec(),
             leader_sampler,
             rotor_sampler,
-            num_shreds,
 
             leader_workload: 0,
             workload: vec![0; num_val],
         }
     }
 
-    /// Sets the number of shreds per slice to `num_shreds`.
-    ///
-    /// Should usually call [`WorkloadTest::reset`] after this.
-    pub fn set_num_shreds(&mut self, num_shreds: usize) {
-        self.num_shreds = num_shreds;
+    /// Returns the number of shreds per slice (quorum size from the sampler).
+    pub fn num_shreds(&self) -> usize {
+        self.rotor_sampler.quorum_size()
     }
 
     /// Simulates distribution of `slices` slices via Rotor.
@@ -221,10 +213,11 @@ impl<L: SamplingStrategy, R: SamplingStrategy> WorkloadTest<L, R> {
     ///
     /// Adds the workload from this iteration to the running totals.
     pub fn run_one(&mut self, rng: &mut impl Rng) {
+        let num_shreds = self.rotor_sampler.quorum_size();
         let leader = self.leader_sampler.sample(rng);
-        self.leader_workload += self.num_shreds as u64;
-        self.workload[leader.as_index()] += self.num_shreds as u64;
-        let relays = self.rotor_sampler.sample_multiple(self.num_shreds, rng);
+        self.leader_workload += num_shreds as u64;
+        self.workload[leader.as_index()] += num_shreds as u64;
+        let relays = self.rotor_sampler.sample_quorum(rng);
         for relay in relays {
             if leader == relay {
                 self.workload[relay.as_index()] += self.validators.len() as u64 - 1;

--- a/src/bin/simulations/alpenglow/bandwidth.rs
+++ b/src/bin/simulations/alpenglow/bandwidth.rs
@@ -55,8 +55,7 @@ impl<L: SamplingStrategy, R: QuorumSamplingStrategy> BandwidthTest<L, R> {
         leader_sampler: L,
         rotor_sampler: R,
     ) -> Self {
-        let workload_test =
-            WorkloadTest::new(validators, leader_sampler, rotor_sampler);
+        let workload_test = WorkloadTest::new(validators, leader_sampler, rotor_sampler);
         Self::from_workload_test(validators, leader_bandwidth, bandwidths, workload_test)
     }
 
@@ -178,11 +177,7 @@ impl<L: SamplingStrategy, R: QuorumSamplingStrategy> BandwidthTest<L, R> {
 
 impl<L: SamplingStrategy, R: QuorumSamplingStrategy> WorkloadTest<L, R> {
     /// Creates a new instance with the given stake distribution.
-    pub fn new(
-        validators: &[ValidatorInfo],
-        leader_sampler: L,
-        rotor_sampler: R,
-    ) -> Self {
+    pub fn new(validators: &[ValidatorInfo], leader_sampler: L, rotor_sampler: R) -> Self {
         let num_val = validators.len();
         Self {
             validators: validators.to_vec(),

--- a/src/bin/simulations/alpenglow/bandwidth.rs
+++ b/src/bin/simulations/alpenglow/bandwidth.rs
@@ -73,11 +73,6 @@ impl<L: SamplingStrategy, R: QuorumSamplingStrategy> BandwidthTest<L, R> {
         }
     }
 
-    /// Returns the number of shreds per slice (quorum size from the sampler).
-    pub fn num_shreds(&self) -> usize {
-        self.workload_test.num_shreds()
-    }
-
     /// Runs multiple iterations of the workload test.
     ///
     /// Each iteration corresponds to distributing one slice, sampling leader

--- a/src/bin/simulations/alpenglow/latency.rs
+++ b/src/bin/simulations/alpenglow/latency.rs
@@ -8,7 +8,9 @@
 use std::hash::Hash;
 use std::marker::PhantomData;
 
-use alpenglow::disseminator::rotor::{QuorumSamplingStrategy, SamplingStrategy, StakeWeightedSampler};
+use alpenglow::disseminator::rotor::{
+    QuorumSamplingStrategy, SamplingStrategy, StakeWeightedSampler,
+};
 use rand::prelude::*;
 
 use crate::discrete_event_simulator::{

--- a/src/bin/simulations/alpenglow/latency.rs
+++ b/src/bin/simulations/alpenglow/latency.rs
@@ -8,7 +8,7 @@
 use std::hash::Hash;
 use std::marker::PhantomData;
 
-use alpenglow::disseminator::rotor::{SamplingStrategy, StakeWeightedSampler};
+use alpenglow::disseminator::rotor::{QuorumSamplingStrategy, SamplingStrategy, StakeWeightedSampler};
 use rand::prelude::*;
 
 use crate::discrete_event_simulator::{
@@ -23,12 +23,12 @@ const VOTE_SIZE: usize = 128 /* sig */ + 64 /* slot, hash, flags */;
 const CERT_SIZE: usize = 128 /* sig */ + 256 /* bitmap */ + 64 /* slot, hash, flags */;
 
 /// Marker type for the Alpenglow latency simulation.
-pub struct AlpenglowLatencySimulation<L: SamplingStrategy, R: SamplingStrategy> {
+pub struct AlpenglowLatencySimulation<L: SamplingStrategy, R: QuorumSamplingStrategy> {
     _leader_sampler: PhantomData<L>,
     _rotor_sampler: PhantomData<R>,
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> Protocol for AlpenglowLatencySimulation<L, R> {
+impl<L: SamplingStrategy, R: QuorumSamplingStrategy> Protocol for AlpenglowLatencySimulation<L, R> {
     type Event = LatencyEvent;
     type Stage = LatencyTestStage;
     type Params = LatencySimParams;
@@ -144,9 +144,12 @@ impl Event for LatencyEvent {
         match self {
             Self::Block => {
                 // TODO: find better way of integrating sub-protocol
+                let rotor_shreds = instance.params.rotor_params.shreds;
                 let builder = RotorInstanceBuilder::new(
-                    StakeWeightedSampler::new(environment.validators.clone()),
-                    StakeWeightedSampler::new(environment.validators.clone()),
+                    StakeWeightedSampler::new(environment.validators.clone())
+                        .into_quorum_strategy(1),
+                    StakeWeightedSampler::new(environment.validators.clone())
+                        .into_quorum_strategy(rotor_shreds),
                     instance.params.rotor_params,
                 );
                 let engine = SimulationEngine::<RotorLatencySimulation<_, _>>::new(
@@ -193,12 +196,12 @@ impl LatencySimParams {
 }
 
 /// A builder for Alpenglow latency simulation instances.
-pub struct LatencySimInstanceBuilder<L: SamplingStrategy, R: SamplingStrategy> {
+pub struct LatencySimInstanceBuilder<L: SamplingStrategy, R: QuorumSamplingStrategy> {
     rotor_builder: RotorInstanceBuilder<L, R>,
     params: LatencySimParams,
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> LatencySimInstanceBuilder<L, R> {
+impl<L: SamplingStrategy, R: QuorumSamplingStrategy> LatencySimInstanceBuilder<L, R> {
     /// Creates a new builder instance from a builder for Rotor instances.
     pub fn new(rotor_builder: RotorInstanceBuilder<L, R>, params: LatencySimParams) -> Self {
         Self {
@@ -208,7 +211,7 @@ impl<L: SamplingStrategy, R: SamplingStrategy> LatencySimInstanceBuilder<L, R> {
     }
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> Builder for LatencySimInstanceBuilder<L, R> {
+impl<L: SamplingStrategy, R: QuorumSamplingStrategy> Builder for LatencySimInstanceBuilder<L, R> {
     type Params = LatencySimParams;
     type Instance = LatencySimInstance;
 

--- a/src/bin/simulations/main.rs
+++ b/src/bin/simulations/main.rs
@@ -202,12 +202,12 @@ fn run_tests_for_stake_distribution(
         if sampling_strat == "uniform" {
             let leader_sampler =
                 UniformSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
-            let ping_leader_sampler =
-                UniformSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
-            let rotor_sampler =
-                UniformSampler::new(validators.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
-            let ping_rotor_sampler =
-                UniformSampler::new(validators_with_pings.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
+            let ping_leader_sampler = UniformSampler::new(validators_with_pings.clone())
+                .into_quorum_strategy(NUM_LEADERS);
+            let rotor_sampler = UniformSampler::new(validators.clone())
+                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
+            let ping_rotor_sampler = UniformSampler::new(validators_with_pings.clone())
+                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
             run_tests(
                 &test_name,
                 &validators,
@@ -220,12 +220,12 @@ fn run_tests_for_stake_distribution(
         } else if sampling_strat == "stake_weighted" {
             let leader_sampler =
                 StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
-            let ping_leader_sampler =
-                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
-            let rotor_sampler =
-                StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
-            let ping_rotor_sampler =
-                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
+            let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
+                .into_quorum_strategy(NUM_LEADERS);
+            let rotor_sampler = StakeWeightedSampler::new(validators.clone())
+                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
+            let ping_rotor_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
+                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
             run_tests(
                 &test_name,
                 &validators,
@@ -238,8 +238,8 @@ fn run_tests_for_stake_distribution(
         } else if sampling_strat == "fa1_iid" {
             let leader_sampler =
                 StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
-            let ping_leader_sampler =
-                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
+            let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
+                .into_quorum_strategy(NUM_LEADERS);
             let rotor_sampler = FaitAccompli1Sampler::new_with_stake_weighted_fallback(
                 validators.clone(),
                 TOTAL_SHREDS_FA1,
@@ -260,8 +260,8 @@ fn run_tests_for_stake_distribution(
         } else if sampling_strat == "fa2" {
             let leader_sampler =
                 StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
-            let ping_leader_sampler =
-                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
+            let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
+                .into_quorum_strategy(NUM_LEADERS);
             let rotor_sampler = FaitAccompli2Sampler::new(validators.clone(), TOTAL_SHREDS_FA1);
             let ping_rotor_sampler =
                 FaitAccompli2Sampler::new(validators_with_pings.clone(), TOTAL_SHREDS_FA1);
@@ -277,8 +277,8 @@ fn run_tests_for_stake_distribution(
         } else if sampling_strat == "fa1_partition" {
             let leader_sampler =
                 StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
-            let ping_leader_sampler =
-                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
+            let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
+                .into_quorum_strategy(NUM_LEADERS);
             let rotor_sampler = FaitAccompli1Sampler::new_with_partition_fallback(
                 validators.clone(),
                 TOTAL_SHREDS_FA1,
@@ -299,12 +299,15 @@ fn run_tests_for_stake_distribution(
         } else if sampling_strat == "decaying_acceptance" {
             let leader_sampler =
                 StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
-            let ping_leader_sampler =
-                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
+            let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
+                .into_quorum_strategy(NUM_LEADERS);
             let rotor_sampler =
                 DecayingAcceptanceSampler::new(validators.clone(), 3.0, TOTAL_SHREDS_FA1 as usize);
-            let ping_rotor_sampler =
-                DecayingAcceptanceSampler::new(validators_with_pings.clone(), 3.0, TOTAL_SHREDS_FA1 as usize);
+            let ping_rotor_sampler = DecayingAcceptanceSampler::new(
+                validators_with_pings.clone(),
+                3.0,
+                TOTAL_SHREDS_FA1 as usize,
+            );
             run_tests(
                 &test_name,
                 &validators,
@@ -317,12 +320,12 @@ fn run_tests_for_stake_distribution(
         } else if sampling_strat == "turbine" {
             let leader_sampler =
                 TurbineSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
-            let ping_leader_sampler =
-                TurbineSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
-            let rotor_sampler =
-                TurbineSampler::new(validators.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
-            let ping_rotor_sampler =
-                TurbineSampler::new(validators_with_pings.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
+            let ping_leader_sampler = TurbineSampler::new(validators_with_pings.clone())
+                .into_quorum_strategy(NUM_LEADERS);
+            let rotor_sampler = TurbineSampler::new(validators.clone())
+                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
+            let ping_rotor_sampler = TurbineSampler::new(validators_with_pings.clone())
+                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
             run_tests(
                 &test_name,
                 &validators,

--- a/src/bin/simulations/main.rs
+++ b/src/bin/simulations/main.rs
@@ -119,9 +119,9 @@ fn main() -> Result<()> {
     crate::ryse::run_robustness_tests();
     crate::pyjama::run_robustness_tests();
 
-    for k in [64, 128, 256, 512] {
-        run_ryse_robustness_test(k)?;
-        run_pyjama_robustness_test(k)?;
+    for k in SHRED_COUNTS {
+        run_ryse_robustness_test(k as u64)?;
+        run_pyjama_robustness_test(k as u64)?;
     }
 
     if RUN_BANDWIDTH_TESTS {

--- a/src/bin/simulations/main.rs
+++ b/src/bin/simulations/main.rs
@@ -75,7 +75,7 @@ use crate::ryse::{
     RyseInstanceBuilder, RyseLatencySimulation, RyseParameters, run_ryse_robustness_test,
 };
 
-const RUN_BANDWIDTH_TESTS: bool = false;
+const RUN_BANDWIDTH_TESTS: bool = true;
 const RUN_LATENCY_TESTS: bool = true;
 const RUN_ROTOR_ROBUSTNESS_TESTS: bool = true;
 
@@ -95,6 +95,8 @@ const MAX_BANDWIDTHS: [u64; 4] = [
     10_000_000_000,  // 10 Gbps
     100_000_000_000, // 100 Gbps
 ];
+
+const SHRED_COUNTS: [usize; 4] = [64, 128, 256, 512];
 
 const TOTAL_SHREDS_FA1: u64 = 64;
 const SHRED_COMBINATIONS: [(usize, usize); 1] = [
@@ -204,137 +206,150 @@ fn run_tests_for_stake_distribution(
                 UniformSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
             let ping_leader_sampler = UniformSampler::new(validators_with_pings.clone())
                 .into_quorum_strategy(NUM_LEADERS);
-            let rotor_sampler = UniformSampler::new(validators.clone())
-                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
             let ping_rotor_sampler = UniformSampler::new(validators_with_pings.clone())
-                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
-            run_tests(
-                &test_name,
-                &validators,
-                &validators_and_ping_servers,
-                &leader_sampler,
-                &rotor_sampler,
-                &ping_leader_sampler,
-                &ping_rotor_sampler,
-            )?;
+                .into_quorum_strategy(NUM_LEADERS);
+            for shreds in SHRED_COUNTS {
+                let rotor_sampler =
+                    UniformSampler::new(validators.clone()).into_quorum_strategy(shreds);
+                run_tests(
+                    &format!("{test_name}-{shreds}"),
+                    &validators,
+                    &validators_and_ping_servers,
+                    &leader_sampler,
+                    &rotor_sampler,
+                    &ping_leader_sampler,
+                    &ping_rotor_sampler,
+                )?;
+            }
         } else if sampling_strat == "stake_weighted" {
             let leader_sampler =
                 StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
             let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
                 .into_quorum_strategy(NUM_LEADERS);
-            let rotor_sampler = StakeWeightedSampler::new(validators.clone())
-                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
             let ping_rotor_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
-                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
-            run_tests(
-                &test_name,
-                &validators,
-                &validators_and_ping_servers,
-                &leader_sampler,
-                &rotor_sampler,
-                &ping_leader_sampler,
-                &ping_rotor_sampler,
-            )?;
+                .into_quorum_strategy(NUM_LEADERS);
+            for shreds in SHRED_COUNTS {
+                let rotor_sampler =
+                    StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(shreds);
+                run_tests(
+                    &format!("{test_name}-{shreds}"),
+                    &validators,
+                    &validators_and_ping_servers,
+                    &leader_sampler,
+                    &rotor_sampler,
+                    &ping_leader_sampler,
+                    &ping_rotor_sampler,
+                )?;
+            }
         } else if sampling_strat == "fa1_iid" {
             let leader_sampler =
                 StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
             let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
                 .into_quorum_strategy(NUM_LEADERS);
-            let rotor_sampler = FaitAccompli1Sampler::new_with_stake_weighted_fallback(
-                validators.clone(),
-                TOTAL_SHREDS_FA1,
-            );
             let ping_rotor_sampler = FaitAccompli1Sampler::new_with_stake_weighted_fallback(
                 validators_with_pings.clone(),
                 TOTAL_SHREDS_FA1,
             );
-            run_tests(
-                &test_name,
-                &validators,
-                &validators_and_ping_servers,
-                &leader_sampler,
-                &rotor_sampler,
-                &ping_leader_sampler,
-                &ping_rotor_sampler,
-            )?;
+            for shreds in SHRED_COUNTS {
+                let rotor_sampler = FaitAccompli1Sampler::new_with_stake_weighted_fallback(
+                    validators.clone(),
+                    shreds as u64,
+                );
+                run_tests(
+                    &format!("{test_name}-{shreds}"),
+                    &validators,
+                    &validators_and_ping_servers,
+                    &leader_sampler,
+                    &rotor_sampler,
+                    &ping_leader_sampler,
+                    &ping_rotor_sampler,
+                )?;
+            }
         } else if sampling_strat == "fa2" {
             let leader_sampler =
                 StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
             let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
                 .into_quorum_strategy(NUM_LEADERS);
-            let rotor_sampler = FaitAccompli2Sampler::new(validators.clone(), TOTAL_SHREDS_FA1);
             let ping_rotor_sampler =
                 FaitAccompli2Sampler::new(validators_with_pings.clone(), TOTAL_SHREDS_FA1);
-            run_tests(
-                &test_name,
-                &validators,
-                &validators_and_ping_servers,
-                &leader_sampler,
-                &rotor_sampler,
-                &ping_leader_sampler,
-                &ping_rotor_sampler,
-            )?;
+            for shreds in SHRED_COUNTS {
+                let rotor_sampler = FaitAccompli2Sampler::new(validators.clone(), shreds as u64);
+                run_tests(
+                    &format!("{test_name}-{shreds}"),
+                    &validators,
+                    &validators_and_ping_servers,
+                    &leader_sampler,
+                    &rotor_sampler,
+                    &ping_leader_sampler,
+                    &ping_rotor_sampler,
+                )?;
+            }
         } else if sampling_strat == "fa1_partition" {
             let leader_sampler =
                 StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
             let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
                 .into_quorum_strategy(NUM_LEADERS);
-            let rotor_sampler = FaitAccompli1Sampler::new_with_partition_fallback(
-                validators.clone(),
-                TOTAL_SHREDS_FA1,
-            );
             let ping_rotor_sampler = FaitAccompli1Sampler::new_with_partition_fallback(
                 validators_with_pings.clone(),
                 TOTAL_SHREDS_FA1,
             );
-            run_tests(
-                &test_name,
-                &validators,
-                &validators_and_ping_servers,
-                &leader_sampler,
-                &rotor_sampler,
-                &ping_leader_sampler,
-                &ping_rotor_sampler,
-            )?;
+            for shreds in SHRED_COUNTS {
+                let rotor_sampler = FaitAccompli1Sampler::new_with_partition_fallback(
+                    validators.clone(),
+                    shreds as u64,
+                );
+                run_tests(
+                    &format!("{test_name}-{shreds}"),
+                    &validators,
+                    &validators_and_ping_servers,
+                    &leader_sampler,
+                    &rotor_sampler,
+                    &ping_leader_sampler,
+                    &ping_rotor_sampler,
+                )?;
+            }
         } else if sampling_strat == "decaying_acceptance" {
             let leader_sampler =
                 StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
             let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone())
                 .into_quorum_strategy(NUM_LEADERS);
-            let rotor_sampler =
-                DecayingAcceptanceSampler::new(validators.clone(), 3.0, TOTAL_SHREDS_FA1 as usize);
             let ping_rotor_sampler = DecayingAcceptanceSampler::new(
                 validators_with_pings.clone(),
                 3.0,
                 TOTAL_SHREDS_FA1 as usize,
             );
-            run_tests(
-                &test_name,
-                &validators,
-                &validators_and_ping_servers,
-                &leader_sampler,
-                &rotor_sampler,
-                &ping_leader_sampler,
-                &ping_rotor_sampler,
-            )?;
+            for shreds in SHRED_COUNTS {
+                let rotor_sampler = DecayingAcceptanceSampler::new(validators.clone(), 3.0, shreds);
+                run_tests(
+                    &format!("{test_name}-{shreds}"),
+                    &validators,
+                    &validators_and_ping_servers,
+                    &leader_sampler,
+                    &rotor_sampler,
+                    &ping_leader_sampler,
+                    &ping_rotor_sampler,
+                )?;
+            }
         } else if sampling_strat == "turbine" {
             let leader_sampler =
                 TurbineSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
             let ping_leader_sampler = TurbineSampler::new(validators_with_pings.clone())
                 .into_quorum_strategy(NUM_LEADERS);
-            let rotor_sampler = TurbineSampler::new(validators.clone())
-                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
             let ping_rotor_sampler = TurbineSampler::new(validators_with_pings.clone())
-                .into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
-            run_tests(
-                &test_name,
-                &validators,
-                &validators_and_ping_servers,
-                &leader_sampler,
-                &rotor_sampler,
-                &ping_leader_sampler,
-                &ping_rotor_sampler,
-            )?;
+                .into_quorum_strategy(NUM_LEADERS);
+            for shreds in SHRED_COUNTS {
+                let rotor_sampler =
+                    TurbineSampler::new(validators.clone()).into_quorum_strategy(shreds);
+                run_tests(
+                    &format!("{test_name}-{shreds}"),
+                    &validators,
+                    &validators_and_ping_servers,
+                    &leader_sampler,
+                    &rotor_sampler,
+                    &ping_leader_sampler,
+                    &ping_rotor_sampler,
+                )?;
+            }
         }
     }
 
@@ -389,7 +404,7 @@ fn run_tests<
             info!(
                 "{test_name} bandwidth test ({:.1} Gbps, {} shreds)",
                 max_bandwidth as f64 / 1e9,
-                tester.num_shreds(),
+                rotor_sampler.quorum_size(),
             );
             tester.reset();
             tester.run_multiple(1_000_000);

--- a/src/bin/simulations/main.rs
+++ b/src/bin/simulations/main.rs
@@ -49,7 +49,9 @@ use ::alpenglow::disseminator::rotor::sampling_strategy::{
     AllSameSampler, DecayingAcceptanceSampler, FaitAccompli1Sampler, FaitAccompli2Sampler,
     TurbineSampler, UniformSampler,
 };
-use ::alpenglow::disseminator::rotor::{SamplingStrategy, StakeWeightedSampler};
+use ::alpenglow::disseminator::rotor::{
+    QuorumSamplingStrategy, SamplingStrategy, StakeWeightedSampler,
+};
 use ::alpenglow::network::simulated::ping_data::PingServer;
 use ::alpenglow::network::simulated::stake_distribution::{
     VALIDATOR_DATA, ValidatorData, validators_from_validator_data,
@@ -192,11 +194,20 @@ fn run_tests_for_stake_distribution(
     // run all tests for the different sampling strategies
     for sampling_strat in SAMPLING_STRATEGIES {
         let test_name = format!("{distribution_name}-{sampling_strat}");
+        // Leader samplers are wrapped with into_quorum_strategy so they satisfy
+        // QuorumSamplingStrategy (needed by Ryse/Pyjama which sample multiple leaders).
+        // Rotor only calls sample() on the leader sampler, ignoring quorum_size.
+        const NUM_LEADERS: usize = 8;
+
         if sampling_strat == "uniform" {
-            let leader_sampler = UniformSampler::new(validators.clone());
-            let ping_leader_sampler = UniformSampler::new(validators_with_pings.clone());
-            let rotor_sampler = UniformSampler::new(validators.clone());
-            let ping_rotor_sampler = UniformSampler::new(validators_with_pings.clone());
+            let leader_sampler =
+                UniformSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
+            let ping_leader_sampler =
+                UniformSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
+            let rotor_sampler =
+                UniformSampler::new(validators.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
+            let ping_rotor_sampler =
+                UniformSampler::new(validators_with_pings.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
             run_tests(
                 &test_name,
                 &validators,
@@ -207,10 +218,14 @@ fn run_tests_for_stake_distribution(
                 &ping_rotor_sampler,
             )?;
         } else if sampling_strat == "stake_weighted" {
-            let leader_sampler = StakeWeightedSampler::new(validators.clone());
-            let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone());
-            let rotor_sampler = StakeWeightedSampler::new(validators.clone());
-            let ping_rotor_sampler = StakeWeightedSampler::new(validators_with_pings.clone());
+            let leader_sampler =
+                StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
+            let ping_leader_sampler =
+                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
+            let rotor_sampler =
+                StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
+            let ping_rotor_sampler =
+                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
             run_tests(
                 &test_name,
                 &validators,
@@ -221,8 +236,10 @@ fn run_tests_for_stake_distribution(
                 &ping_rotor_sampler,
             )?;
         } else if sampling_strat == "fa1_iid" {
-            let leader_sampler = StakeWeightedSampler::new(validators.clone());
-            let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone());
+            let leader_sampler =
+                StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
+            let ping_leader_sampler =
+                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
             let rotor_sampler = FaitAccompli1Sampler::new_with_stake_weighted_fallback(
                 validators.clone(),
                 TOTAL_SHREDS_FA1,
@@ -241,8 +258,10 @@ fn run_tests_for_stake_distribution(
                 &ping_rotor_sampler,
             )?;
         } else if sampling_strat == "fa2" {
-            let leader_sampler = StakeWeightedSampler::new(validators.clone());
-            let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone());
+            let leader_sampler =
+                StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
+            let ping_leader_sampler =
+                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
             let rotor_sampler = FaitAccompli2Sampler::new(validators.clone(), TOTAL_SHREDS_FA1);
             let ping_rotor_sampler =
                 FaitAccompli2Sampler::new(validators_with_pings.clone(), TOTAL_SHREDS_FA1);
@@ -256,8 +275,10 @@ fn run_tests_for_stake_distribution(
                 &ping_rotor_sampler,
             )?;
         } else if sampling_strat == "fa1_partition" {
-            let leader_sampler = StakeWeightedSampler::new(validators.clone());
-            let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone());
+            let leader_sampler =
+                StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
+            let ping_leader_sampler =
+                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
             let rotor_sampler = FaitAccompli1Sampler::new_with_partition_fallback(
                 validators.clone(),
                 TOTAL_SHREDS_FA1,
@@ -276,11 +297,14 @@ fn run_tests_for_stake_distribution(
                 &ping_rotor_sampler,
             )?;
         } else if sampling_strat == "decaying_acceptance" {
-            let leader_sampler = StakeWeightedSampler::new(validators.clone());
-            let ping_leader_sampler = StakeWeightedSampler::new(validators_with_pings.clone());
-            let rotor_sampler = DecayingAcceptanceSampler::new(validators.clone(), 3.0);
+            let leader_sampler =
+                StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
+            let ping_leader_sampler =
+                StakeWeightedSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
+            let rotor_sampler =
+                DecayingAcceptanceSampler::new(validators.clone(), 3.0, TOTAL_SHREDS_FA1 as usize);
             let ping_rotor_sampler =
-                DecayingAcceptanceSampler::new(validators_with_pings.clone(), 3.0);
+                DecayingAcceptanceSampler::new(validators_with_pings.clone(), 3.0, TOTAL_SHREDS_FA1 as usize);
             run_tests(
                 &test_name,
                 &validators,
@@ -291,10 +315,14 @@ fn run_tests_for_stake_distribution(
                 &ping_rotor_sampler,
             )?;
         } else if sampling_strat == "turbine" {
-            let leader_sampler = TurbineSampler::new(validators.clone());
-            let ping_leader_sampler = TurbineSampler::new(validators_with_pings.clone());
-            let rotor_sampler = TurbineSampler::new(validators.clone());
-            let ping_rotor_sampler = TurbineSampler::new(validators_with_pings.clone());
+            let leader_sampler =
+                TurbineSampler::new(validators.clone()).into_quorum_strategy(NUM_LEADERS);
+            let ping_leader_sampler =
+                TurbineSampler::new(validators_with_pings.clone()).into_quorum_strategy(NUM_LEADERS);
+            let rotor_sampler =
+                TurbineSampler::new(validators.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
+            let ping_rotor_sampler =
+                TurbineSampler::new(validators_with_pings.clone()).into_quorum_strategy(TOTAL_SHREDS_FA1 as usize);
             run_tests(
                 &test_name,
                 &validators,
@@ -311,8 +339,8 @@ fn run_tests_for_stake_distribution(
 }
 
 fn run_tests<
-    L: SamplingStrategy + Send + Sync + Clone,
-    R: SamplingStrategy + Send + Sync + Clone,
+    L: SamplingStrategy + QuorumSamplingStrategy + Send + Sync + Clone,
+    R: QuorumSamplingStrategy + Send + Sync + Clone,
 >(
     test_name: &str,
     validators: &[ValidatorInfo],
@@ -354,19 +382,16 @@ fn run_tests<
                 bandwidths,
                 leader_sampler.clone(),
                 rotor_sampler.clone(),
-                64,
             );
-            for shreds in [64, 128, 256, 512] {
-                info!(
-                    "{test_name} bandwidth test ({:.1} Gbps, {shreds} shreds)",
-                    max_bandwidth as f64 / 1e9,
-                );
-                tester.set_num_shreds(shreds);
-                tester.reset();
-                tester.run_multiple(1_000_000);
-                tester.evaluate_supported(test_name, supported_writer_ref);
-                tester.evaluate_usage(test_name, usage_writer_ref.clone());
-            }
+            info!(
+                "{test_name} bandwidth test ({:.1} Gbps, {} shreds)",
+                max_bandwidth as f64 / 1e9,
+                tester.num_shreds(),
+            );
+            tester.reset();
+            tester.run_multiple(1_000_000);
+            tester.evaluate_supported(test_name, supported_writer_ref);
+            tester.evaluate_usage(test_name, usage_writer_ref.clone());
         });
     }
 

--- a/src/bin/simulations/pyjama/latency.rs
+++ b/src/bin/simulations/pyjama/latency.rs
@@ -8,7 +8,9 @@
 use std::marker::PhantomData;
 
 use alpenglow::ValidatorId;
-use alpenglow::disseminator::rotor::{SamplingStrategy, StakeWeightedSampler};
+use alpenglow::disseminator::rotor::{
+    QuorumSamplingStrategy, SamplingStrategy, StakeWeightedSampler,
+};
 use alpenglow::shredder::{DATA_SHREDS, MAX_DATA_PER_SHRED, TOTAL_SHREDS};
 
 use super::{PyjamaInstance, PyjamaInstanceBuilder, PyjamaParams};
@@ -23,7 +25,7 @@ use crate::rotor::RotorParams;
 ///
 /// This type implements the `Protocol` trait and can be passed to the simulation engine.
 /// There is probably never a need to construct this type directly.
-pub struct PyjamaLatencySimulation<L: SamplingStrategy, P: SamplingStrategy, R: SamplingStrategy> {
+pub struct PyjamaLatencySimulation<L: SamplingStrategy, P: QuorumSamplingStrategy, R: QuorumSamplingStrategy> {
     _leader_sampler: PhantomData<L>,
     _proposer_sampler: PhantomData<P>,
     _rotor_sampler: PhantomData<R>,
@@ -32,8 +34,8 @@ pub struct PyjamaLatencySimulation<L: SamplingStrategy, P: SamplingStrategy, R: 
 impl<L, P, R> Protocol for PyjamaLatencySimulation<L, P, R>
 where
     L: SamplingStrategy,
-    P: SamplingStrategy,
-    R: SamplingStrategy,
+    P: QuorumSamplingStrategy,
+    R: QuorumSamplingStrategy,
 {
     type Event = LatencyEvent;
     type Stage = LatencyTestStage;
@@ -200,8 +202,10 @@ impl Event for LatencyEvent {
                     slices: slices_required,
                 };
                 let rotor_builder = crate::rotor::RotorInstanceBuilder::new(
-                    StakeWeightedSampler::new(environment.validators.clone()),
-                    StakeWeightedSampler::new(environment.validators.clone()),
+                    StakeWeightedSampler::new(environment.validators.clone())
+                        .into_quorum_strategy(1),
+                    StakeWeightedSampler::new(environment.validators.clone())
+                        .into_quorum_strategy(TOTAL_SHREDS),
                     rotor_params,
                 );
                 let builder = crate::alpenglow::LatencySimInstanceBuilder::new(

--- a/src/bin/simulations/pyjama/latency.rs
+++ b/src/bin/simulations/pyjama/latency.rs
@@ -25,7 +25,11 @@ use crate::rotor::RotorParams;
 ///
 /// This type implements the `Protocol` trait and can be passed to the simulation engine.
 /// There is probably never a need to construct this type directly.
-pub struct PyjamaLatencySimulation<L: SamplingStrategy, P: QuorumSamplingStrategy, R: QuorumSamplingStrategy> {
+pub struct PyjamaLatencySimulation<
+    L: SamplingStrategy,
+    P: QuorumSamplingStrategy,
+    R: QuorumSamplingStrategy,
+> {
     _leader_sampler: PhantomData<L>,
     _proposer_sampler: PhantomData<P>,
     _rotor_sampler: PhantomData<R>,

--- a/src/bin/simulations/pyjama/parameters.rs
+++ b/src/bin/simulations/pyjama/parameters.rs
@@ -57,6 +57,11 @@ where
         relay_sampler: R,
         params: PyjamaParameters,
     ) -> Self {
+        assert_eq!(
+            proposer_sampler.quorum_size(),
+            params.num_proposers as usize
+        );
+        assert_eq!(relay_sampler.quorum_size(), params.num_relays as usize);
         Self {
             leader_sampler,
             proposer_sampler,

--- a/src/bin/simulations/pyjama/parameters.rs
+++ b/src/bin/simulations/pyjama/parameters.rs
@@ -6,7 +6,7 @@
 //!
 
 use alpenglow::ValidatorId;
-use alpenglow::disseminator::rotor::SamplingStrategy;
+use alpenglow::disseminator::rotor::{QuorumSamplingStrategy, SamplingStrategy};
 use log::info;
 use rand::prelude::*;
 use statrs::distribution::{Binomial, DiscreteCDF};
@@ -33,7 +33,7 @@ pub struct PyjamaInstance {
 }
 
 /// Builder for Ryse instances with a specific set of parameters.
-pub struct PyjamaInstanceBuilder<L: SamplingStrategy, P: SamplingStrategy, R: SamplingStrategy> {
+pub struct PyjamaInstanceBuilder<L: SamplingStrategy, P: QuorumSamplingStrategy, R: QuorumSamplingStrategy> {
     leader_sampler: L,
     proposer_sampler: P,
     relay_sampler: R,
@@ -43,8 +43,8 @@ pub struct PyjamaInstanceBuilder<L: SamplingStrategy, P: SamplingStrategy, R: Sa
 impl<L, P, R> PyjamaInstanceBuilder<L, P, R>
 where
     L: SamplingStrategy,
-    P: SamplingStrategy,
-    R: SamplingStrategy,
+    P: QuorumSamplingStrategy,
+    R: QuorumSamplingStrategy,
 {
     /// Creates a new builder instance, with the provided sampling strategies.
     pub fn new(
@@ -65,8 +65,8 @@ where
 impl<L, P, R> Builder for PyjamaInstanceBuilder<L, P, R>
 where
     L: SamplingStrategy,
-    P: SamplingStrategy,
-    R: SamplingStrategy,
+    P: QuorumSamplingStrategy,
+    R: QuorumSamplingStrategy,
 {
     type Params = PyjamaParameters;
     type Instance = PyjamaInstance;
@@ -74,12 +74,8 @@ where
     fn build(&self, rng: &mut impl Rng) -> PyjamaInstance {
         PyjamaInstance {
             leader: self.leader_sampler.sample(rng),
-            proposers: self
-                .proposer_sampler
-                .sample_multiple(self.params.num_proposers as usize, rng),
-            relays: self
-                .relay_sampler
-                .sample_multiple(self.params.num_relays as usize, rng),
+            proposers: self.proposer_sampler.sample_quorum(rng),
+            relays: self.relay_sampler.sample_quorum(rng),
             params: self.params,
         }
     }

--- a/src/bin/simulations/pyjama/parameters.rs
+++ b/src/bin/simulations/pyjama/parameters.rs
@@ -33,7 +33,11 @@ pub struct PyjamaInstance {
 }
 
 /// Builder for Ryse instances with a specific set of parameters.
-pub struct PyjamaInstanceBuilder<L: SamplingStrategy, P: QuorumSamplingStrategy, R: QuorumSamplingStrategy> {
+pub struct PyjamaInstanceBuilder<
+    L: SamplingStrategy,
+    P: QuorumSamplingStrategy,
+    R: QuorumSamplingStrategy,
+> {
     leader_sampler: L,
     proposer_sampler: P,
     relay_sampler: R,

--- a/src/bin/simulations/pyjama/robustness.rs
+++ b/src/bin/simulations/pyjama/robustness.rs
@@ -102,6 +102,7 @@ pub fn run_pyjama_robustness_test(total_shreds: u64) -> Result<()> {
     let test = QuorumRobustnessTest::new(
         validators,
         "solana".to_string(),
+        "fa1_iid".to_string(),
         vec![leader_sampler, proposer_sampler, relay_sampler],
         vec![0, 1, 2],
         vec![1, params.num_proposers as usize, params.num_relays as usize],

--- a/src/bin/simulations/quorum_robustness.rs
+++ b/src/bin/simulations/quorum_robustness.rs
@@ -16,7 +16,7 @@ use std::cmp::Reverse;
 use std::fs::File;
 use std::sync::RwLock;
 
-use alpenglow::disseminator::rotor::{FaitAccompli1Sampler, SamplingStrategy};
+use alpenglow::disseminator::rotor::{FaitAccompli1Sampler, QuorumSamplingStrategy};
 use alpenglow::{Stake, ValidatorInfo};
 use color_eyre::Result;
 use log::debug;
@@ -44,7 +44,7 @@ pub struct AdversaryStrength {
 }
 
 /// Test harness for quorum robustness testing.
-pub struct QuorumRobustnessTest<S: SamplingStrategy> {
+pub struct QuorumRobustnessTest<S: QuorumSamplingStrategy> {
     samplers: Vec<S>,
     quorum_samplers: Vec<usize>,
     quorum_sizes: Vec<usize>,
@@ -58,7 +58,7 @@ pub struct QuorumRobustnessTest<S: SamplingStrategy> {
     stake_distribution: String,
 }
 
-impl<S: SamplingStrategy + Send + Sync> QuorumRobustnessTest<S> {
+impl<S: QuorumSamplingStrategy + Send + Sync> QuorumRobustnessTest<S> {
     /// Creates a new instance of the test harness.
     pub fn new(
         validators: Vec<ValidatorInfo>,
@@ -355,9 +355,9 @@ impl<S: SamplingStrategy + Send + Sync> QuorumRobustnessTest<S> {
                 .iter()
                 .copied()
                 .enumerate()
-                .map(|(quorum_index, quorum_size)| {
+                .map(|(quorum_index, _quorum_size)| {
                     let sampler = &self.samplers[self.quorum_samplers[quorum_index]];
-                    let sampled = sampler.sample_multiple(quorum_size, &mut rng);
+                    let sampled = sampler.sample_quorum(&mut rng);
                     let byzantine_samples =
                         sampled.iter().filter(|v| byzantine[v.as_index()]).count();
                     let crashed_samples = sampled.iter().filter(|v| crashed[v.as_index()]).count();

--- a/src/bin/simulations/quorum_robustness.rs
+++ b/src/bin/simulations/quorum_robustness.rs
@@ -56,6 +56,7 @@ pub struct QuorumRobustnessTest<S: QuorumSamplingStrategy> {
     validators: Vec<ValidatorInfo>,
     total_stake: Stake,
     stake_distribution: String,
+    sampling_strategy: String,
 }
 
 impl<S: QuorumSamplingStrategy + Send + Sync> QuorumRobustnessTest<S> {
@@ -63,6 +64,7 @@ impl<S: QuorumSamplingStrategy + Send + Sync> QuorumRobustnessTest<S> {
     pub fn new(
         validators: Vec<ValidatorInfo>,
         stake_distribution: String,
+        sampling_strategy: String,
         samplers: Vec<S>,
         quorum_samplers: Vec<usize>,
         quorum_sizes: Vec<usize>,
@@ -84,6 +86,7 @@ impl<S: QuorumSamplingStrategy + Send + Sync> QuorumRobustnessTest<S> {
             validators,
             total_stake,
             stake_distribution,
+            sampling_strategy,
         }
     }
 
@@ -134,10 +137,9 @@ impl<S: QuorumSamplingStrategy + Send + Sync> QuorumRobustnessTest<S> {
         vec_max(&mut attack_probs, &large_attack_probs);
 
         // write results to CSV
-        let sampling_strategy = S::name();
         let mut row = vec![
             self.stake_distribution.clone(),
-            sampling_strategy.to_string(),
+            self.sampling_strategy.clone(),
             adversary_strength.byzantine.to_string(),
             adversary_strength.crashed.to_string(),
             // self.params().num_data_shreds.to_string(),

--- a/src/bin/simulations/rotor.rs
+++ b/src/bin/simulations/rotor.rs
@@ -51,6 +51,7 @@ pub struct RotorInstanceBuilder<L: SamplingStrategy, R: QuorumSamplingStrategy> 
 impl<L: SamplingStrategy, R: QuorumSamplingStrategy> RotorInstanceBuilder<L, R> {
     /// Creates a new builder instance, with the provided sampling strategies.
     pub fn new(leader_sampler: L, rotor_sampler: R, params: RotorParams) -> Self {
+        assert_eq!(rotor_sampler.quorum_size(), params.shreds);
         Self {
             leader_sampler,
             rotor_sampler,

--- a/src/bin/simulations/rotor.rs
+++ b/src/bin/simulations/rotor.rs
@@ -11,7 +11,7 @@ pub mod latency;
 pub mod robustness;
 
 use alpenglow::ValidatorId;
-use alpenglow::disseminator::rotor::SamplingStrategy;
+use alpenglow::disseminator::rotor::{QuorumSamplingStrategy, SamplingStrategy};
 use rand::prelude::*;
 
 pub use self::latency::{LatencyEvent, RotorLatencySimulation};
@@ -42,13 +42,13 @@ impl RotorParams {
 
 /// Builder for Rotor instances with a specific set of parameters.
 #[derive(Debug)]
-pub struct RotorInstanceBuilder<L: SamplingStrategy, R: SamplingStrategy> {
+pub struct RotorInstanceBuilder<L: SamplingStrategy, R: QuorumSamplingStrategy> {
     pub leader_sampler: L,
     pub rotor_sampler: R,
     pub params: RotorParams,
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> RotorInstanceBuilder<L, R> {
+impl<L: SamplingStrategy, R: QuorumSamplingStrategy> RotorInstanceBuilder<L, R> {
     /// Creates a new builder instance, with the provided sampling strategies.
     pub fn new(leader_sampler: L, rotor_sampler: R, params: RotorParams) -> Self {
         Self {
@@ -59,7 +59,7 @@ impl<L: SamplingStrategy, R: SamplingStrategy> RotorInstanceBuilder<L, R> {
     }
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> Builder for RotorInstanceBuilder<L, R> {
+impl<L: SamplingStrategy, R: QuorumSamplingStrategy> Builder for RotorInstanceBuilder<L, R> {
     type Params = RotorParams;
     type Instance = RotorInstance;
 
@@ -67,7 +67,7 @@ impl<L: SamplingStrategy, R: SamplingStrategy> Builder for RotorInstanceBuilder<
         RotorInstance {
             leader: self.leader_sampler.sample(rng),
             relays: (0..self.params.slices)
-                .map(|_| self.rotor_sampler.sample_multiple(self.params.shreds, rng))
+                .map(|_| self.rotor_sampler.sample_quorum(rng))
                 .collect(),
             params: self.params,
         }

--- a/src/bin/simulations/rotor/latency.rs
+++ b/src/bin/simulations/rotor/latency.rs
@@ -8,7 +8,7 @@
 use std::marker::PhantomData;
 
 use alpenglow::ValidatorId;
-use alpenglow::disseminator::rotor::SamplingStrategy;
+use alpenglow::disseminator::rotor::{QuorumSamplingStrategy, SamplingStrategy};
 use alpenglow::shredder::MAX_DATA_PER_SHRED;
 
 use super::{RotorInstance, RotorInstanceBuilder, RotorParams};
@@ -20,12 +20,12 @@ use crate::discrete_event_simulator::{
 ///
 /// This type implements the `Protocol` trait and can be passed to the simulation engine.
 /// There is probably never a need to construct this type directly.
-pub struct RotorLatencySimulation<L: SamplingStrategy, R: SamplingStrategy> {
+pub struct RotorLatencySimulation<L: SamplingStrategy, R: QuorumSamplingStrategy> {
     _leader_sampler: PhantomData<L>,
     _rotor_sampler: PhantomData<R>,
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> Protocol for RotorLatencySimulation<L, R> {
+impl<L: SamplingStrategy, R: QuorumSamplingStrategy> Protocol for RotorLatencySimulation<L, R> {
     type Event = LatencyEvent;
     type Stage = LatencyTestStage;
     type Params = RotorParams;

--- a/src/bin/simulations/rotor/robustness.rs
+++ b/src/bin/simulations/rotor/robustness.rs
@@ -28,7 +28,8 @@ use crate::quorum_robustness::{AdversaryStrength, QuorumRobustnessTest, QuorumTh
 pub fn run_rotor_robustness_test(data_shreds: usize, total_shreds: usize) -> Result<()> {
     let (validators, _with_pings) = validators_from_validator_data(&VALIDATOR_DATA);
     let leader_sampler = StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(1);
-    let rotor_sampler = StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(total_shreds);
+    let rotor_sampler =
+        StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(total_shreds);
 
     let params = RotorParams {
         data_shreds,

--- a/src/bin/simulations/rotor/robustness.rs
+++ b/src/bin/simulations/rotor/robustness.rs
@@ -14,7 +14,7 @@
 
 use std::fs::File;
 
-use alpenglow::disseminator::rotor::StakeWeightedSampler;
+use alpenglow::disseminator::rotor::{SamplingStrategy, StakeWeightedSampler};
 use alpenglow::network::simulated::stake_distribution::{
     VALIDATOR_DATA, validators_from_validator_data,
 };
@@ -27,8 +27,8 @@ use crate::quorum_robustness::{AdversaryStrength, QuorumRobustnessTest, QuorumTh
 
 pub fn run_rotor_robustness_test(data_shreds: usize, total_shreds: usize) -> Result<()> {
     let (validators, _with_pings) = validators_from_validator_data(&VALIDATOR_DATA);
-    let leader_sampler = StakeWeightedSampler::new(validators.clone());
-    let rotor_sampler = StakeWeightedSampler::new(validators.clone());
+    let leader_sampler = StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(1);
+    let rotor_sampler = StakeWeightedSampler::new(validators.clone()).into_quorum_strategy(total_shreds);
 
     let params = RotorParams {
         data_shreds,

--- a/src/bin/simulations/rotor/robustness.rs
+++ b/src/bin/simulations/rotor/robustness.rs
@@ -58,6 +58,7 @@ pub fn run_rotor_robustness_test(data_shreds: usize, total_shreds: usize) -> Res
     let test = QuorumRobustnessTest::new(
         validators,
         "solana".to_string(),
+        "stake_weighted".to_string(),
         vec![leader_sampler, rotor_sampler],
         vec![1; params.slices],
         vec![params.shreds; params.slices],

--- a/src/bin/simulations/ryse/latency.rs
+++ b/src/bin/simulations/ryse/latency.rs
@@ -33,7 +33,9 @@ pub struct RyseLatencySimulation<L: QuorumSamplingStrategy, R: QuorumSamplingStr
     _rotor_sampler: PhantomData<R>,
 }
 
-impl<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> Protocol for RyseLatencySimulation<L, R> {
+impl<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> Protocol
+    for RyseLatencySimulation<L, R>
+{
     type Event = LatencyEvent;
     type Stage = LatencyTestStage;
     type Params = LatencySimParams;
@@ -370,7 +372,9 @@ impl<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> LatencySimInstanceBui
     }
 }
 
-impl<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> Builder for LatencySimInstanceBuilder<L, R> {
+impl<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> Builder
+    for LatencySimInstanceBuilder<L, R>
+{
     type Params = LatencySimParams;
     type Instance = LatencySimInstance;
 

--- a/src/bin/simulations/ryse/latency.rs
+++ b/src/bin/simulations/ryse/latency.rs
@@ -11,7 +11,7 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 
 use alpenglow::ValidatorId;
-use alpenglow::disseminator::rotor::SamplingStrategy;
+use alpenglow::disseminator::rotor::QuorumSamplingStrategy;
 use alpenglow::shredder::MAX_DATA_PER_SHRED;
 use log::debug;
 use rand::prelude::*;
@@ -28,12 +28,12 @@ const VOTE_SIZE: usize = 128 /* sig */ + 64 /* slot, hash, flags */;
 const CERT_SIZE: usize = 128 /* sig */ + 256 /* bitmap */ + 64 /* slot, hash, flags */;
 
 /// Marker type for the Ryse latency simulation.
-pub struct RyseLatencySimulation<L: SamplingStrategy, R: SamplingStrategy> {
+pub struct RyseLatencySimulation<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> {
     _leader_sampler: PhantomData<L>,
     _rotor_sampler: PhantomData<R>,
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> Protocol for RyseLatencySimulation<L, R> {
+impl<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> Protocol for RyseLatencySimulation<L, R> {
     type Event = LatencyEvent;
     type Stage = LatencyTestStage;
     type Params = LatencySimParams;
@@ -355,12 +355,12 @@ impl LatencySimParams {
 }
 
 /// A builder for Ryse latency simulation instances.
-pub struct LatencySimInstanceBuilder<L: SamplingStrategy, R: SamplingStrategy> {
+pub struct LatencySimInstanceBuilder<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> {
     ryse_builder: RyseInstanceBuilder<L, R>,
     params: LatencySimParams,
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> LatencySimInstanceBuilder<L, R> {
+impl<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> LatencySimInstanceBuilder<L, R> {
     /// Creates a new builder instance from a builder for Rotor instances.
     pub fn new(ryse_builder: RyseInstanceBuilder<L, R>, params: LatencySimParams) -> Self {
         Self {
@@ -370,7 +370,7 @@ impl<L: SamplingStrategy, R: SamplingStrategy> LatencySimInstanceBuilder<L, R> {
     }
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> Builder for LatencySimInstanceBuilder<L, R> {
+impl<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> Builder for LatencySimInstanceBuilder<L, R> {
     type Params = LatencySimParams;
     type Instance = LatencySimInstance;
 

--- a/src/bin/simulations/ryse/parameters.rs
+++ b/src/bin/simulations/ryse/parameters.rs
@@ -45,6 +45,7 @@ pub struct RyseInstanceBuilder<L: QuorumSamplingStrategy, R: QuorumSamplingStrat
 impl<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> RyseInstanceBuilder<L, R> {
     /// Creates a new builder instance, with the provided sampling strategies.
     pub fn new(leader_sampler: L, relay_sampler: R, params: RyseParameters) -> Self {
+        assert_eq!(relay_sampler.quorum_size(), params.num_relays as usize);
         Self {
             leader_sampler,
             relay_sampler,

--- a/src/bin/simulations/ryse/parameters.rs
+++ b/src/bin/simulations/ryse/parameters.rs
@@ -6,7 +6,7 @@
 //!
 
 use alpenglow::ValidatorId;
-use alpenglow::disseminator::rotor::SamplingStrategy;
+use alpenglow::disseminator::rotor::QuorumSamplingStrategy;
 use log::info;
 use rand::prelude::*;
 use statrs::distribution::{Binomial, DiscreteCDF};
@@ -36,13 +36,13 @@ pub struct RyseInstance {
 }
 
 /// Builder for Ryse instances with a specific set of parameters.
-pub struct RyseInstanceBuilder<L: SamplingStrategy, R: SamplingStrategy> {
+pub struct RyseInstanceBuilder<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> {
     leader_sampler: L,
     relay_sampler: R,
     params: RyseParameters,
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> RyseInstanceBuilder<L, R> {
+impl<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> RyseInstanceBuilder<L, R> {
     /// Creates a new builder instance, with the provided sampling strategies.
     pub fn new(leader_sampler: L, relay_sampler: R, params: RyseParameters) -> Self {
         Self {
@@ -53,20 +53,15 @@ impl<L: SamplingStrategy, R: SamplingStrategy> RyseInstanceBuilder<L, R> {
     }
 }
 
-impl<L: SamplingStrategy, R: SamplingStrategy> Builder for RyseInstanceBuilder<L, R> {
+impl<L: QuorumSamplingStrategy, R: QuorumSamplingStrategy> Builder for RyseInstanceBuilder<L, R> {
     type Params = RyseParameters;
     type Instance = RyseInstance;
 
     fn build(&self, rng: &mut impl Rng) -> RyseInstance {
         RyseInstance {
-            leaders: self
-                .leader_sampler
-                .sample_multiple(self.params.num_leaders as usize, rng),
+            leaders: self.leader_sampler.sample_quorum(rng),
             relays: (0..self.params.num_slices)
-                .map(|_| {
-                    self.relay_sampler
-                        .sample_multiple(self.params.num_relays as usize, rng)
-                })
+                .map(|_| self.relay_sampler.sample_quorum(rng))
                 .collect(),
         }
     }

--- a/src/bin/simulations/ryse/robustness.rs
+++ b/src/bin/simulations/ryse/robustness.rs
@@ -66,6 +66,7 @@ pub fn run_ryse_robustness_test(total_shreds: u64) -> Result<()> {
     let test = QuorumRobustnessTest::new(
         validators,
         "solana".to_string(),
+        "fa1_iid".to_string(),
         vec![proposer_sampler, relay_sampler],
         vec![0, 1],
         vec![params.num_leaders as usize, params.num_relays as usize],

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -6,9 +6,9 @@
 //! This is an evolution of Solana's original Turbine block dissemination protocol.
 //! Instead of a multi-layered tree, it always uses a single layer of relayers.
 //!
-//! Rotor can be instantiated with any quorum sampling strategy.
-//! Therefore, this module also provides multiple implementation of such.
-//! See also, the [`sampling_strategy`] module and the [`SamplingStrategy`] trait.
+//! Rotor can be instantiated with any [`QuorumSamplingStrategy`].
+//! Therefore, this module also provides multiple implementations of such.
+//! See also, the [`sampling_strategy`] module.
 //!
 //! For an implementation of Turbine, see [`crate::disseminator::turbine::Turbine`].
 
@@ -21,7 +21,8 @@ use rand::prelude::*;
 
 use self::sampling_strategy::PartitionSampler;
 pub use self::sampling_strategy::{
-    FaitAccompli1Sampler, QuorumSamplingStrategy, SamplingStrategy, StakeWeightedSampler,
+    FaitAccompli1Sampler, IidQuorumSampler, QuorumSamplingStrategy, SamplingStrategy,
+    StakeWeightedSampler,
 };
 use super::Disseminator;
 use crate::consensus::ValidatorEpochInfo;
@@ -30,20 +31,22 @@ use crate::shredder::{Shred, TOTAL_SHREDS};
 use crate::{Slot, ValidatorId};
 
 /// Rotor is a new block dissemination protocol presented together with Alpenglow.
-pub struct Rotor<N: Network, S: SamplingStrategy> {
+///
+/// Uses a [`QuorumSamplingStrategy`] to select all relays for a slice at once.
+pub struct Rotor<N: Network, S: QuorumSamplingStrategy> {
     network: N,
     sampler: S,
     epoch_info: Arc<ValidatorEpochInfo>,
 }
 
-impl<N: Network> Rotor<N, StakeWeightedSampler> {
+impl<N: Network> Rotor<N, IidQuorumSampler<StakeWeightedSampler>> {
     /// Creates a new Rotor instance with the default sampling strategy.
     ///
     /// Contact information for all validators is provided in `validators`.
     /// Provided `network` will be used to send and receive shreds.
     pub fn new(network: N, epoch_info: Arc<ValidatorEpochInfo>) -> Self {
         let validators = epoch_info.epoch_info().validators().to_vec();
-        let sampler = StakeWeightedSampler::new(validators);
+        let sampler = StakeWeightedSampler::new(validators).into_quorum_strategy(TOTAL_SHREDS);
         Self {
             network,
             sampler,
@@ -69,7 +72,7 @@ impl<N: Network> Rotor<N, FaitAccompli1Sampler<PartitionSampler>> {
     }
 }
 
-impl<N, S: SamplingStrategy> Rotor<N, S>
+impl<N, S: QuorumSamplingStrategy> Rotor<N, S>
 where
     N: ShredNetwork,
 {
@@ -113,21 +116,30 @@ where
         Ok(())
     }
 
-    fn sample_relay(&self, slot: Slot, shred: usize) -> ValidatorId {
+    /// Deterministically samples the relay for a given shred within a slot.
+    ///
+    /// Seeds an RNG per slice and calls [`QuorumSamplingStrategy::sample_quorum`]
+    /// to get all relays for that slice, then picks the one at the shred's position.
+    fn sample_relay(&self, slot: Slot, shred_index_in_slot: usize) -> ValidatorId {
+        let quorum_size = self.sampler.quorum_size();
+        let slice_index = shred_index_in_slot / quorum_size;
+        let position_in_slice = shred_index_in_slot % quorum_size;
+
         let seed = [
             slot.inner().to_be_bytes(),
-            shred.to_be_bytes(),
+            slice_index.to_be_bytes(),
             [0; 8],
             [0; 8],
         ]
         .concat();
         let mut rng = StdRng::from_seed(seed.try_into().unwrap());
-        self.sampler.sample(&mut rng)
+        let relays = self.sampler.sample_quorum(&mut rng);
+        relays[position_in_slice]
     }
 }
 
 #[async_trait]
-impl<N, S: SamplingStrategy + Send + Sync + 'static> Disseminator for Rotor<N, S>
+impl<N, S: QuorumSamplingStrategy + Send + Sync + 'static> Disseminator for Rotor<N, S>
 where
     N: ShredNetwork,
 {
@@ -162,7 +174,7 @@ mod tests {
     use crate::types::slice::create_slice_with_invalid_txs;
     use crate::{Stake, ValidatorId, ValidatorInfo};
 
-    type MyRotor = Rotor<UdpNetwork<Shred, Shred>, StakeWeightedSampler>;
+    type MyRotor = Rotor<UdpNetwork<Shred, Shred>, IidQuorumSampler<StakeWeightedSampler>>;
 
     fn create_rotor_instances(count: u64, base_port: u16) -> (Vec<SecretKey>, Vec<MyRotor>) {
         let mut sks = Vec::new();

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -25,10 +25,10 @@ pub use self::sampling_strategy::{
     StakeWeightedSampler,
 };
 use super::Disseminator;
+use crate::ValidatorId;
 use crate::consensus::ValidatorEpochInfo;
 use crate::network::{Network, ShredNetwork};
 use crate::shredder::{Shred, TOTAL_SHREDS};
-use crate::{Slot, ValidatorId};
 
 /// Rotor is a new block dissemination protocol presented together with Alpenglow.
 ///
@@ -84,7 +84,7 @@ where
 
     /// Sends the shred to the correct relay.
     async fn send_as_leader(&self, shred: &Shred) -> std::io::Result<()> {
-        let relay = self.sample_relay(shred.payload().header.slot, shred.payload().index_in_slot());
+        let relay = self.sample_relay(shred);
         let v = self.epoch_info.epoch_info().validator(relay);
         self.network.send(shred, v.disseminator_address).await
     }
@@ -99,7 +99,7 @@ where
             .id;
 
         // do nothing if we are not the relay
-        let relay = self.sample_relay(shred.payload().header.slot, shred.payload().index_in_slot());
+        let relay = self.sample_relay(shred);
         if self.epoch_info.own_id() != relay {
             return Ok(());
         }
@@ -120,21 +120,21 @@ where
     ///
     /// Seeds an RNG per slice and calls [`QuorumSamplingStrategy::sample_quorum`]
     /// to get all relays for that slice, then picks the one at the shred's position.
-    fn sample_relay(&self, slot: Slot, shred_index_in_slot: usize) -> ValidatorId {
-        let quorum_size = self.sampler.quorum_size();
-        let slice_index = shred_index_in_slot / quorum_size;
-        let position_in_slice = shred_index_in_slot % quorum_size;
+    fn sample_relay(&self, shred: &Shred) -> ValidatorId {
+        let slot = shred.payload().header.slot;
+        let slice = shred.payload().header.slice_index.inner();
+        let shred = shred.payload().shred_index.inner();
 
         let seed = [
             slot.inner().to_be_bytes(),
-            slice_index.to_be_bytes(),
+            slice.to_be_bytes(),
             [0; 8],
             [0; 8],
         ]
         .concat();
         let mut rng = StdRng::from_seed(seed.try_into().unwrap());
         let relays = self.sampler.sample_quorum(&mut rng);
-        relays[position_in_slice]
+        relays[shred]
     }
 }
 

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -20,7 +20,9 @@ use async_trait::async_trait;
 use rand::prelude::*;
 
 use self::sampling_strategy::PartitionSampler;
-pub use self::sampling_strategy::{FaitAccompli1Sampler, SamplingStrategy, StakeWeightedSampler};
+pub use self::sampling_strategy::{
+    FaitAccompli1Sampler, QuorumSamplingStrategy, SamplingStrategy, StakeWeightedSampler,
+};
 use super::Disseminator;
 use crate::consensus::ValidatorEpochInfo;
 use crate::network::{Network, ShredNetwork};

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -116,7 +116,7 @@ where
         Ok(())
     }
 
-    /// Deterministically samples the relay for a given shred within a slot.
+    /// Deterministically samples the relay for a given shred.
     ///
     /// Seeds an RNG per slice and calls [`QuorumSamplingStrategy::sample_quorum`]
     /// to get all relays for that slice, then picks the one at the shred's position.

--- a/src/disseminator/rotor/sampling_strategy.rs
+++ b/src/disseminator/rotor/sampling_strategy.rs
@@ -68,11 +68,6 @@ pub trait SamplingStrategy {
     /// or if the sampling process failed [`MAX_TRIES_PER_SAMPLE`] times.
     fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo;
 
-    /// Returns a printable name of the sampling strategy.
-    fn name() -> &'static str {
-        std::any::type_name::<Self>()
-    }
-
     /// Wraps this sampler into an [`IidQuorumSampler`] with the given quorum size.
     ///
     /// The returned adapter implements [`QuorumSamplingStrategy`] by calling
@@ -98,11 +93,6 @@ pub trait QuorumSamplingStrategy {
 
     /// Samples a quorum of [`Self::quorum_size()`] validators.
     fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId>;
-
-    /// Returns a printable name of the sampling strategy.
-    fn name() -> &'static str {
-        std::any::type_name::<Self>()
-    }
 }
 
 /// Adapter that turns any [`SamplingStrategy`] into a [`QuorumSamplingStrategy`]
@@ -130,10 +120,6 @@ impl<S: SamplingStrategy> SamplingStrategy for IidQuorumSampler<S> {
     fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
         self.inner.sample_info(rng)
     }
-
-    fn name() -> &'static str {
-        S::name()
-    }
 }
 
 impl<S: SamplingStrategy> QuorumSamplingStrategy for IidQuorumSampler<S> {
@@ -143,10 +129,6 @@ impl<S: SamplingStrategy> QuorumSamplingStrategy for IidQuorumSampler<S> {
 
     fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId> {
         (0..self.k).map(|_| self.inner.sample(rng)).collect()
-    }
-
-    fn name() -> &'static str {
-        S::name()
     }
 }
 
@@ -161,10 +143,6 @@ impl SamplingStrategy for AllSameSampler {
 
     fn sample_info<R: Rng>(&self, _rng: &mut R) -> &ValidatorInfo {
         &self.0
-    }
-
-    fn name() -> &'static str {
-        "all_same"
     }
 }
 
@@ -191,10 +169,6 @@ impl SamplingStrategy for UniformSampler {
     fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
         let index = self.sample(rng).as_index();
         &self.validators[index]
-    }
-
-    fn name() -> &'static str {
-        "uniform"
     }
 }
 
@@ -228,10 +202,6 @@ impl SamplingStrategy for StakeWeightedSampler {
     fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
         let index = self.sample(rng).as_index();
         &self.validators[index]
-    }
-
-    fn name() -> &'static str {
-        "stake_weighted"
     }
 }
 
@@ -334,10 +304,6 @@ impl SamplingStrategy for TurbineSampler {
         let index = self.sample(rng).as_index();
         &self.stake_weighted.validators[index]
     }
-
-    fn name() -> &'static str {
-        "turbine"
-    }
 }
 
 /// A hybrid sampler between weighted sampling with and without replacement.
@@ -414,10 +380,6 @@ impl QuorumSamplingStrategy for DecayingAcceptanceSampler {
         let samples = (0..self.k).map(|_| self.sample_one(rng)).collect();
         self.reset();
         samples
-    }
-
-    fn name() -> &'static str {
-        "decaying_acceptance"
     }
 }
 
@@ -521,10 +483,6 @@ impl QuorumSamplingStrategy for PartitionSampler {
         }
         samples
     }
-
-    fn name() -> &'static str {
-        "partition"
-    }
 }
 
 /// A sampler that uses the FA1-F committee sampling strategy.
@@ -624,16 +582,6 @@ impl<F: QuorumSamplingStrategy> QuorumSamplingStrategy for FaitAccompli1Sampler<
             result.extend_from_slice(&additional_samples);
         }
         result
-    }
-
-    fn name() -> &'static str {
-        if F::name() == "stake_weighted" {
-            "fa1_iid"
-        } else if F::name() == "partition" {
-            "fa1_partition"
-        } else {
-            "fa1"
-        }
     }
 }
 
@@ -764,10 +712,6 @@ impl QuorumSamplingStrategy for FaitAccompli2Sampler {
         }
 
         result
-    }
-
-    fn name() -> &'static str {
-        "fa2"
     }
 }
 

--- a/src/disseminator/rotor/sampling_strategy.rs
+++ b/src/disseminator/rotor/sampling_strategy.rs
@@ -718,12 +718,8 @@ impl QuorumSamplingStrategy for FaitAccompli2Sampler {
         }
 
         // sample remaining validators IID stake-weighted
-        if result.len() < self.k {
-            let k_prime = self.k - result.len();
-            let additional_samples: Vec<_> = (0..k_prime)
-                .map(|_| self.fallback_sampler.sample(rng))
-                .collect();
-            result.extend_from_slice(&additional_samples);
+        for _ in result.len()..self.k {
+            result.push(self.fallback_sampler.sample(rng));
         }
 
         result

--- a/src/disseminator/rotor/sampling_strategy.rs
+++ b/src/disseminator/rotor/sampling_strategy.rs
@@ -23,6 +23,7 @@
 //! - [`AllSameSampler`] always returns the same validator (for testing).
 //! - [`UniformSampler`] picks all validators with equal probability.
 //! - [`StakeWeightedSampler`] picks validators proportional to their stake.
+//! - [`DecayingAcceptanceSampler`] hybrid between with/without replacement.
 //! - [`TurbineSampler`] simulates the workload of Turbine.
 //!
 //! Quorum strategies ([`QuorumSamplingStrategy`]):
@@ -31,6 +32,12 @@
 //! - [`PartitionSampler`] splits validators into bins and samples from each bin.
 //! - [`FaitAccompli1Sampler`] uses the FA1-F committee sampling strategy.
 //! - [`FaitAccompli2Sampler`] uses the FA2 committee sampling strategy.
+//!
+//! Note that [`DecayingAcceptanceSampler`] implements both traits.
+//! When used as a single-node strategy, it needs to be manually reset.
+//! When used as a quorum strategy, it automatically resets after each call to [`sample_quorum`].
+//!
+//! [`sample_quorum`]: QuorumSamplingStrategy::sample_quorum
 
 use std::sync::Mutex;
 
@@ -322,7 +329,7 @@ impl SamplingStrategy for TurbineSampler {
 /// [`sample_quorum`]: QuorumSamplingStrategy::sample_quorum
 pub struct DecayingAcceptanceSampler {
     stake_weighted: StakeWeightedSampler,
-    pub max_samples: f64,
+    max_samples: f64,
     sample_count: Mutex<Vec<usize>>,
     k: usize,
 }
@@ -368,6 +375,17 @@ impl DecayingAcceptanceSampler {
         }
 
         panic!("rejected all {MAX_TRIES_PER_SAMPLE} samples");
+    }
+}
+
+impl SamplingStrategy for DecayingAcceptanceSampler {
+    fn sample<R: Rng>(&self, rng: &mut R) -> ValidatorId {
+        self.sample_one(rng)
+    }
+
+    fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
+        let index = self.sample(rng).as_index();
+        &self.stake_weighted.validators[index]
     }
 }
 

--- a/src/disseminator/rotor/sampling_strategy.rs
+++ b/src/disseminator/rotor/sampling_strategy.rs
@@ -10,6 +10,10 @@
 //! via [`SamplingStrategy::sample_multiple`].
 //! However, samplers might override this for performance reasons.
 //!
+//! For strategies that produce a fixed-size quorum (like [`FaitAccompli1Sampler`]),
+//! use [`QuorumSamplingStrategy::sample_quorum`] instead of `sample_multiple`.
+//! The quorum size is fixed at construction time for these strategies.
+//!
 //! # Sampling strategies
 //!
 //! This module provides implementations for the following sampling strategies:
@@ -20,6 +24,8 @@
 //! - [`PartitionSampler`] splits validators into bins and samples from each bin.
 //! - [`FaitAccompli1Sampler`] uses the FA1-F committee sampling strategy.
 //! - [`FaitAccompli2Sampler`] uses the FA2 committee sampling strategy.
+//!
+//! The last three implement [`QuorumSamplingStrategy`] in addition to [`SamplingStrategy`].
 
 use std::sync::Mutex;
 
@@ -58,6 +64,10 @@ pub trait SamplingStrategy {
 
     /// Samples `k` validators with this probability distribution.
     ///
+    /// For samplers that implement [`QuorumSamplingStrategy`], prefer
+    /// [`QuorumSamplingStrategy::sample_quorum`], which uses the quorum size fixed
+    /// at construction time and avoids passing an incorrect `k`.
+    ///
     /// # Panics
     ///
     /// Panics if any of the `k` calls to [`SamplingStrategy::sample`] panics.
@@ -69,6 +79,23 @@ pub trait SamplingStrategy {
     fn name() -> &'static str {
         std::any::type_name::<Self>()
     }
+}
+
+/// Extension of [`SamplingStrategy`] for strategies that produce a fixed-size quorum.
+///
+/// Unlike [`SamplingStrategy::sample_multiple`], which takes `k` as a parameter at
+/// each call, a [`QuorumSamplingStrategy`] encodes the quorum size at construction time.
+/// This prevents accidental mismatches between the `k` used for construction (which
+/// pre-computes internal state) and the `k` passed to `sample_multiple` at call time.
+///
+/// Implementors also implement [`SamplingStrategy`] for single-validator sampling
+/// via [`SamplingStrategy::sample`].
+pub trait QuorumSamplingStrategy {
+    /// Returns the quorum size this sampler was constructed for.
+    fn quorum_size(&self) -> usize;
+
+    /// Samples a quorum of [`Self::quorum_size()`] validators.
+    fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId>;
 }
 
 /// A trivial sampler that picks the same validator all the time.
@@ -355,7 +382,7 @@ impl SamplingStrategy for TurbineSampler {
 /// However, this is done with lower variance than [`StakeWeightedSampler`] would.
 #[derive(Clone)]
 pub struct PartitionSampler {
-    validators: Vec<ValidatorInfo>,
+    stake_sampler: StakeWeightedSampler,
     bins: Vec<WeightedIndex<u64>>,
     pub bin_validators: Vec<Vec<ValidatorId>>,
     pub bin_stakes: Vec<Vec<Stake>>,
@@ -367,9 +394,10 @@ impl PartitionSampler {
     /// Partitions the given validators into `num_bins` bins of equal stake.
     /// Paritioning is done randomly by splitting a randomly permuted list of nodes.
     pub fn new(validators: Vec<ValidatorInfo>, num_bins: usize) -> Self {
+        let stake_sampler = StakeWeightedSampler::new(validators.clone());
         if num_bins == 0 {
             return Self {
-                validators,
+                stake_sampler,
                 bins: Vec::new(),
                 bin_validators: Vec::new(),
                 bin_stakes: Vec::new(),
@@ -412,7 +440,7 @@ impl PartitionSampler {
         }
 
         Self {
-            validators,
+            stake_sampler,
             bins,
             bin_validators,
             bin_stakes,
@@ -422,25 +450,47 @@ impl PartitionSampler {
 
 impl SamplingStrategy for PartitionSampler {
     fn sample<R: Rng>(&self, rng: &mut R) -> ValidatorId {
-        ValidatorId::new(rng.random_range(0..self.validators.len()) as u64)
+        self.stake_sampler.sample(rng)
     }
 
     fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
-        let index = self.sample(rng).as_index();
-        &self.validators[index]
+        self.stake_sampler.sample_info(rng)
     }
 
-    fn sample_multiple<R: Rng>(&self, _k: usize, rng: &mut R) -> Vec<ValidatorId> {
+    /// Samples `k` validators using the partition quorum sampling strategy.
+    ///
+    /// # Panics (debug only)
+    ///
+    /// In debug builds, panics if `k != self.quorum_size()`.
+    /// Prefer [`QuorumSamplingStrategy::sample_quorum`] instead.
+    fn sample_multiple<R: Rng>(&self, k: usize, rng: &mut R) -> Vec<ValidatorId> {
+        debug_assert_eq!(
+            k,
+            self.quorum_size(),
+            "PartitionSampler::sample_multiple called with k={k}, but was initialized for \
+             quorum_size={}; use sample_quorum() instead",
+            self.quorum_size()
+        );
+        self.sample_quorum(rng)
+    }
+
+    fn name() -> &'static str {
+        "partition"
+    }
+}
+
+impl QuorumSamplingStrategy for PartitionSampler {
+    fn quorum_size(&self) -> usize {
+        self.bins.len()
+    }
+
+    fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId> {
         let mut samples = Vec::new();
         for (bin, validators) in self.bins.iter().zip(self.bin_validators.iter()) {
             let i = bin.sample(rng);
             samples.push(validators[i]);
         }
         samples
-    }
-
-    fn name() -> &'static str {
-        "partition"
     }
 }
 
@@ -458,8 +508,10 @@ impl SamplingStrategy for PartitionSampler {
 /// See also: <https://dl.acm.org/doi/pdf/10.1145/3576915.3623194>
 pub struct FaitAccompli1Sampler<F: SamplingStrategy> {
     validators: Vec<ValidatorInfo>,
+    stake_sampler: StakeWeightedSampler,
     required_samples: Vec<ValidatorId>,
     pub fallback_sampler: F,
+    k: usize,
 }
 
 impl FaitAccompli1Sampler<PartitionSampler> {
@@ -480,6 +532,7 @@ impl FaitAccompli1Sampler<PartitionSampler> {
         let all_zero = validators_truncated_stake
             .iter()
             .all(|v| v.stake == Stake::new(0));
+        let stake_sampler = StakeWeightedSampler::new(validators.clone());
         let k_prime = k as usize - required_samples.len();
         let fallback_sampler = if all_zero {
             PartitionSampler::new(validators.clone(), k_prime)
@@ -488,8 +541,10 @@ impl FaitAccompli1Sampler<PartitionSampler> {
         };
         Self {
             validators,
+            stake_sampler,
             required_samples,
             fallback_sampler,
+            k: k as usize,
         }
     }
 }
@@ -512,6 +567,7 @@ impl FaitAccompli1Sampler<StakeWeightedSampler> {
         let all_zero = validators_truncated_stake
             .iter()
             .all(|v| v.stake == Stake::new(0));
+        let stake_sampler = StakeWeightedSampler::new(validators.clone());
         let fallback_sampler = if all_zero {
             StakeWeightedSampler::new(validators.clone())
         } else {
@@ -519,31 +575,38 @@ impl FaitAccompli1Sampler<StakeWeightedSampler> {
         };
         Self {
             validators,
+            stake_sampler,
             required_samples,
             fallback_sampler,
+            k: k as usize,
         }
     }
 }
 
 impl<F: SamplingStrategy> SamplingStrategy for FaitAccompli1Sampler<F> {
     fn sample<R: Rng>(&self, rng: &mut R) -> ValidatorId {
-        ValidatorId::new(rng.random_range(0..self.validators.len()) as u64)
+        self.stake_sampler.sample(rng)
     }
 
     fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
-        let index = self.sample(rng).as_index();
-        &self.validators[index]
+        self.stake_sampler.sample_info(rng)
     }
 
+    /// Samples `k` validators via the FA1 quorum sampling strategy.
+    ///
+    /// # Panics (debug only)
+    ///
+    /// In debug builds, panics if `k != self.quorum_size()`.
+    /// Prefer [`QuorumSamplingStrategy::sample_quorum`] instead.
     fn sample_multiple<R: Rng>(&self, k: usize, rng: &mut R) -> Vec<ValidatorId> {
-        let mut validators = Vec::with_capacity(k);
-        validators.extend_from_slice(&self.required_samples);
-        if validators.len() < k {
-            let k_prime = k - validators.len();
-            let additional_samples = self.fallback_sampler.sample_multiple(k_prime, rng);
-            validators.extend_from_slice(&additional_samples);
-        }
-        validators
+        debug_assert_eq!(
+            k,
+            self.quorum_size(),
+            "FaitAccompli1Sampler::sample_multiple called with k={k}, but was initialized for \
+             quorum_size={}; use sample_quorum() instead",
+            self.quorum_size()
+        );
+        self.sample_quorum(rng)
     }
 
     fn name() -> &'static str {
@@ -557,12 +620,31 @@ impl<F: SamplingStrategy> SamplingStrategy for FaitAccompli1Sampler<F> {
     }
 }
 
+impl<F: SamplingStrategy> QuorumSamplingStrategy for FaitAccompli1Sampler<F> {
+    fn quorum_size(&self) -> usize {
+        self.k
+    }
+
+    fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId> {
+        let mut result = Vec::with_capacity(self.k);
+        result.extend_from_slice(&self.required_samples);
+        if result.len() < self.k {
+            let k_prime = self.k - result.len();
+            let additional_samples = self.fallback_sampler.sample_multiple(k_prime, rng);
+            result.extend_from_slice(&additional_samples);
+        }
+        result
+    }
+}
+
 impl<F: SamplingStrategy + Clone> Clone for FaitAccompli1Sampler<F> {
     fn clone(&self) -> Self {
         Self {
             validators: self.validators.clone(),
+            stake_sampler: self.stake_sampler.clone(),
             required_samples: self.required_samples.clone(),
             fallback_sampler: self.fallback_sampler.clone(),
+            k: self.k,
         }
     }
 }
@@ -572,9 +654,11 @@ impl<F: SamplingStrategy + Clone> Clone for FaitAccompli1Sampler<F> {
 /// See also: <https://dl.acm.org/doi/pdf/10.1145/3576915.3623194>
 pub struct FaitAccompli2Sampler {
     validators: Vec<ValidatorInfo>,
+    stake_sampler: StakeWeightedSampler,
     required_samples: Vec<ValidatorId>,
     medium_nodes: Vec<(ValidatorId, f64)>,
     fallback_sampler: StakeWeightedSampler,
+    k: usize,
 }
 
 impl FaitAccompli2Sampler {
@@ -627,6 +711,7 @@ impl FaitAccompli2Sampler {
                 v
             })
             .collect();
+        let stake_sampler = StakeWeightedSampler::new(validators.clone());
         let fallback_sampler = if r == 0.0 {
             StakeWeightedSampler::new(validators.clone())
         } else {
@@ -635,9 +720,11 @@ impl FaitAccompli2Sampler {
 
         Self {
             validators,
+            stake_sampler,
             required_samples,
             medium_nodes,
             fallback_sampler,
+            k: k as usize,
         }
     }
 
@@ -656,34 +743,28 @@ impl FaitAccompli2Sampler {
 
 impl SamplingStrategy for FaitAccompli2Sampler {
     fn sample<R: Rng>(&self, rng: &mut R) -> ValidatorId {
-        ValidatorId::new(rng.random_range(0..self.validators.len()) as u64)
+        self.stake_sampler.sample(rng)
     }
 
     fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
-        let index = self.sample(rng).as_index();
-        &self.validators[index]
+        self.stake_sampler.sample_info(rng)
     }
 
+    /// Samples `k` validators via the FA2 quorum sampling strategy.
+    ///
+    /// # Panics (debug only)
+    ///
+    /// In debug builds, panics if `k != self.quorum_size()`.
+    /// Prefer [`QuorumSamplingStrategy::sample_quorum`] instead.
     fn sample_multiple<R: Rng>(&self, k: usize, rng: &mut R) -> Vec<ValidatorId> {
-        // add required FA1 samples
-        let mut validators = Vec::with_capacity(k);
-        validators.extend_from_slice(&self.required_samples);
-
-        // sample medium nodes (FA2 step)
-        for (validator, probability) in &self.medium_nodes {
-            if rng.random_bool(*probability) {
-                validators.push(*validator);
-            }
-        }
-
-        // sample remaining validators IID stake-weighted
-        if validators.len() < k {
-            let k_prime = k - validators.len();
-            let additional_samples = self.fallback_sampler.sample_multiple(k_prime, rng);
-            validators.extend_from_slice(&additional_samples);
-        }
-
-        validators
+        debug_assert_eq!(
+            k,
+            self.quorum_size(),
+            "FaitAccompli2Sampler::sample_multiple called with k={k}, but was initialized for \
+             quorum_size={}; use sample_quorum() instead",
+            self.quorum_size()
+        );
+        self.sample_quorum(rng)
     }
 
     fn name() -> &'static str {
@@ -691,13 +772,43 @@ impl SamplingStrategy for FaitAccompli2Sampler {
     }
 }
 
+impl QuorumSamplingStrategy for FaitAccompli2Sampler {
+    fn quorum_size(&self) -> usize {
+        self.k
+    }
+
+    fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId> {
+        // add required FA1 samples
+        let mut result = Vec::with_capacity(self.k);
+        result.extend_from_slice(&self.required_samples);
+
+        // sample medium nodes (FA2 step)
+        for (validator, probability) in &self.medium_nodes {
+            if rng.random_bool(*probability) {
+                result.push(*validator);
+            }
+        }
+
+        // sample remaining validators IID stake-weighted
+        if result.len() < self.k {
+            let k_prime = self.k - result.len();
+            let additional_samples = self.fallback_sampler.sample_multiple(k_prime, rng);
+            result.extend_from_slice(&additional_samples);
+        }
+
+        result
+    }
+}
+
 impl Clone for FaitAccompli2Sampler {
     fn clone(&self) -> Self {
         Self {
             validators: self.validators.clone(),
+            stake_sampler: self.stake_sampler.clone(),
             required_samples: self.required_samples.clone(),
             medium_nodes: self.medium_nodes.clone(),
             fallback_sampler: self.fallback_sampler.clone(),
+            k: self.k,
         }
     }
 }
@@ -1029,7 +1140,8 @@ mod tests {
         // with k equal-weight nodes this deterministically selects all nodes
         let validators = create_validator_info(64);
         let sampler = PartitionSampler::new(validators, 64);
-        let sampled = sampler.sample_multiple(64, &mut rand::rng());
+        assert_eq!(sampler.quorum_size(), 64);
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         assert_eq!(sampled.len(), 64);
         let sampled: HashSet<_> = sampled.into_iter().collect();
         assert_eq!(sampled.len(), 64);
@@ -1043,7 +1155,8 @@ mod tests {
         // with k equal-weight nodes this deterministically selects all nodes
         let validators = create_validator_info(64);
         let sampler = FaitAccompli1Sampler::new_with_stake_weighted_fallback(validators, 64);
-        let sampled = sampler.sample_multiple(64, &mut rand::rng());
+        assert_eq!(sampler.quorum_size(), 64);
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         assert_eq!(sampled.len(), 64);
         let sampled: HashSet<_> = sampled.into_iter().collect();
         assert_eq!(sampled.len(), 64);
@@ -1055,7 +1168,8 @@ mod tests {
         // (also for partitioning fallback sampler)
         let validators = create_validator_info(64);
         let sampler = FaitAccompli1Sampler::new_with_partition_fallback(validators, 64);
-        let sampled = sampler.sample_multiple(64, &mut rand::rng());
+        assert_eq!(sampler.quorum_size(), 64);
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         assert_eq!(sampled.len(), 64);
         let sampled: HashSet<_> = sampled.into_iter().collect();
         assert_eq!(sampled.len(), 64);
@@ -1068,7 +1182,7 @@ mod tests {
         for _ in 0..20 {
             let validators = create_validator_info(1000);
             let sampler = FaitAccompli1Sampler::new_with_stake_weighted_fallback(validators, 64);
-            let sampled = sampler.sample_multiple(64, &mut rand::rng());
+            let sampled = sampler.sample_quorum(&mut rand::rng());
             assert_eq!(sampled.len(), 64);
             let sampled_set = sampled.iter().collect::<HashSet<_>>();
             let max_appearances = sampled_set
@@ -1086,7 +1200,7 @@ mod tests {
         validators[0].stake = Stake::new(52);
         validators[1].stake = Stake::new(52);
         let sampler = FaitAccompli1Sampler::new_with_stake_weighted_fallback(validators, 64);
-        let sampled = sampler.sample_multiple(64, &mut rand::rng());
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         assert_eq!(sampled.len(), 64);
         let sampled0 = sampled
             .iter()
@@ -1105,7 +1219,8 @@ mod tests {
         // with k equal-weight nodes this deterministically selects all nodes
         let validators = create_validator_info(64);
         let sampler = FaitAccompli2Sampler::new(validators, 64);
-        let sampled = sampler.sample_multiple(64, &mut rand::rng());
+        assert_eq!(sampler.quorum_size(), 64);
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         assert_eq!(sampled.len(), 64);
         let sampled: HashSet<_> = sampled.into_iter().collect();
         assert_eq!(sampled.len(), 64);

--- a/src/disseminator/rotor/sampling_strategy.rs
+++ b/src/disseminator/rotor/sampling_strategy.rs
@@ -1,31 +1,36 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Different strategies for sampling validators.
+//! Strategies for sampling validators.
 //!
-//! First, this module provides a trait for randomly sampling validators.
-//! To implement a new sampling strategy, you need to implement [`SamplingStrategy`],
-//! by implementing [`SamplingStrategy::sample`].
-//! The trait provides a default implementation for sampling `k` validators,
-//! via [`SamplingStrategy::sample_multiple`].
-//! However, samplers might override this for performance reasons.
+//! This module provides two traits reflecting two distinct operations:
 //!
-//! For strategies that produce a fixed-size quorum (like [`FaitAccompli1Sampler`]),
-//! use [`QuorumSamplingStrategy::sample_quorum`] instead of `sample_multiple`.
-//! The quorum size is fixed at construction time for these strategies.
+//! - [`SamplingStrategy`] samples a single validator from some distribution.
+//!   Implemented by [`UniformSampler`], [`StakeWeightedSampler`], [`TurbineSampler`], etc.
+//!
+//! - [`QuorumSamplingStrategy`] samples a fixed-size committee (quorum) of validators.
+//!   The quorum size is fixed at construction time. Implemented by [`FaitAccompli1Sampler`],
+//!   [`FaitAccompli2Sampler`], and [`PartitionSampler`].
+//!
+//! Any single-node strategy can be turned into a quorum strategy via IID sampling:
+//! Call [`SamplingStrategy::into_quorum_strategy`] to obtain an [`IidQuorumSampler`].
+//! The reverse direction (quorum → single-node) is intentionally not provided,
+//! because quorum strategies like FA1 have no meaningful single-node operation.
 //!
 //! # Sampling strategies
 //!
-//! This module provides implementations for the following sampling strategies:
-//! - [`UniformSampler`] does uniform sampling with replacement.
-//! - [`StakeWeightedSampler`] samples validators proportional to their stake.
-//! - [`DecayingAcceptanceSampler`] samples validators less as they approach maximum.
+//! Single-node strategies ([`SamplingStrategy`]):
+//! - [`AllSameSampler`] always returns the same validator (for testing).
+//! - [`UniformSampler`] picks all validators with equal probability.
+//! - [`StakeWeightedSampler`] picks validators proportional to their stake.
 //! - [`TurbineSampler`] simulates the workload of Turbine.
+//!
+//! Quorum strategies ([`QuorumSamplingStrategy`]):
+//! - [`IidQuorumSampler`] wraps any single-node strategy, sampling IID.
+//! - [`DecayingAcceptanceSampler`] hybrid between with/without replacement.
 //! - [`PartitionSampler`] splits validators into bins and samples from each bin.
 //! - [`FaitAccompli1Sampler`] uses the FA1-F committee sampling strategy.
 //! - [`FaitAccompli2Sampler`] uses the FA2 committee sampling strategy.
-//!
-//! The last three implement [`QuorumSamplingStrategy`] in addition to [`SamplingStrategy`].
 
 use std::sync::Mutex;
 
@@ -38,11 +43,14 @@ use crate::{Stake, ValidatorId, ValidatorInfo};
 /// Sampling strategies involving rejection sampling may panic after rejecting this many samples.
 const MAX_TRIES_PER_SAMPLE: usize = 100_000;
 
-/// An abstraction for randomly sampling validators based on some distribution.
+/// Strategy for sampling individual validators from some distribution.
+///
+/// Use [`into_quorum_strategy`] to turn any single-node strategy into a
+/// [`QuorumSamplingStrategy`] via IID sampling.
+///
+/// [`into_quorum_strategy`]: SamplingStrategy::into_quorum_strategy
 pub trait SamplingStrategy {
     /// Samples a validator with this probability distribution.
-    ///
-    /// Depending on the implementor, this may or may not be stateless.
     ///
     /// # Panics
     ///
@@ -52,9 +60,7 @@ pub trait SamplingStrategy {
         self.sample_info(rng).id
     }
 
-    /// Samples a validator's `ValidatorInfo` with this probability distribution.
-    ///
-    /// Depending on the implementor, this may or may not be stateless.
+    /// Samples a validator's [`ValidatorInfo`] with this probability distribution.
     ///
     /// # Panics
     ///
@@ -62,18 +68,36 @@ pub trait SamplingStrategy {
     /// or if the sampling process failed [`MAX_TRIES_PER_SAMPLE`] times.
     fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo;
 
-    /// Samples `k` validators with this probability distribution.
-    ///
-    /// For samplers that implement [`QuorumSamplingStrategy`], prefer
-    /// [`QuorumSamplingStrategy::sample_quorum`], which uses the quorum size fixed
-    /// at construction time and avoids passing an incorrect `k`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if any of the `k` calls to [`SamplingStrategy::sample`] panics.
-    fn sample_multiple<R: Rng>(&self, k: usize, rng: &mut R) -> Vec<ValidatorId> {
-        (0..k).map(|_| self.sample(rng)).collect()
+    /// Returns a printable name of the sampling strategy.
+    fn name() -> &'static str {
+        std::any::type_name::<Self>()
     }
+
+    /// Wraps this sampler into an [`IidQuorumSampler`] with the given quorum size.
+    ///
+    /// The returned adapter implements [`QuorumSamplingStrategy`] by calling
+    /// [`sample`] `k` times independently.
+    ///
+    /// [`sample`]: SamplingStrategy::sample
+    fn into_quorum_strategy(self, k: usize) -> IidQuorumSampler<Self>
+    where
+        Self: Sized,
+    {
+        IidQuorumSampler::new(self, k)
+    }
+}
+
+/// Strategy for sampling a fixed-size quorum (committee) of validators.
+///
+/// The quorum size is determined at construction time. Strategies like
+/// [`FaitAccompli1Sampler`] pre-compute internal state based on this size,
+/// so it cannot be changed after construction.
+pub trait QuorumSamplingStrategy {
+    /// Returns the quorum size this sampler was constructed for.
+    fn quorum_size(&self) -> usize;
+
+    /// Samples a quorum of [`Self::quorum_size()`] validators.
+    fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId>;
 
     /// Returns a printable name of the sampling strategy.
     fn name() -> &'static str {
@@ -81,21 +105,49 @@ pub trait SamplingStrategy {
     }
 }
 
-/// Extension of [`SamplingStrategy`] for strategies that produce a fixed-size quorum.
+/// Adapter that turns any [`SamplingStrategy`] into a [`QuorumSamplingStrategy`]
+/// by sampling IID (independently and identically distributed).
 ///
-/// Unlike [`SamplingStrategy::sample_multiple`], which takes `k` as a parameter at
-/// each call, a [`QuorumSamplingStrategy`] encodes the quorum size at construction time.
-/// This prevents accidental mismatches between the `k` used for construction (which
-/// pre-computes internal state) and the `k` passed to `sample_multiple` at call time.
-///
-/// Implementors also implement [`SamplingStrategy`] for single-validator sampling
-/// via [`SamplingStrategy::sample`].
-pub trait QuorumSamplingStrategy {
-    /// Returns the quorum size this sampler was constructed for.
-    fn quorum_size(&self) -> usize;
+/// Created via [`SamplingStrategy::into_quorum_strategy`].
+#[derive(Clone)]
+pub struct IidQuorumSampler<S: SamplingStrategy> {
+    inner: S,
+    k: usize,
+}
 
-    /// Samples a quorum of [`Self::quorum_size()`] validators.
-    fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId>;
+impl<S: SamplingStrategy> IidQuorumSampler<S> {
+    /// Creates a new [`IidQuorumSampler`] wrapping `inner` with quorum size `k`.
+    pub fn new(inner: S, k: usize) -> Self {
+        Self { inner, k }
+    }
+}
+
+impl<S: SamplingStrategy> SamplingStrategy for IidQuorumSampler<S> {
+    fn sample<R: Rng>(&self, rng: &mut R) -> ValidatorId {
+        self.inner.sample(rng)
+    }
+
+    fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
+        self.inner.sample_info(rng)
+    }
+
+    fn name() -> &'static str {
+        S::name()
+    }
+}
+
+impl<S: SamplingStrategy> QuorumSamplingStrategy for IidQuorumSampler<S> {
+    fn quorum_size(&self) -> usize {
+        self.k
+    }
+
+    fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId> {
+        (0..self.k).map(|_| self.inner.sample(rng)).collect()
+    }
+
+    fn name() -> &'static str {
+        S::name()
+    }
 }
 
 /// A trivial sampler that picks the same validator all the time.
@@ -180,86 +232,6 @@ impl SamplingStrategy for StakeWeightedSampler {
 
     fn name() -> &'static str {
         "stake_weighted"
-    }
-}
-
-/// A hybrid sampler between weighted sampling with and without replacement.
-///
-/// Any element is sample at most `ceil(max_samples)` times.
-/// Elements are rejected with probability proportional to `k / max_samples`,
-/// where `k` is how often the element has been sampled before.
-/// Sampling differs between, e.g., `max_samples = 2` and `max_samples = 2.5`.
-///
-/// - For `max_samples = 1` it is stake-weighted sampling WITHOUT replacement.
-/// - For `max_samples -> inf` it approaches the behavior WITH replacement.
-pub struct DecayingAcceptanceSampler {
-    stake_weighted: StakeWeightedSampler,
-    max_samples: f64,
-    sample_count: Mutex<Vec<usize>>,
-}
-
-impl DecayingAcceptanceSampler {
-    /// Creates a new `DecayingAcceptanceSampler` instance.
-    pub fn new(validators: Vec<ValidatorInfo>, max_samples: f64) -> Self {
-        let sample_count = vec![0; validators.len()];
-        Self {
-            stake_weighted: StakeWeightedSampler::new(validators),
-            max_samples,
-            sample_count: Mutex::new(sample_count),
-        }
-    }
-
-    /// Resets the internal state of this stateful sampler.
-    /// After resetting it is just as it was when it was first created.
-    pub fn reset(&self) {
-        let mut sample_count = self.sample_count.lock().unwrap();
-        *sample_count = vec![0; self.stake_weighted.validators.len()];
-    }
-}
-
-impl SamplingStrategy for DecayingAcceptanceSampler {
-    /// Samples a validator with the given probability distribution.
-    ///
-    /// # Panics
-    ///
-    /// Panics if after [`MAX_TRIES_PER_SAMPLE`] samples none was valid.
-    fn sample<R: Rng>(&self, rng: &mut R) -> ValidatorId {
-        for _ in 0..MAX_TRIES_PER_SAMPLE {
-            let sample = self.stake_weighted.sample(rng);
-            let mut sample_count = self.sample_count.lock().unwrap();
-            let p_reject = sample_count[sample.as_index()] as f64 / self.max_samples;
-            if rng.random::<f64>() >= p_reject {
-                sample_count[sample.as_index()] += 1;
-                return sample;
-            }
-        }
-
-        panic!("rejected all {MAX_TRIES_PER_SAMPLE} samples");
-    }
-
-    fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
-        let index = self.sample(rng).as_index();
-        &self.stake_weighted.validators[index]
-    }
-
-    fn sample_multiple<R: Rng>(&self, k: usize, rng: &mut R) -> Vec<ValidatorId> {
-        let samples = (0..k).map(|_| self.sample(rng)).collect();
-        self.reset();
-        samples
-    }
-
-    fn name() -> &'static str {
-        "decaying_acceptance"
-    }
-}
-
-impl Clone for DecayingAcceptanceSampler {
-    fn clone(&self) -> Self {
-        Self {
-            stake_weighted: self.stake_weighted.clone(),
-            max_samples: self.max_samples,
-            sample_count: Mutex::new(self.sample_count.lock().unwrap().clone()),
-        }
     }
 }
 
@@ -368,6 +340,98 @@ impl SamplingStrategy for TurbineSampler {
     }
 }
 
+/// A hybrid sampler between weighted sampling with and without replacement.
+///
+/// Any element is sample at most `ceil(max_samples)` times.
+/// Elements are rejected with probability proportional to `k / max_samples`,
+/// where `k` is how often the element has been sampled before.
+/// Sampling differs between, e.g., `max_samples = 2` and `max_samples = 2.5`.
+///
+/// - For `max_samples = 1` it is stake-weighted sampling WITHOUT replacement.
+/// - For `max_samples -> infinity` it approaches the behavior WITH replacement.
+///
+/// This sampler implements [`QuorumSamplingStrategy`] with a fixed quorum size.
+/// Internal state is automatically reset after each call to [`sample_quorum`].
+///
+/// [`sample_quorum`]: QuorumSamplingStrategy::sample_quorum
+pub struct DecayingAcceptanceSampler {
+    stake_weighted: StakeWeightedSampler,
+    pub max_samples: f64,
+    sample_count: Mutex<Vec<usize>>,
+    k: usize,
+}
+
+impl DecayingAcceptanceSampler {
+    /// Creates a new `DecayingAcceptanceSampler` instance with the given quorum size.
+    pub fn new(validators: Vec<ValidatorInfo>, max_samples: f64, k: usize) -> Self {
+        let sample_count = vec![0; validators.len()];
+        Self {
+            stake_weighted: StakeWeightedSampler::new(validators),
+            max_samples,
+            sample_count: Mutex::new(sample_count),
+            k,
+        }
+    }
+
+    /// Resets the internal state of this stateful sampler.
+    /// After resetting it is just as it was when it was first created.
+    pub fn reset(&self) {
+        let mut sample_count = self.sample_count.lock().unwrap();
+        *sample_count = vec![0; self.stake_weighted.validators.len()];
+    }
+
+    /// Samples a single validator with the decaying acceptance distribution.
+    ///
+    /// This is stateful: repeated calls without [`reset`] will cause
+    /// previously-sampled validators to be rejected more often.
+    ///
+    /// # Panics
+    ///
+    /// Panics if after [`MAX_TRIES_PER_SAMPLE`] samples none was valid.
+    ///
+    /// [`reset`]: DecayingAcceptanceSampler::reset
+    pub fn sample_one<R: Rng>(&self, rng: &mut R) -> ValidatorId {
+        for _ in 0..MAX_TRIES_PER_SAMPLE {
+            let sample = self.stake_weighted.sample(rng);
+            let mut sample_count = self.sample_count.lock().unwrap();
+            let p_reject = sample_count[sample.as_index()] as f64 / self.max_samples;
+            if rng.random::<f64>() >= p_reject {
+                sample_count[sample.as_index()] += 1;
+                return sample;
+            }
+        }
+
+        panic!("rejected all {MAX_TRIES_PER_SAMPLE} samples");
+    }
+}
+
+impl QuorumSamplingStrategy for DecayingAcceptanceSampler {
+    fn quorum_size(&self) -> usize {
+        self.k
+    }
+
+    fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId> {
+        let samples = (0..self.k).map(|_| self.sample_one(rng)).collect();
+        self.reset();
+        samples
+    }
+
+    fn name() -> &'static str {
+        "decaying_acceptance"
+    }
+}
+
+impl Clone for DecayingAcceptanceSampler {
+    fn clone(&self) -> Self {
+        Self {
+            stake_weighted: self.stake_weighted.clone(),
+            max_samples: self.max_samples,
+            sample_count: Mutex::new(self.sample_count.lock().unwrap().clone()),
+            k: self.k,
+        }
+    }
+}
+
 /// A sampler that samples proportional to stake with reduced variance.
 ///
 /// This sampler operates on `k` bins of validators of equal stake.
@@ -382,7 +446,6 @@ impl SamplingStrategy for TurbineSampler {
 /// However, this is done with lower variance than [`StakeWeightedSampler`] would.
 #[derive(Clone)]
 pub struct PartitionSampler {
-    stake_sampler: StakeWeightedSampler,
     bins: Vec<WeightedIndex<u64>>,
     pub bin_validators: Vec<Vec<ValidatorId>>,
     pub bin_stakes: Vec<Vec<Stake>>,
@@ -394,10 +457,8 @@ impl PartitionSampler {
     /// Partitions the given validators into `num_bins` bins of equal stake.
     /// Paritioning is done randomly by splitting a randomly permuted list of nodes.
     pub fn new(validators: Vec<ValidatorInfo>, num_bins: usize) -> Self {
-        let stake_sampler = StakeWeightedSampler::new(validators.clone());
         if num_bins == 0 {
             return Self {
-                stake_sampler,
                 bins: Vec::new(),
                 bin_validators: Vec::new(),
                 bin_stakes: Vec::new(),
@@ -409,7 +470,7 @@ impl PartitionSampler {
 
         let total_stake: Stake = validators.iter().map(|v| v.stake).sum();
         let stake_per_bin = total_stake.div_ceil(num_bins as u64);
-        let mut validators_random = validators.clone();
+        let mut validators_random = validators;
         validators_random.shuffle(&mut rand::rng());
 
         // partition into bins
@@ -440,42 +501,10 @@ impl PartitionSampler {
         }
 
         Self {
-            stake_sampler,
             bins,
             bin_validators,
             bin_stakes,
         }
-    }
-}
-
-impl SamplingStrategy for PartitionSampler {
-    fn sample<R: Rng>(&self, rng: &mut R) -> ValidatorId {
-        self.stake_sampler.sample(rng)
-    }
-
-    fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
-        self.stake_sampler.sample_info(rng)
-    }
-
-    /// Samples `k` validators using the partition quorum sampling strategy.
-    ///
-    /// # Panics (debug only)
-    ///
-    /// In debug builds, panics if `k != self.quorum_size()`.
-    /// Prefer [`QuorumSamplingStrategy::sample_quorum`] instead.
-    fn sample_multiple<R: Rng>(&self, k: usize, rng: &mut R) -> Vec<ValidatorId> {
-        debug_assert_eq!(
-            k,
-            self.quorum_size(),
-            "PartitionSampler::sample_multiple called with k={k}, but was initialized for \
-             quorum_size={}; use sample_quorum() instead",
-            self.quorum_size()
-        );
-        self.sample_quorum(rng)
-    }
-
-    fn name() -> &'static str {
-        "partition"
     }
 }
 
@@ -492,6 +521,10 @@ impl QuorumSamplingStrategy for PartitionSampler {
         }
         samples
     }
+
+    fn name() -> &'static str {
+        "partition"
+    }
 }
 
 /// A sampler that uses the FA1-F committee sampling strategy.
@@ -506,9 +539,7 @@ impl QuorumSamplingStrategy for PartitionSampler {
 ///    with modified stake weights: `S'(v) = S(v) - floor(S(v) * k) / k`
 ///
 /// See also: <https://dl.acm.org/doi/pdf/10.1145/3576915.3623194>
-pub struct FaitAccompli1Sampler<F: SamplingStrategy> {
-    validators: Vec<ValidatorInfo>,
-    stake_sampler: StakeWeightedSampler,
+pub struct FaitAccompli1Sampler<F: QuorumSamplingStrategy> {
     required_samples: Vec<ValidatorId>,
     pub fallback_sampler: F,
     k: usize,
@@ -532,16 +563,13 @@ impl FaitAccompli1Sampler<PartitionSampler> {
         let all_zero = validators_truncated_stake
             .iter()
             .all(|v| v.stake == Stake::new(0));
-        let stake_sampler = StakeWeightedSampler::new(validators.clone());
         let k_prime = k as usize - required_samples.len();
         let fallback_sampler = if all_zero {
-            PartitionSampler::new(validators.clone(), k_prime)
+            PartitionSampler::new(validators, k_prime)
         } else {
             PartitionSampler::new(validators_truncated_stake, k_prime)
         };
         Self {
-            validators,
-            stake_sampler,
             required_samples,
             fallback_sampler,
             k: k as usize,
@@ -549,7 +577,7 @@ impl FaitAccompli1Sampler<PartitionSampler> {
     }
 }
 
-impl FaitAccompli1Sampler<StakeWeightedSampler> {
+impl FaitAccompli1Sampler<IidQuorumSampler<StakeWeightedSampler>> {
     /// Creates a new FA1-F sampler with an IID stake-weighted fallback sampler.
     ///
     /// See [`StakeWeightedSampler`] for more details.
@@ -567,15 +595,13 @@ impl FaitAccompli1Sampler<StakeWeightedSampler> {
         let all_zero = validators_truncated_stake
             .iter()
             .all(|v| v.stake == Stake::new(0));
-        let stake_sampler = StakeWeightedSampler::new(validators.clone());
+        let k_prime = k as usize - required_samples.len();
         let fallback_sampler = if all_zero {
-            StakeWeightedSampler::new(validators.clone())
+            StakeWeightedSampler::new(validators).into_quorum_strategy(k_prime)
         } else {
-            StakeWeightedSampler::new(validators_truncated_stake)
+            StakeWeightedSampler::new(validators_truncated_stake).into_quorum_strategy(k_prime)
         };
         Self {
-            validators,
-            stake_sampler,
             required_samples,
             fallback_sampler,
             k: k as usize,
@@ -583,30 +609,21 @@ impl FaitAccompli1Sampler<StakeWeightedSampler> {
     }
 }
 
-impl<F: SamplingStrategy> SamplingStrategy for FaitAccompli1Sampler<F> {
-    fn sample<R: Rng>(&self, rng: &mut R) -> ValidatorId {
-        self.stake_sampler.sample(rng)
+impl<F: QuorumSamplingStrategy> QuorumSamplingStrategy for FaitAccompli1Sampler<F> {
+    fn quorum_size(&self) -> usize {
+        self.k
     }
 
-    fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
-        self.stake_sampler.sample_info(rng)
-    }
-
-    /// Samples `k` validators via the FA1 quorum sampling strategy.
-    ///
-    /// # Panics (debug only)
-    ///
-    /// In debug builds, panics if `k != self.quorum_size()`.
-    /// Prefer [`QuorumSamplingStrategy::sample_quorum`] instead.
-    fn sample_multiple<R: Rng>(&self, k: usize, rng: &mut R) -> Vec<ValidatorId> {
-        debug_assert_eq!(
-            k,
-            self.quorum_size(),
-            "FaitAccompli1Sampler::sample_multiple called with k={k}, but was initialized for \
-             quorum_size={}; use sample_quorum() instead",
-            self.quorum_size()
-        );
-        self.sample_quorum(rng)
+    fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId> {
+        let mut result = Vec::with_capacity(self.k);
+        result.extend_from_slice(&self.required_samples);
+        if result.len() < self.k {
+            let k_prime = self.k - result.len();
+            assert_eq!(k_prime, self.fallback_sampler.quorum_size());
+            let additional_samples = self.fallback_sampler.sample_quorum(rng);
+            result.extend_from_slice(&additional_samples);
+        }
+        result
     }
 
     fn name() -> &'static str {
@@ -620,28 +637,9 @@ impl<F: SamplingStrategy> SamplingStrategy for FaitAccompli1Sampler<F> {
     }
 }
 
-impl<F: SamplingStrategy> QuorumSamplingStrategy for FaitAccompli1Sampler<F> {
-    fn quorum_size(&self) -> usize {
-        self.k
-    }
-
-    fn sample_quorum<R: Rng>(&self, rng: &mut R) -> Vec<ValidatorId> {
-        let mut result = Vec::with_capacity(self.k);
-        result.extend_from_slice(&self.required_samples);
-        if result.len() < self.k {
-            let k_prime = self.k - result.len();
-            let additional_samples = self.fallback_sampler.sample_multiple(k_prime, rng);
-            result.extend_from_slice(&additional_samples);
-        }
-        result
-    }
-}
-
-impl<F: SamplingStrategy + Clone> Clone for FaitAccompli1Sampler<F> {
+impl<F: QuorumSamplingStrategy + Clone> Clone for FaitAccompli1Sampler<F> {
     fn clone(&self) -> Self {
         Self {
-            validators: self.validators.clone(),
-            stake_sampler: self.stake_sampler.clone(),
             required_samples: self.required_samples.clone(),
             fallback_sampler: self.fallback_sampler.clone(),
             k: self.k,
@@ -653,11 +651,9 @@ impl<F: SamplingStrategy + Clone> Clone for FaitAccompli1Sampler<F> {
 ///
 /// See also: <https://dl.acm.org/doi/pdf/10.1145/3576915.3623194>
 pub struct FaitAccompli2Sampler {
-    validators: Vec<ValidatorInfo>,
-    stake_sampler: StakeWeightedSampler,
     required_samples: Vec<ValidatorId>,
     medium_nodes: Vec<(ValidatorId, f64)>,
-    fallback_sampler: StakeWeightedSampler,
+    fallback_sampler: IidQuorumSampler<StakeWeightedSampler>,
     k: usize,
 }
 
@@ -711,16 +707,16 @@ impl FaitAccompli2Sampler {
                 v
             })
             .collect();
-        let stake_sampler = StakeWeightedSampler::new(validators.clone());
+        // The fallback quorum size is an upper bound; FA2's sample_quorum may request
+        // fewer samples depending on how many medium nodes were included.
+        let fallback_k = k as usize - required_samples.len();
         let fallback_sampler = if r == 0.0 {
-            StakeWeightedSampler::new(validators.clone())
+            StakeWeightedSampler::new(validators).into_quorum_strategy(fallback_k)
         } else {
-            StakeWeightedSampler::new(new_stake_distribution)
+            StakeWeightedSampler::new(new_stake_distribution).into_quorum_strategy(fallback_k)
         };
 
         Self {
-            validators,
-            stake_sampler,
             required_samples,
             medium_nodes,
             fallback_sampler,
@@ -738,37 +734,6 @@ impl FaitAccompli2Sampler {
             .collect();
         assert!(f.iter().sum::<f64>() <= 1.0);
         f
-    }
-}
-
-impl SamplingStrategy for FaitAccompli2Sampler {
-    fn sample<R: Rng>(&self, rng: &mut R) -> ValidatorId {
-        self.stake_sampler.sample(rng)
-    }
-
-    fn sample_info<R: Rng>(&self, rng: &mut R) -> &ValidatorInfo {
-        self.stake_sampler.sample_info(rng)
-    }
-
-    /// Samples `k` validators via the FA2 quorum sampling strategy.
-    ///
-    /// # Panics (debug only)
-    ///
-    /// In debug builds, panics if `k != self.quorum_size()`.
-    /// Prefer [`QuorumSamplingStrategy::sample_quorum`] instead.
-    fn sample_multiple<R: Rng>(&self, k: usize, rng: &mut R) -> Vec<ValidatorId> {
-        debug_assert_eq!(
-            k,
-            self.quorum_size(),
-            "FaitAccompli2Sampler::sample_multiple called with k={k}, but was initialized for \
-             quorum_size={}; use sample_quorum() instead",
-            self.quorum_size()
-        );
-        self.sample_quorum(rng)
-    }
-
-    fn name() -> &'static str {
-        "fa2"
     }
 }
 
@@ -792,19 +757,23 @@ impl QuorumSamplingStrategy for FaitAccompli2Sampler {
         // sample remaining validators IID stake-weighted
         if result.len() < self.k {
             let k_prime = self.k - result.len();
-            let additional_samples = self.fallback_sampler.sample_multiple(k_prime, rng);
+            let additional_samples: Vec<_> = (0..k_prime)
+                .map(|_| self.fallback_sampler.inner.sample(rng))
+                .collect();
             result.extend_from_slice(&additional_samples);
         }
 
         result
+    }
+
+    fn name() -> &'static str {
+        "fa2"
     }
 }
 
 impl Clone for FaitAccompli2Sampler {
     fn clone(&self) -> Self {
         Self {
-            validators: self.validators.clone(),
-            stake_sampler: self.stake_sampler.clone(),
             required_samples: self.required_samples.clone(),
             medium_nodes: self.medium_nodes.clone(),
             fallback_sampler: self.fallback_sampler.clone(),
@@ -855,8 +824,9 @@ mod tests {
             assert_eq!(sampler.sample_info(&mut rng).id, ValidatorId::new(3));
         }
 
+        let quorum = sampler.into_quorum_strategy(TOTAL_SHREDS);
         for _ in 0..10 {
-            let sampled_vals = sampler.sample_multiple(TOTAL_SHREDS, &mut rng);
+            let sampled_vals = quorum.sample_quorum(&mut rng);
             for val in sampled_vals {
                 assert_eq!(val, ValidatorId::new(3));
             }
@@ -867,8 +837,8 @@ mod tests {
     fn uniform_sampler() {
         // apply Hoeffding's bound to number of different samples
         let validators = create_validator_info(1000);
-        let sampler = UniformSampler::new(validators);
-        let sampled = sampler.sample_multiple(1000, &mut rand::rng());
+        let sampler = UniformSampler::new(validators).into_quorum_strategy(1000);
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         let sampled_set: HashSet<_> = sampled.iter().collect();
         assert!(sampled_set.len() > 500 && sampled_set.len() < 750);
         // apply Chernoff's bound to maximum appearances of any sample
@@ -883,8 +853,8 @@ mod tests {
         // bounds should hold even with one high-stake validator
         let mut validators = create_validator_info(1000);
         validators[0].stake = Stake::new(1_000_000_000);
-        let sampler = UniformSampler::new(validators);
-        let sampled = sampler.sample_multiple(1000, &mut rand::rng());
+        let sampler = UniformSampler::new(validators).into_quorum_strategy(1000);
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         let sampled_set: HashSet<_> = sampled.iter().collect();
         assert!(sampled_set.len() > 500 && sampled_set.len() < 750);
         let max_appearances = sampled_set
@@ -900,8 +870,8 @@ mod tests {
         for i in (0..validators.len()).step_by(2) {
             validators[i].stake = Stake::new(1_000_000_000);
         }
-        let sampler = UniformSampler::new(validators);
-        let sampled = sampler.sample_multiple(1000, &mut rand::rng());
+        let sampler = UniformSampler::new(validators).into_quorum_strategy(1000);
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         let sampled_set: HashSet<_> = sampled.iter().collect();
         assert!(sampled_set.len() > 500 && sampled_set.len() < 750);
         let max_appearances = sampled_set
@@ -917,8 +887,8 @@ mod tests {
     fn stake_weighted_sampler() {
         // with equal stake, bounds from uniform sampling hold
         let validators = create_validator_info(1000);
-        let sampler = StakeWeightedSampler::new(validators);
-        let sampled = sampler.sample_multiple(1000, &mut rand::rng());
+        let sampler = StakeWeightedSampler::new(validators).into_quorum_strategy(1000);
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         let sampled_set: HashSet<_> = sampled.iter().collect();
         assert!(sampled_set.len() > 500 && sampled_set.len() < 750);
         let max_appearances = sampled_set
@@ -934,7 +904,8 @@ mod tests {
         validators[0].stake = Stake::new(1_000_000_000);
         let sampler = StakeWeightedSampler::new(validators);
         assert_eq!(sampler.sample(&mut rand::rng()), ValidatorId::new(0));
-        let sampled = sampler.sample_multiple(100, &mut rand::rng());
+        let quorum = sampler.into_quorum_strategy(100);
+        let sampled = quorum.sample_quorum(&mut rand::rng());
         let sampled0 = sampled
             .into_iter()
             .filter(|v| *v == ValidatorId::new(0))
@@ -946,16 +917,16 @@ mod tests {
     fn decaying_acceptance_sampler() {
         // max_samples = 1 equivalent to sampling w/o replacement
         let validators = create_validator_info(100);
-        let sampler = DecayingAcceptanceSampler::new(validators, 1.0);
-        let sampled = sampler.sample_multiple(100, &mut rand::rng());
+        let sampler = DecayingAcceptanceSampler::new(validators, 1.0, 100);
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         let sampled_set: HashSet<_> = sampled.iter().copied().collect();
         assert_eq!(sampled_set.len(), 100);
 
         // heavy node sampled at most max_samples times
         let mut validators = create_validator_info(100);
         validators[0].stake = Stake::new(10_000);
-        let sampler = DecayingAcceptanceSampler::new(validators, 5.0);
-        let sampled = sampler.sample_multiple(100, &mut rand::rng());
+        let sampler = DecayingAcceptanceSampler::new(validators, 5.0, 100);
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         let sampled0 = sampled
             .into_iter()
             .filter(|v| *v == ValidatorId::new(0))
@@ -965,9 +936,10 @@ mod tests {
         // max_samples = inf equivalent to sampling with replacement
         let mut validators = create_validator_info(100);
         validators[0].stake = Stake::new(1_000_000_000);
-        let sampler = DecayingAcceptanceSampler::new(validators, f64::INFINITY);
-        assert_eq!(sampler.sample(&mut rand::rng()), ValidatorId::new(0));
-        let sampled = sampler.sample_multiple(100, &mut rand::rng());
+        let sampler = DecayingAcceptanceSampler::new(validators, f64::INFINITY, 100);
+        assert_eq!(sampler.sample_one(&mut rand::rng()), ValidatorId::new(0));
+        sampler.reset();
+        let sampled = sampler.sample_quorum(&mut rand::rng());
         let sampled0 = sampled
             .into_iter()
             .filter(|v| *v == ValidatorId::new(0))
@@ -980,7 +952,7 @@ mod tests {
         sampler.max_samples = 5.0;
         for _ in 0..100 {
             sampler.reset();
-            let id = sampler.sample(&mut rand::rng());
+            let id = sampler.sample_one(&mut rand::rng());
             assert_eq!(id, ValidatorId::new(0));
         }
     }
@@ -999,8 +971,9 @@ mod tests {
             Stake::new(validators.len() as u64 - 2) + validators[0].stake + validators[1].stake;
 
         // calculate work expected with `TurbineSampler`
-        let sampler = TurbineSampler::new(validators.clone());
-        let sampled = sampler.sample_multiple(TOTAL_SHREDS * SLICES, &mut rng);
+        let sampler =
+            TurbineSampler::new(validators.clone()).into_quorum_strategy(TOTAL_SHREDS * SLICES);
+        let sampled = sampler.sample_quorum(&mut rng);
         let appearances0 = sampled
             .iter()
             .filter(|v| **v == ValidatorId::new(0))
@@ -1081,9 +1054,10 @@ mod tests {
 
         // calculate work expected with `TurbineSampler`
         let mut rng = SmallRng::from_rng(&mut rand::rng());
-        let sampler = TurbineSampler::new(validators.clone());
+        let sampler =
+            TurbineSampler::new(validators.clone()).into_quorum_strategy(TOTAL_SHREDS * SLICES);
         let mut expected_work = vec![0; validators.len()];
-        let relays = sampler.sample_multiple(TOTAL_SHREDS * SLICES, &mut rng);
+        let relays = sampler.sample_quorum(&mut rng);
         for (v, stake) in validators.iter().map(|v| v.stake).enumerate() {
             let appearances = relays
                 .iter()
@@ -1230,22 +1204,28 @@ mod tests {
     }
 
     #[test]
+    fn iid_quorum_sampler() {
+        // wrapping a stake-weighted sampler with a fixed quorum size
+        let validators = create_validator_info(100);
+        let sampler = StakeWeightedSampler::new(validators).into_quorum_strategy(32);
+        assert_eq!(sampler.quorum_size(), 32);
+        let sampled = sampler.sample_quorum(&mut rand::rng());
+        assert_eq!(sampled.len(), 32);
+
+        // IidQuorumSampler also forwards single-node sampling
+        let validators = create_validator_info(100);
+        let sampler = StakeWeightedSampler::new(validators).into_quorum_strategy(32);
+        let mut rng = rand::rng();
+        let id = sampler.sample(&mut rng);
+        assert!(id.as_index() < 100);
+    }
+
+    #[test]
     fn completeness() {
         let validators = create_validator_info(10);
         sample_all_validators(&UniformSampler::new(validators.clone()));
         sample_all_validators(&StakeWeightedSampler::new(validators.clone()));
-        sample_all_validators(&DecayingAcceptanceSampler::new(validators.clone(), 1000.0));
         sample_all_validators(&TurbineSampler::new(validators.clone()));
-        sample_all_validators(&PartitionSampler::new(validators.clone(), 10));
-        sample_all_validators(&FaitAccompli1Sampler::new_with_stake_weighted_fallback(
-            validators.clone(),
-            10,
-        ));
-        sample_all_validators(&FaitAccompli1Sampler::new_with_partition_fallback(
-            validators.clone(),
-            10,
-        ));
-        sample_all_validators(&FaitAccompli2Sampler::new(validators.clone(), 10));
     }
 
     fn sample_all_validators<S: SamplingStrategy>(sampler: &S) {

--- a/src/disseminator/rotor/sampling_strategy.rs
+++ b/src/disseminator/rotor/sampling_strategy.rs
@@ -619,7 +619,7 @@ impl<F: QuorumSamplingStrategy + Clone> Clone for FaitAccompli1Sampler<F> {
 pub struct FaitAccompli2Sampler {
     required_samples: Vec<ValidatorId>,
     medium_nodes: Vec<(ValidatorId, f64)>,
-    fallback_sampler: IidQuorumSampler<StakeWeightedSampler>,
+    fallback_sampler: StakeWeightedSampler,
     k: usize,
 }
 
@@ -673,13 +673,10 @@ impl FaitAccompli2Sampler {
                 v
             })
             .collect();
-        // The fallback quorum size is an upper bound; FA2's sample_quorum may request
-        // fewer samples depending on how many medium nodes were included.
-        let fallback_k = k as usize - required_samples.len();
         let fallback_sampler = if r == 0.0 {
-            StakeWeightedSampler::new(validators).into_quorum_strategy(fallback_k)
+            StakeWeightedSampler::new(validators)
         } else {
-            StakeWeightedSampler::new(new_stake_distribution).into_quorum_strategy(fallback_k)
+            StakeWeightedSampler::new(new_stake_distribution)
         };
 
         Self {
@@ -724,7 +721,7 @@ impl QuorumSamplingStrategy for FaitAccompli2Sampler {
         if result.len() < self.k {
             let k_prime = self.k - result.len();
             let additional_samples: Vec<_> = (0..k_prime)
-                .map(|_| self.fallback_sampler.inner.sample(rng))
+                .map(|_| self.fallback_sampler.sample(rng))
                 .collect();
             result.extend_from_slice(&additional_samples);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ use crate::consensus::{ConsensusMessage, EpochInfo, ValidatorEpochInfo};
 use crate::crypto::merkle::BlockHash;
 use crate::crypto::signature::SecretKey;
 use crate::disseminator::Rotor;
-use crate::disseminator::rotor::StakeWeightedSampler;
+use crate::disseminator::rotor::{IidQuorumSampler, StakeWeightedSampler};
 use crate::network::{UdpNetwork, localhost_ip_sockaddr};
 use crate::repair::{RepairRequest, RepairResponse};
 use crate::shredder::Shred;
@@ -91,7 +91,7 @@ pub struct ValidatorInfo {
 
 type TestNode = Alpenglow<
     TrivialAll2All<UdpNetwork<ConsensusMessage, ConsensusMessage>>,
-    Rotor<UdpNetwork<Shred, Shred>, StakeWeightedSampler>,
+    Rotor<UdpNetwork<Shred, Shred>, IidQuorumSampler<StakeWeightedSampler>>,
     UdpNetwork<Transaction, Transaction>,
 >;
 

--- a/src/shredder/shred_index.rs
+++ b/src/shredder/shred_index.rs
@@ -35,6 +35,12 @@ impl ShredIndex {
     pub(crate) fn all() -> impl Iterator<Item = Self> {
         (0..TOTAL_SHREDS).map(Self)
     }
+
+    /// Returns the inner `usize`.
+    #[must_use]
+    pub fn inner(&self) -> usize {
+        self.0
+    }
 }
 
 impl Deref for ShredIndex {


### PR DESCRIPTION
This is a change to the sampling strategies API I wanted to clean up for a while. It adds a `QuorumSamplingStrategy` trait for sampling fixed size quorums, whereas the regular `SamplingStrategy` trait tells you how to sample a single node. These two traits are bridged by the `IidQuorumSampler<S>`, which for any `S: SamplingStrategy` implements i.i.d. sampling of a quorum.

This should be cleaner than the previous abstraction where you for example could use FA1 to sample a single node, which was explicitly implemented as a fallback to `StakeWeightedSampler` just to make sense of it.

Closes #256.