### PR TITLE
build: put telemetry stack behind optional feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,19 +25,19 @@ ctr = "0.10"
 derive_more = { version = "2", features = ["add", "add_assign", "as_ref", "from", "into", "sum"] }
 ed25519-consensus = "2"
 either = "1"
-fastrace = { version = "0.7", features = ["enable"] }
-fastrace-opentelemetry = "0.17"
+fastrace = "0.7"
+fastrace-opentelemetry = { version = "0.17", optional = true }
 futures = "0.3"
 geo = "0.33"
 hex = "0.4"
 hex-literal = "1"
 hotpath = "0.16"
 log = "0.4"
-logforth = { version = "0.29", features = ["append-fastrace", "starter-log"] }
+logforth = { version = "0.29", features = ["starter-log"] }
 moka = { version = "0.12", features = ["future"] }
-opentelemetry = "0.31"
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
-opentelemetry_sdk = "0.31"
+opentelemetry = { version = "0.31", optional = true }
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"], optional = true }
+opentelemetry_sdk = { version = "0.31", optional = true }
 rand = "0.10"
 rayon = { version = "1", optional = true }
 reed-solomon-simd = "3"
@@ -50,7 +50,7 @@ statrs = { version = "0.18", optional = true }
 thiserror = "2"
 time = { version = "0.3", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
-tokio-util = "0.7"
+tokio-util = { version = "0.7", features = ["codec"] }
 toml = "1"
 wincode = { version = "0.5", features = ["derive"] }
 
@@ -64,6 +64,17 @@ tempfile = "3"
 hotpath = ["hotpath/hotpath"]
 hotpath-alloc = ["hotpath/hotpath-alloc"]
 simulations = ["dep:rayon", "dep:statrs"]
+# Enables `fastrace` span collection and OpenTelemetry (OTLP) export. Off by
+# default: without it, `fastrace` instrumentation compiles to no-ops and the
+# gRPC/OTLP dependency stack is dropped entirely.
+telemetry = [
+    "fastrace/enable",
+    "logforth/append-fastrace",
+    "dep:fastrace-opentelemetry",
+    "dep:opentelemetry",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry_sdk",
+]
 
 [lints.rust]
 unreachable_pub = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,9 @@ tempfile = "3"
 hotpath = ["hotpath/hotpath"]
 hotpath-alloc = ["hotpath/hotpath-alloc"]
 simulations = ["dep:rayon", "dep:statrs"]
-# Enables `fastrace` span collection and OpenTelemetry (OTLP) export. Off by
-# default: without it, `fastrace` instrumentation compiles to no-ops and the
-# gRPC/OTLP dependency stack is dropped entirely.
+# Enables `fastrace` span collection and OpenTelemetry (OTLP) export.
+# Off by default: Without it, `fastrace` instrumentation compiles to no-ops and
+# the gRPC/OTLP dependency stack is dropped entirely.
 telemetry = [
     "fastrace/enable",
     "logforth/append-fastrace",

--- a/src/bin/local_cluster.rs
+++ b/src/bin/local_cluster.rs
@@ -1,17 +1,23 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "telemetry")]
 use std::borrow::Cow;
 
 use alpenglow::{create_test_nodes, logging};
 use clap::Parser;
 use color_eyre::Result;
+#[cfg(feature = "telemetry")]
 use fastrace::collector::Config;
 use fastrace::prelude::*;
+#[cfg(feature = "telemetry")]
 use fastrace_opentelemetry::OpenTelemetryReporter;
 use log::warn;
+#[cfg(feature = "telemetry")]
 use opentelemetry::{InstrumentationScope, KeyValue};
+#[cfg(feature = "telemetry")]
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
+#[cfg(feature = "telemetry")]
 use opentelemetry_sdk::Resource;
 
 /// Local Alpenglow cluster for testing and development.
