### PR TITLE
build: add `test-utils` feature to expose test/bench helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,9 +71,8 @@ hotpath-alloc = ["hotpath/hotpath-alloc"]
 # stake_distribution}`) and the `simulations` binary. Pulls in `csv` /
 # `serde_json` for parsing `data/*.{csv,json}` and `rayon` for parallel sims.
 simulations = ["dep:rayon", "dep:csv", "dep:serde_json"]
-# Exposes `test_utils` and internal benchmarking hooks (e.g. the `consensus`
-# `SlotState` replay kernel) to out-of-crate test/bench targets. Off by default;
-# enabled implicitly by `cargo test` and explicitly for benches that need it.
+# Exposes `test_utils` and other test-only methods to out-of-crate test/bench targets.
+# Off by default; enabled implicitly by `cargo test` and explicitly for some benches.
 test-utils = []
 # Enables `fastrace` span collection and OpenTelemetry (OTLP) export.
 # Off by default: Without it, `fastrace` instrumentation compiles to no-ops and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,10 @@ hotpath-alloc = ["hotpath/hotpath-alloc"]
 # stake_distribution}`) and the `simulations` binary. Pulls in `csv` /
 # `serde_json` for parsing `data/*.{csv,json}` and `rayon` for parallel sims.
 simulations = ["dep:rayon", "dep:csv", "dep:serde_json"]
+# Exposes `test_utils` and internal benchmarking hooks (e.g. the `consensus`
+# `SlotState` replay kernel) to out-of-crate test/bench targets. Off by default;
+# enabled implicitly by `cargo test` and explicitly for benches that need it.
+test-utils = []
 # Enables `fastrace` span collection and OpenTelemetry (OTLP) export.
 # Off by default: Without it, `fastrace` instrumentation compiles to no-ops and
 # the gRPC/OTLP dependency stack is dropped entirely.
@@ -106,14 +110,17 @@ harness = false
 [[bench]]
 name = "disseminator"
 harness = false
+required-features = ["test-utils"]
 
 [[bench]]
 name = "network"
 harness = false
+required-features = ["test-utils"]
 
 [[bench]]
 name = "shredder"
 harness = false
+required-features = ["test-utils"]
 
 [[bin]]
 name = "all2all_test"

--- a/Justfile
+++ b/Justfile
@@ -118,7 +118,7 @@ fuzz:
     done
 
 # Compile-check benchmarks. CI never runs benches.
-# `test-utils` unlocks the slice/`SlotState` helpers that most benches need.
+# `test-utils` unlocks the `slice`/`SlotState` helpers that most benches need.
 bench-build: _lockfile
     cargo bench --no-run --locked --features test-utils
 

--- a/Justfile
+++ b/Justfile
@@ -118,12 +118,13 @@ fuzz:
     done
 
 # Compile-check benchmarks. CI never runs benches.
+# `test-utils` unlocks the slice/`SlotState` helpers that most benches need.
 bench-build: _lockfile
-    cargo bench --no-run --locked
+    cargo bench --no-run --locked --features test-utils
 
 # Run benchmarks (divan). For local profiling only.
 bench:
