### PR TITLE
fix: forwarding shreds before validation

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -329,10 +329,7 @@ where
     #[fastrace::trace(short_name = true)]
     #[hotpath::measure]
     async fn handle_disseminator_shred(&self, shred: Shred) -> std::io::Result<()> {
-        // validate signature against the slot's leader before forwarding, so a
-        // relay can't be used to amplify forged or cross-slot-replayed shreds
-        // across the network. this applies even when we are the leader, since
-        // we may also be the Rotor relay for this shred.
+        // validate shred before forwarding or inserting
         let slot = shred.payload().header.slot;
         let leader_pk = self.epoch_info.epoch_info().leader(slot).pubkey;
         let validated = match ValidatedShred::try_new(shred, None, &leader_pk) {

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -49,7 +49,7 @@ use crate::consensus::block_producer::BlockProducer;
 use crate::crypto::{aggsig, signature};
 use crate::network::{RepairNetwork, RepairRequestNetwork, TransactionNetwork};
 use crate::repair::{Repair, RepairRequestHandler};
-use crate::shredder::Shred;
+use crate::shredder::{Shred, ValidatedShred};
 use crate::types::Fraction;
 use crate::{All2All, Disseminator, Slot, ValidatorInfo};
 
@@ -329,11 +329,21 @@ where
     #[fastrace::trace(short_name = true)]
     #[hotpath::measure]
     async fn handle_disseminator_shred(&self, shred: Shred) -> std::io::Result<()> {
+        // validate signature against the slot's leader before forwarding, so a
+        // relay can't be used to amplify forged or cross-slot-replayed shreds
+        // across the network. this applies even when we are the leader, since
+        // we may also be the Rotor relay for this shred.
+        let slot = shred.payload().header.slot;
+        let leader_pk = self.epoch_info.epoch_info().leader(slot).pubkey;
+        let validated = match ValidatedShred::try_new(shred, None, &leader_pk) {
+            Ok(v) => v,
+            Err(_) => return Ok(()),
+        };
+
         // potentially forward shred
-        self.disseminator.forward(&shred).await?;
+        self.disseminator.forward(&validated).await?;
 
         // if we are the leader, we already have the shred
-        let slot = shred.payload().header.slot;
         if self.epoch_info.epoch_info().leader(slot).id == self.epoch_info.own_id() {
             return Ok(());
         }
@@ -343,7 +353,7 @@ where
             .blockstore
             .write()
             .await
-            .add_shred_from_disseminator(shred)
+            .add_shred_from_disseminator(validated.into_shred())
             .await;
         if let Ok(Some(block_info)) = res {
             let mut guard = self.pool.write().await;


### PR DESCRIPTION
Currently we forward any unverified shreds we receive in Rotor. Instead, we should first verify shred validity before forwarding or inserting into blockstore. In a follow-up I will clean up Blockstore to seemlessly take `ValidatedShred` and not re-verify.