@@ -27,25 +33,28 @@ async fn main() -> Result<()> {
 
     Args::parse();
 
-    // enable `fastrace` tracing
-    let reporter = OpenTelemetryReporter::new(
-        SpanExporter::builder()
-            .with_tonic()
-            .with_endpoint("http://127.0.0.1:4317".to_string())
-            .with_protocol(opentelemetry_otlp::Protocol::Grpc)
-            .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
-            .build()
-            .expect("initialize oltp exporter"),
-        Cow::Owned(
-            Resource::builder()
-                .with_attributes([KeyValue::new("service.name", "alpenglow-main")])
+    // enable `fastrace` tracing via OpenTelemetry export (only with `telemetry` feature)
+    #[cfg(feature = "telemetry")]
+    {
+        let reporter = OpenTelemetryReporter::new(
+            SpanExporter::builder()
+                .with_tonic()
+                .with_endpoint("http://127.0.0.1:4317".to_string())
+                .with_protocol(opentelemetry_otlp::Protocol::Grpc)
+                .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
+                .build()
+                .expect("initialize oltp exporter"),
+            Cow::Owned(
+                Resource::builder()
+                    .with_attributes([KeyValue::new("service.name", "alpenglow-main")])
+                    .build(),
+            ),
+            InstrumentationScope::builder("alpenglow")
+                .with_version(env!("CARGO_PKG_VERSION"))
                 .build(),
-        ),
-        InstrumentationScope::builder("alpenglow")
-            .with_version(env!("CARGO_PKG_VERSION"))
-            .build(),
-    );
-    fastrace::set_reporter(reporter, Config::default());
+        );
+        fastrace::set_reporter(reporter, Config::default());
+    }
 
     logging::enable_logforth();
 

--- a/src/bin/local_cluster.rs
+++ b/src/bin/local_cluster.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
                 .with_protocol(opentelemetry_otlp::Protocol::Grpc)
                 .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
                 .build()
-                .expect("initialize oltp exporter"),
+                .expect("initialize OTLP exporter"),
             Cow::Owned(
                 Resource::builder()
                     .with_attributes([KeyValue::new("service.name", "alpenglow-main")])

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
                 .with_protocol(opentelemetry_otlp::Protocol::Grpc)
                 .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
                 .build()
-                .expect("initialize oltp exporter"),
+                .expect("initialize OTLP exporter"),
             Cow::Owned(
                 Resource::builder()
                     .with_attributes([KeyValue::new("service.name", "alpenglow-main")])

--- a/src/bin/node.rs
+++ b/src/bin/node.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "telemetry")]
 use std::borrow::Cow;
 use std::fs::File;
 use std::io::Read;
@@ -19,12 +20,17 @@ use alpenglow::{Stake, Transaction, ValidatorId, ValidatorInfo, logging};
 use clap::Parser;
 use color_eyre::Result;
 use color_eyre::eyre::Context;
+#[cfg(feature = "telemetry")]
 use fastrace::collector::Config;
 use fastrace::prelude::*;
+#[cfg(feature = "telemetry")]
 use fastrace_opentelemetry::OpenTelemetryReporter;
 use log::warn;
+#[cfg(feature = "telemetry")]
 use opentelemetry::{InstrumentationScope, KeyValue};
+#[cfg(feature = "telemetry")]
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
+#[cfg(feature = "telemetry")]
 use opentelemetry_sdk::Resource;
 use rand::rng;
 use serde::{Deserialize, Serialize};
@@ -69,25 +75,28 @@ async fn main() -> Result<()> {
     config.read_to_string(&mut config_string)?;
     let config: ConfigFile = toml::from_str(&config_string).context("Can not parse config")?;
 
-    // enable `fastrace` tracing
-    let reporter = OpenTelemetryReporter::new(
-        SpanExporter::builder()
-            .with_tonic()
-            .with_endpoint("http://127.0.0.1:4317".to_string())
-            .with_protocol(opentelemetry_otlp::Protocol::Grpc)
-            .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
-            .build()
-            .expect("initialize oltp exporter"),
-        Cow::Owned(
-            Resource::builder()
-                .with_attributes([KeyValue::new("service.name", "alpenglow-main")])
+    // enable `fastrace` tracing via OpenTelemetry export (only with `telemetry` feature)
+    #[cfg(feature = "telemetry")]
+    {
+        let reporter = OpenTelemetryReporter::new(
+            SpanExporter::builder()
+                .with_tonic()
+                .with_endpoint("http://127.0.0.1:4317".to_string())
+                .with_protocol(opentelemetry_otlp::Protocol::Grpc)
+                .with_timeout(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT)
+                .build()
+                .expect("initialize oltp exporter"),
+            Cow::Owned(
+                Resource::builder()
+                    .with_attributes([KeyValue::new("service.name", "alpenglow-main")])
+                    .build(),
+            ),
+            InstrumentationScope::builder("alpenglow")
+                .with_version(env!("CARGO_PKG_VERSION"))
                 .build(),
-        ),
-        InstrumentationScope::builder("alpenglow")
-            .with_version(env!("CARGO_PKG_VERSION"))
-            .build(),
-    );
-    fastrace::set_reporter(reporter, Config::default());
+        );
+        fastrace::set_reporter(reporter, Config::default());
+    }
 
     logging::enable_logforth();
 


### PR DESCRIPTION
Before this change `fastrace` was enabled by default and the entire telemetry stack, including the heavy `opentelemetry` dependencies were required dependencies. The `opentelemetry` dependencies are now optional and enabling `fastrace` as well pulling in the `opentelemetry` dependencies are now gated on a `telemetry` feature flag, which is not enabled by default.