-    cargo bench
+    cargo bench --features test-utils
 
 # Generate an HTML coverage report and open it.
 coverage:

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -18,7 +18,7 @@ pub struct Hash(pub(super) [u8; 32]);
 
 impl Hash {
     /// Creates a random hash for testing.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn random_for_test() -> Self {
         use rand::Rng;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod logging;
 pub mod network;
 pub mod repair;
 pub mod shredder;
-#[cfg(test)]
+#[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 pub mod types;
 pub mod validator;

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -5,6 +5,7 @@
 
 use std::ops::Deref;
 
+#[cfg(any(test, feature = "test-utils"))]
 use rand::prelude::*;
 use thiserror::Error;
 use wincode::config::DefaultConfig;
@@ -202,10 +203,9 @@ impl TryFrom<&[u8]> for SlicePayload {
 /// Creates a [`SlicePayload`] with a random payload of desired size (in bytes).
 ///
 /// The payload does not contain valid transactions.
-/// This function should only be used for testing and benchmarking.
-//
-// TODO: This is only used in test and benchmarking code.
-// Ensure it is only compiled when we are testing or benchmarking.
+/// This function should only be used for testing and benchmarking, hence it is
+/// only compiled under `cfg(test)` or the `test-utils` feature.
+#[cfg(any(test, feature = "test-utils"))]
 pub(crate) fn create_slice_payload_with_invalid_txs(
     parent: Option<BlockId>,
     desired_size: usize,
@@ -228,10 +228,9 @@ pub(crate) fn create_slice_payload_with_invalid_txs(
 /// Creates a [`Slice`] with a random payload of desired size (in bytes).
 ///
 /// The slice does not contain valid transactions.
-/// This function should only be used for testing and benchmarking.
-//
-// TODO: This is only used in test and benchmarking code.
-// Ensure it is only compiled when we are testing or benchmarking.
+/// This function should only be used for testing and benchmarking, hence it is
+/// only compiled under `cfg(test)` or the `test-utils` feature.
+#[cfg(any(test, feature = "test-utils"))]
 pub fn create_slice_with_invalid_txs(desired_size: usize) -> Slice {
     let payload = create_slice_payload_with_invalid_txs(None, desired_size);
     let header = SliceHeader {

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -203,8 +203,8 @@ impl TryFrom<&[u8]> for SlicePayload {
 /// Creates a [`SlicePayload`] with a random payload of desired size (in bytes).
 ///
 /// The payload does not contain valid transactions.
-/// This function should only be used for testing and benchmarking, hence it is
-/// only compiled under `cfg(test)` or the `test-utils` feature.
+/// This function should only be used for testing and benchmarking,
+/// hence it is only compiled under `cfg(test)` or the `test-utils` feature.
 #[cfg(any(test, feature = "test-utils"))]
 pub(crate) fn create_slice_payload_with_invalid_txs(
     parent: Option<BlockId>,
@@ -228,8 +228,8 @@ pub(crate) fn create_slice_payload_with_invalid_txs(
 /// Creates a [`Slice`] with a random payload of desired size (in bytes).
 ///
 /// The slice does not contain valid transactions.
-/// This function should only be used for testing and benchmarking, hence it is
-/// only compiled under `cfg(test)` or the `test-utils` feature.
+/// This function should only be used for testing and benchmarking,
+/// hence it is only compiled under `cfg(test)` or the `test-utils` feature.
 #[cfg(any(test, feature = "test-utils"))]
 pub fn create_slice_with_invalid_txs(desired_size: usize) -> Slice {
     let payload = create_slice_payload_with_invalid_txs(None, desired_size);

--- a/src/types/slice_index.rs
+++ b/src/types/slice_index.rs
@@ -25,7 +25,7 @@ impl SliceIndex {
     /// Creates a new slice index for testing purposes.
     ///
     /// Panics if `index` is not in the valid range.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-utils"))]
     pub(crate) fn new_unchecked(index: usize) -> Self {
         Self::new(index).unwrap()
     }


### PR DESCRIPTION
Introduce a `test-utils` cargo feature that compiles `test_utils` and a handful of previously test-only helpers for out-of-crate bench targets.

- Ungate `test_utils`, `Hash::random_for_test`, and `SliceIndex::new_unchecked` under `cfg(any(test, feature = "test-utils"))`.
- Gate `create_slice(_payload)_with_invalid_txs` behind the same cfg, resolving the standing TODO that they should not be compiled in normal builds (previously they were always compiled).
- The `disseminator`/`network`/`shredder` benches now consume the gated slice helper, so they require the feature; `just bench` / `bench-build` pass `--features test-utils`.


Change-Id: Ib6c77d40aedf89b613be4335adbbf7aef9878009