### PR TITLE
fix(pool): prune `ParentReadyTracker`

### DIFF
--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -338,6 +338,7 @@ impl PoolImpl {
     fn prune(&mut self) {
         let last_slot = self.finalized_slot();
         self.slot_states = self.slot_states.split_off(&last_slot);
+        self.parent_ready_tracker.prune(last_slot);
     }
 
     /// Returns `true` iff the given parent is ready for the given slot.

--- a/src/consensus/pool/parent_ready_tracker.rs
+++ b/src/consensus/pool/parent_ready_tracker.rs
@@ -151,6 +151,15 @@ impl ParentReadyTracker {
         state.wait_for_parent_ready()
     }
 
+    /// Removes all tracked state for slots strictly below `new_root`.
+    ///
+    /// After this, only slots `>= new_root` are tracked. This should be called
+    /// when the root (finalized) slot advances, to free memory for slots that
+    /// are no longer relevant.
+    pub(super) fn prune(&mut self, new_root: Slot) {
+        self.0.retain(|slot, _| *slot >= new_root);
+    }
+
     /// Mutably accesses the [`ParentReadyState`] for the given `slot`.
     ///
     /// Initializes the state with [`Default`] if necessary.
@@ -407,5 +416,29 @@ mod tests {
         let parent_ready = &parents[0];
         assert_eq!(parent_ready.0, parent.0);
         assert_eq!(parent_ready.1, parent_parent);
+    }
+
+    #[test]
+    fn prune() {
+        let mut tracker = ParentReadyTracker::default();
+
+        // Populate per-slot state across the first two windows.
+        for slot in Slot::genesis()
+            .future_slots()
+            .take(2 * SLOTS_PER_WINDOW as usize)
+        {
+            tracker.mark_skipped(slot);
+        }
+
+        // There is state both below and at the future root.
+        let new_root = Slot::new(SLOTS_PER_WINDOW);
+        assert!(tracker.0.keys().any(|s| *s < new_root));
+        assert!(tracker.0.contains_key(&new_root));
+
+        tracker.prune(new_root);
+
+        // Everything strictly below the new root is gone; the rest remains.
+        assert!(tracker.0.keys().all(|s| *s >= new_root));
+        assert!(tracker.0.contains_key(&new_root));
     }
 }

--- a/src/consensus/pool/parent_ready_tracker.rs
+++ b/src/consensus/pool/parent_ready_tracker.rs
@@ -153,9 +153,9 @@ impl ParentReadyTracker {
 
     /// Removes all tracked state for slots strictly below `new_root`.
     ///
-    /// After this, only slots `>= new_root` are tracked. This should be called
-    /// when the root (finalized) slot advances, to free memory for slots that
-    /// are no longer relevant.
+    /// After this, only slots `>= new_root` are retained.
+    /// This should be called when the root (finalized) slot advances,
+    /// to free memory for slots that are no longer relevant.
     pub(super) fn prune(&mut self, new_root: Slot) {
         self.0.retain(|slot, _| *slot >= new_root);
     }
@@ -422,7 +422,7 @@ mod tests {
     fn prune() {
         let mut tracker = ParentReadyTracker::default();
 
-        // Populate per-slot state across the first two windows.
+        // populate per-slot state across the first two windows
         for slot in Slot::genesis()
             .future_slots()
             .take(2 * SLOTS_PER_WINDOW as usize)
@@ -430,14 +430,14 @@ mod tests {
             tracker.mark_skipped(slot);
         }
 
-        // There is state both below and at the future root.
+        // before, there is state both before and at the future root
         let new_root = Slot::new(SLOTS_PER_WINDOW);
         assert!(tracker.0.keys().any(|s| *s < new_root));
         assert!(tracker.0.contains_key(&new_root));
 
         tracker.prune(new_root);
 
-        // Everything strictly below the new root is gone; the rest remains.
+        // state strictly below the new root is gone
         assert!(tracker.0.keys().all(|s| *s >= new_root));
         assert!(tracker.0.contains_key(&new_root));
     }


### PR DESCRIPTION
Closes #487