### PR TITLE
nit: use more reasonable default of 6 nodes for local cluster

### DIFF
--- a/src/bin/local_cluster.rs
+++ b/src/bin/local_cluster.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
         let parent = SpanContext::random();
 
         // spawn local cluster
-        let nodes = create_test_nodes(2);
+        let nodes = create_test_nodes(6);
         let mut node_tasks = Vec::new();
         let mut cancel_tokens = Vec::new();
         for (i, node) in nodes.into_iter().enumerate() {


### PR DESCRIPTION
The previous default of 2 nodes is a very special case that can lead to unexpected behavior, e.g. #363.