### PR TITLE
build: replace `colored` with already-present `owo-colors`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,6 @@ dependencies = [
  "blst",
  "clap",
  "color-eyre",
- "colored",
  "csv",
  "ctr",
  "derive_more",
@@ -76,6 +75,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "owo-colors",
  "rand 0.10.1",
  "rayon",
  "reed-solomon-simd",
@@ -446,15 +446,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "colored"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
-dependencies = [
- "windows-sys",
-]
 
 [[package]]
 name = "concurrent-queue"
@@ -1753,11 +1744,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c105c59828d07aeb95b06f9a345b12869ddc249d44a7302697a66da439076f"
 dependencies = [
  "logforth-append-fastrace",
- "logforth-append-file",
  "logforth-bridge-log",
  "logforth-core",
- "logforth-layout-json",
- "logforth-layout-text",
 ]
 
 [[package]]
@@ -1767,16 +1755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9166d398b5c892ac63ef3437ae67b7d1fe63f67c2a0ecc0f77849a3420ee33c3"
 dependencies = [
  "fastrace",
- "jiff",
- "logforth-core",
-]
-
-[[package]]
-name = "logforth-append-file"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2ccb8b7e501c114e80069eb2b83c02a48039c23a7037e717b5b09a4ed306fb"
-dependencies = [
  "jiff",
  "logforth-core",
 ]
@@ -1799,29 +1777,6 @@ checksum = "a77869b8dba38c67ed19e1753e59d9faefdcc60557bc4e84db0348606a304ac5"
 dependencies = [
  "anyhow",
  "value-bag",
-]
-
-[[package]]
-name = "logforth-layout-json"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b80d310e0670560404a825f64dbd78a8761c5bb7da952513e90ba9dd525bd2"
-dependencies = [
- "jiff",
- "logforth-core",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "logforth-layout-text"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a4674e549a59eeac8e301584143186c433181bdc5460046a130becedef6a3d"
-dependencies = [
- "colored",
- "jiff",
- "logforth-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ bitvec = { version = "1", features = ["serde"] }
 blst = { version = "0.3", features = ["serde", "serde-secret"] }
 clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6"
-colored = "3"
 csv = "1"
 ctr = "0.10"
 derive_more = { version = "2", features = ["add", "add_assign", "as_ref", "from", "into", "sum"] }
@@ -33,11 +32,12 @@ hex = "0.4"
 hex-literal = "1"
 hotpath = "0.16"
 log = "0.4"
-logforth = { version = "0.29", features = ["append-fastrace", "starter-log"] }
+logforth = { version = "0.29", features = ["append-fastrace", "bridge-log"] }
 moka = { version = "0.12", features = ["future"] }
 opentelemetry = "0.31"
 opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
 opentelemetry_sdk = "0.31"
+owo-colors = "4"
 rand = "0.10"
 rayon = { version = "1", optional = true }
 reed-solomon-simd = "3"

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,25 +1,35 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use colored::{Color, ColoredString, Colorize};
+use std::io::{IsTerminal, stderr};
+
 use logforth::filter::env_filter::EnvFilterBuilder;
 use logforth::record::Level;
 use logforth::{Layout, append};
+use owo_colors::{AnsiColors, OwoColorize};
 
 #[derive(Clone, Debug)]
-struct MinimalLogforthLayout;
+struct MinimalLogforthLayout {
+    /// Whether to emit ANSI color codes. Disabled when stderr is not a terminal
+    /// or the `NO_COLOR` environment variable is set.
+    colorize: bool,
+}
 
 impl MinimalLogforthLayout {
-    fn colorize_record_level(&self, level: Level) -> ColoredString {
-        let color = match level {
-            Level::Fatal | Level::Fatal2 | Level::Fatal3 | Level::Fatal4 => Color::BrightRed,
-            Level::Error | Level::Error2 | Level::Error3 | Level::Error4 => Color::Red,
-            Level::Warn | Level::Warn2 | Level::Warn3 | Level::Warn4 => Color::Yellow,
-            Level::Info | Level::Info2 | Level::Info3 | Level::Info4 => Color::Green,
-            Level::Debug | Level::Debug2 | Level::Debug3 | Level::Debug4 => Color::Blue,
-            Level::Trace | Level::Trace2 | Level::Trace3 | Level::Trace4 => Color::Magenta,
-        };
-        ColoredString::from(level.to_string()).color(color)
+    fn new() -> Self {
+        let colorize = stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none();
+        Self { colorize }
+    }
+
+    fn level_color(level: Level) -> AnsiColors {
+        match level {
+            Level::Fatal | Level::Fatal2 | Level::Fatal3 | Level::Fatal4 => AnsiColors::BrightRed,
+            Level::Error | Level::Error2 | Level::Error3 | Level::Error4 => AnsiColors::Red,
+            Level::Warn | Level::Warn2 | Level::Warn3 | Level::Warn4 => AnsiColors::Yellow,
+            Level::Info | Level::Info2 | Level::Info3 | Level::Info4 => AnsiColors::Green,
+            Level::Debug | Level::Debug2 | Level::Debug3 | Level::Debug4 => AnsiColors::Blue,
+            Level::Trace | Level::Trace2 | Level::Trace3 | Level::Trace4 => AnsiColors::Magenta,
+        }
     }
 }
 
@@ -29,14 +39,22 @@ impl Layout for MinimalLogforthLayout {
         record: &logforth::record::Record,
         _diagnostics: &[Box<dyn logforth::Diagnostic>],
     ) -> Result<Vec<u8>, logforth::Error> {
-        let level = self.colorize_record_level(record.level());
+        let level = record.level();
+        // Pad the level name to width 5 *before* coloring so the ANSI escape
+        // codes don't throw off the alignment.
+        let padded = format!("{:>5}", level.to_string());
         let message = record.payload();
-        Ok(format!("{level:>5} {message}").into_bytes())
+        let line = if self.colorize {
+            format!("{} {message}", padded.color(Self::level_color(level)))
+        } else {
+            format!("{padded} {message}")
+        };
+        Ok(line.into_bytes())
     }
 }
 
 pub fn enable_logforth() {
-    enable_logforth_append(append::Stderr::default().with_layout(MinimalLogforthLayout));
+    enable_logforth_append(append::Stderr::default().with_layout(MinimalLogforthLayout::new()));
 }
 
 pub fn enable_logforth_stderr() {


### PR DESCRIPTION
We had both `colored` and `owo-colors` in our dependency graph, `owo-colors` comes indirectly from `color-eyre`, whereas `colored` was used directly by us in the `logging` module and indirectly by the `logforth/starter-log` feature. Slimming that to `logforth/bridge-log` drops the indirect dependency, which then allows us to replace `colored` with `owo-colors` in the `logging` module. Removes 11 crates from our dependencies.