### PR TITLE
fix: avoid panicking on consensus channel/broadcast failures 

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -35,7 +35,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use fastrace::Span;
 use fastrace::future::FutureExt;
-use log::{debug, trace, warn};
+use log::{debug, error, trace, warn};
 use tokio::sync::{RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 use wincode::{SchemaRead, SchemaWrite};
@@ -47,7 +47,7 @@ pub use self::cert::{Cert, CertError, NotarCert};
 pub use self::epoch_info::{EpochInfo, ValidatorEpochInfo};
 #[cfg(feature = "test-utils")]
 pub use self::pool::bench_replay_votes;
-pub use self::pool::{AddVoteError, Pool, PoolEvent, PoolImpl, PoolOutbox, SharedPool};
+pub use self::pool::{AddVoteError, Pool, PoolEffect, PoolEvent, PoolImpl, PoolOutbox, SharedPool};
 pub use self::validated_cert::{CertValidationError, ValidatedCert};
 pub use self::validated_vote::{ValidatedVote, VoteValidationError};
 pub use self::vote::{FinalVote, NotarFallbackVote, NotarVote, SkipFallbackVote, SkipVote, Vote};
@@ -116,6 +116,19 @@ impl From<Cert> for ConsensusMessage {
 /// blocking send then back-pressures that (ingest) task instead of dropping the
 /// event or stalling the lock.
 ///
+/// # Ordering
+///
+/// Forwarding one drained outbox preserves the order the producing component
+/// buffered its effects in. What the write lock no longer provides is a *global*
+/// order across tasks: two tasks that each mutate the Pool can now interleave
+/// their forwarding, so Votor may see a later task's event before an earlier
+/// one's. That is safe because Votor's handling of these events is order-
+/// insensitive except for its prune gate (`Votor::should_ignore_pool_event`),
+/// and an event losing that race is by definition one for a slot whose vote no
+/// longer matters. Restoring the global order would require holding a second
+/// lock across the send, which reintroduces exactly the lock jam this design
+/// exists to avoid.
+///
 /// Cloneable so the message loop, the repair loop and the block producer can each
 /// forward the events they produce.
 #[derive(Clone)]
@@ -126,43 +139,84 @@ pub(crate) struct EventForwarder {
     pool_events: mpsc::Sender<PoolEvent>,
     /// Repair requests destined for the repair loop.
     repairs: mpsc::Sender<BlockId>,
+    /// Shuts the node down when a consumer disappears unexpectedly.
+    cancel_token: CancellationToken,
 }
 
 impl EventForwarder {
     /// Creates a forwarder over Votor's event channels and the repair channel.
+    ///
+    /// `cancel_token` is the node's shutdown token, used both to tell an expected
+    /// shutdown from an unexpected consumer death and to bring the node down in
+    /// the latter case.
     pub(crate) fn new(
         blockstore_events: mpsc::Sender<BlockstoreEvent>,
         pool_events: mpsc::Sender<PoolEvent>,
         repairs: mpsc::Sender<BlockId>,
+        cancel_token: CancellationToken,
     ) -> Self {
         Self {
             blockstore_events,
             pool_events,
             repairs,
+            cancel_token,
         }
     }
 
-    /// Forwards `items` to `sender` with blocking sends, stopping early if the
-    /// channel has closed (the consumer shut down). A closed channel is logged
-    /// (using `what` to name it) and the remaining items dropped, not panicked on.
-    async fn forward_all<T>(sender: &mpsc::Sender<T>, items: Vec<T>, what: &str) {
-        for item in items {
-            if sender.send(item).await.is_err() {
-                debug!("{what} channel closed, dropping remaining events");
+    /// Sends a single `item` to `sender`, returning `false` if the channel closed.
+    ///
+    /// A closed channel means the consuming task is gone. While the node is
+    /// shutting down that is expected and the item is simply dropped. Otherwise
+    /// it is unrecoverable: Votor or the repair loop died, and a node that keeps
+    /// ingesting but can no longer vote contributes nothing while still counting
+    /// against liveness. Rather than fail silently, log at error level (using
+    /// `what` to name the channel) and shut the node down.
+    async fn send<T>(&self, sender: &mpsc::Sender<T>, item: T, what: &str) -> bool {
+        if sender.send(item).await.is_ok() {
+            return true;
+        }
+        if self.cancel_token.is_cancelled() {
+            debug!("{what} channel closed during shutdown, dropping remaining events");
+        } else {
+            error!("{what} channel closed unexpectedly, shutting down node");
+            self.cancel_token.cancel();
+        }
+        false
+    }
+
+    /// Forwards buffered blockstore events to Votor.
+    pub(crate) async fn forward_blockstore_events(&self, events: Vec<BlockstoreEvent>) {
+        for event in events {
+            if !self
+                .send(&self.blockstore_events, event, "Votor blockstore-event")
+                .await
+            {
                 return;
             }
         }
     }
 
-    /// Forwards buffered blockstore events to Votor.
-    pub(crate) async fn forward_blockstore_events(&self, events: Vec<BlockstoreEvent>) {
-        Self::forward_all(&self.blockstore_events, events, "Votor blockstore-event").await;
+    /// Forwards a single Pool event to Votor.
+    pub(crate) async fn forward_pool_event(&self, event: PoolEvent) {
+        self.send(&self.pool_events, event, "Votor pool-event")
+            .await;
     }
 
-    /// Forwards a drained [`PoolOutbox`]: Votor events first, then repair requests.
+    /// Forwards a drained [`PoolOutbox`], replaying the effects in the order the
+    /// Pool produced them.
     pub(crate) async fn forward_pool_outbox(&self, outbox: PoolOutbox) {
-        Self::forward_all(&self.pool_events, outbox.votor_events, "Votor pool-event").await;
-        Self::forward_all(&self.repairs, outbox.repairs, "repair").await;
+        for effect in outbox.effects {
+            let sent = match effect {
+                PoolEffect::VotorEvent(event) => {
+                    self.send(&self.pool_events, event, "Votor pool-event")
+                        .await
+                }
+                PoolEffect::Repair(block_id) => self.send(&self.repairs, block_id, "repair").await,
+            };
+            if !sent {
+                return;
+            }
+        }
     }
 }
 
@@ -248,7 +302,8 @@ where
         let (repair_tx, repair_rx) = mpsc::channel(1024);
         let all2all = Arc::new(all2all);
 
-        let event_forwarder = EventForwarder::new(blockstore_tx, pool_tx, repair_tx);
+        let event_forwarder =
+            EventForwarder::new(blockstore_tx, pool_tx, repair_tx, cancel_token.clone());
 
         let blockstore: SharedBlockstore = Arc::new(RwLock::new(BlockstoreImpl::new()));
 
@@ -507,15 +562,17 @@ mod tests {
     use super::*;
     use crate::crypto::merkle::GENESIS_BLOCK_HASH;
 
-    /// A closed Votor / repair channel (a shutting-down node) must not panic the
+    /// A closed Votor / repair channel on a shutting-down node must not panic the
     /// forwarder: the send fails, is logged, and the remaining items are dropped.
     #[tokio::test]
-    async fn forward_to_closed_channels_does_not_panic() {
+    async fn forward_to_closed_channels_during_shutdown_does_not_panic() {
         let (bs_tx, bs_rx) = mpsc::channel(1);
         let (pool_tx, pool_rx) = mpsc::channel(1);
         let (repair_tx, repair_rx) = mpsc::channel(1);
-        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx);
-        // Votor and the repair loop have shut down.
+        let cancel_token = CancellationToken::new();
+        // The node is already shutting down, which is why its consumers are gone.
+        cancel_token.cancel();
+        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx, cancel_token);
         drop(bs_rx);
         drop(pool_rx);
         drop(repair_rx);
@@ -525,10 +582,60 @@ mod tests {
             .await;
         forwarder
             .forward_pool_outbox(PoolOutbox {
-                votor_events: vec![PoolEvent::SafeToSkip(Slot::new(1))],
-                repairs: vec![(Slot::new(1), GENESIS_BLOCK_HASH)],
+                effects: vec![
+                    PoolEffect::VotorEvent(PoolEvent::SafeToSkip(Slot::new(1))),
+                    PoolEffect::Repair((Slot::new(1), GENESIS_BLOCK_HASH)),
+                ],
             })
             .await;
+    }
+
+    /// A consumer dying while the node is running is unrecoverable: this node can
+    /// no longer vote, so the forwarder shuts it down instead of dropping events
+    /// silently and leaving a zombie that still counts against liveness.
+    #[tokio::test]
+    async fn consumer_death_while_running_shuts_node_down() {
+        let (bs_tx, bs_rx) = mpsc::channel(1);
+        let (pool_tx, _pool_rx) = mpsc::channel(1);
+        let (repair_tx, _repair_rx) = mpsc::channel(1);
+        let cancel_token = CancellationToken::new();
+        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx, cancel_token.clone());
+        // Votor died mid-run, taking its receiver with it.
+        drop(bs_rx);
+
+        assert!(!cancel_token.is_cancelled());
+        forwarder
+            .forward_blockstore_events(vec![BlockstoreEvent::FirstShred(Slot::new(1))])
+            .await;
+        assert!(cancel_token.is_cancelled());
+    }
+
+    /// A drained outbox is replayed in the order the Pool produced it: a repair
+    /// request buffered before a Votor event is issued before it, not held back
+    /// until every Votor event has drained.
+    #[tokio::test]
+    async fn forward_pool_outbox_preserves_effect_order() {
+        let (bs_tx, _bs_rx) = mpsc::channel(1);
+        // Capacity 1, so forwarding blocks on the second Votor event.
+        let (pool_tx, _pool_rx) = mpsc::channel(1);
+        let (repair_tx, mut repair_rx) = mpsc::channel(1);
+        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx, CancellationToken::new());
+
+        let block = (Slot::new(3), GENESIS_BLOCK_HASH);
+        let outbox = PoolOutbox {
+            effects: vec![
+                PoolEffect::Repair(block.clone()),
+                PoolEffect::VotorEvent(PoolEvent::SafeToSkip(Slot::new(3))),
+                PoolEffect::VotorEvent(PoolEvent::SafeToSkip(Slot::new(4))),
+            ],
+        };
+        let handle = tokio::spawn(async move { forwarder.forward_pool_outbox(outbox).await });
+
+        let repaired = tokio::time::timeout(Duration::from_secs(1), repair_rx.recv())
+            .await
+            .expect("repair request should be forwarded before the Votor events drain");
+        assert_eq!(repaired.unwrap(), block);
+        handle.abort();
     }
 
     /// Forwarding delivers all buffered items, in order, to open channels.
@@ -537,7 +644,7 @@ mod tests {
         let (bs_tx, mut bs_rx) = mpsc::channel(8);
         let (pool_tx, mut pool_rx) = mpsc::channel(8);
         let (repair_tx, mut repair_rx) = mpsc::channel(8);
-        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx);
+        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx, CancellationToken::new());
 
         forwarder
             .forward_blockstore_events(vec![
@@ -556,8 +663,10 @@ mod tests {
         let block = (Slot::new(3), GENESIS_BLOCK_HASH);
         forwarder
             .forward_pool_outbox(PoolOutbox {
-                votor_events: vec![PoolEvent::SafeToSkip(Slot::new(3))],
-                repairs: vec![block.clone()],
+                effects: vec![
+                    PoolEffect::VotorEvent(PoolEvent::SafeToSkip(Slot::new(3))),
+                    PoolEffect::Repair(block.clone()),
+                ],
             })
             .await;
         assert!(matches!(pool_rx.try_recv(), Ok(PoolEvent::SafeToSkip(s)) if s == Slot::new(3)));

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -120,14 +120,24 @@ impl From<Cert> for ConsensusMessage {
 ///
 /// Forwarding one drained outbox preserves the order the producing component
 /// buffered its effects in. What the write lock no longer provides is a *global*
-/// order across tasks: two tasks that each mutate the Pool can now interleave
-/// their forwarding, so Votor may see a later task's event before an earlier
-/// one's. That is safe because Votor's handling of these events is order-
-/// insensitive except for its prune gate (`Votor::should_ignore_pool_event`),
-/// and an event losing that race is by definition one for a slot whose vote no
-/// longer matters. Restoring the global order would require holding a second
-/// lock across the send, which reintroduces exactly the lock jam this design
-/// exists to avoid.
+/// order across tasks: two tasks that each mutate the Pool or Blockstore can now
+/// interleave their forwarding, so Votor may see a later task's event before an
+/// earlier one's.
+///
+/// Votor must therefore not depend on the relative order of events from different
+/// tasks, on either channel. For pool events that holds already: handling is
+/// order-insensitive apart from the prune gate
+/// (`Votor::should_ignore_pool_event`), and an event losing that race is by
+/// definition one for a slot whose vote no longer matters. On the blockstore
+/// channel the order-sensitive pair is `InvalidBlock` against `Block` for the same
+/// window, which `Votor::try_skip_window` handles by marking the window bad
+/// regardless of whether the slot was already voted on.
+///
+/// Restoring the global order is not the alternative it looks like: it would take
+/// a second lock held across the send, reintroducing exactly the jam this design
+/// exists to avoid, and it would not even be sufficient — the lock only ever
+/// ordered events already buffered, never the arrival of the inputs that produce
+/// them.
 ///
 /// Cloneable so the message loop, the repair loop and the block producer can each
 /// forward the events they produce.

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -167,6 +167,10 @@ where
         RP: RepairResponderNetwork + 'static,
     {
         let cancel_token = CancellationToken::new();
+        // Producers (blockstore/pool) send on these with a non-blocking `try_send`
+        // so they never hold a write lock waiting on Votor; the buffer must be deep
+        // enough to absorb bursts, since on overflow events are dropped (and only
+        // recovered later via standstill recovery). Keep these capacities generous.
         let (blockstore_tx, blockstore_rx) = mpsc::channel(1024);
         let (pool_tx, pool_rx) = mpsc::channel(1024);
         let (repair_tx, repair_rx) = mpsc::channel(1024);

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -142,37 +142,27 @@ impl EventForwarder {
         }
     }
 
-    /// Forwards buffered blockstore events to Votor with a blocking send.
-    ///
-    /// A closed channel (Votor shutting down) is logged and the remaining events
-    /// dropped, rather than panicking.
-    pub(crate) async fn forward_blockstore_events(&self, events: Vec<BlockstoreEvent>) {
-        for event in events {
-            if self.blockstore_events.send(event).await.is_err() {
-                debug!("Votor event channel closed, dropping blockstore events");
-                break;
+    /// Forwards `items` to `sender` with blocking sends, stopping early if the
+    /// channel has closed (the consumer shut down). A closed channel is logged
+    /// (using `what` to name it) and the remaining items dropped, not panicked on.
+    async fn forward_all<T>(sender: &mpsc::Sender<T>, items: Vec<T>, what: &str) {
+        for item in items {
+            if sender.send(item).await.is_err() {
+                debug!("{what} channel closed, dropping remaining events");
+                return;
             }
         }
     }
 
-    /// Forwards a drained [`PoolOutbox`] (Votor events, then repair requests) with
-    /// blocking sends.
-    ///
-    /// A closed channel (Votor or the repair loop shutting down) is logged and the
-    /// remaining items dropped, rather than panicking.
+    /// Forwards buffered blockstore events to Votor.
+    pub(crate) async fn forward_blockstore_events(&self, events: Vec<BlockstoreEvent>) {
+        Self::forward_all(&self.blockstore_events, events, "Votor blockstore-event").await;
+    }
+
+    /// Forwards a drained [`PoolOutbox`]: Votor events first, then repair requests.
     pub(crate) async fn forward_pool_outbox(&self, outbox: PoolOutbox) {
-        for event in outbox.votor_events {
-            if self.pool_events.send(event).await.is_err() {
-                debug!("Votor event channel closed, dropping pool events");
-                break;
-            }
-        }
-        for block in outbox.repairs {
-            if self.repairs.send(block).await.is_err() {
-                debug!("repair channel closed, dropping repair requests");
-                break;
-            }
-        }
+        Self::forward_all(&self.pool_events, outbox.votor_events, "Votor pool-event").await;
+        Self::forward_all(&self.repairs, outbox.repairs, "repair").await;
     }
 }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -173,7 +173,7 @@ impl EventForwarder {
         }
     }
 
-    /// Sends a single `item` to `sender`, returning `false` if the channel closed.
+    /// Sends a single `item` to `sender`, returning `false` if it was not delivered.
     ///
     /// A closed channel means the consuming task is gone. While the node is
     /// shutting down that is expected and the item is simply dropped. Otherwise
@@ -181,17 +181,39 @@ impl EventForwarder {
     /// ingesting but can no longer vote contributes nothing while still counting
     /// against liveness. Rather than fail silently, log at error level (using
     /// `what` to name the channel) and shut the node down.
+    ///
+    /// A *full* channel is not an error — back-pressuring the calling ingest task
+    /// is the whole point of buffering into an outbox. But `send` would then park
+    /// until the consumer drains, and only the consumer can release it, so the
+    /// shutdown token is raced against the send to bound that wait. This is
+    /// currently belt-and-braces: Votor holds no Blockstore/Pool lock and blocks
+    /// only on a (UDP) [`All2All`] broadcast, so it always keeps draining and no
+    /// forwarder can be parked indefinitely. That is a property of Votor's shape,
+    /// though, not something the type system enforces — racing the token keeps
+    /// shutdown bounded even if that stops holding.
+    ///
+    /// The send is polled first (`biased`), so a shutting-down node still delivers
+    /// everything it can send without waiting, and drops only what would block.
     async fn send<T>(&self, sender: &mpsc::Sender<T>, item: T, what: &str) -> bool {
-        if sender.send(item).await.is_ok() {
-            return true;
+        tokio::select! {
+            biased;
+            res = sender.send(item) => {
+                if res.is_ok() {
+                    return true;
+                }
+                if self.cancel_token.is_cancelled() {
+                    debug!("{what} channel closed during shutdown, dropping remaining events");
+                } else {
+                    error!("{what} channel closed unexpectedly, shutting down node");
+                    self.cancel_token.cancel();
+                }
+                false
+            }
+            () = self.cancel_token.cancelled() => {
+                debug!("{what} channel full at shutdown, dropping remaining events");
+                false
+            }
         }
-        if self.cancel_token.is_cancelled() {
-            debug!("{what} channel closed during shutdown, dropping remaining events");
-        } else {
-            error!("{what} channel closed unexpectedly, shutting down node");
-            self.cancel_token.cancel();
-        }
-        false
     }
 
     /// Forwards buffered blockstore events to Votor.
@@ -206,16 +228,19 @@ impl EventForwarder {
         }
     }
 
-    /// Forwards a single Pool event to Votor.
-    pub(crate) async fn forward_pool_event(&self, event: PoolEvent) {
+    /// Forwards a single Pool event to Votor, returning `false` if it was dropped.
+    ///
+    /// A `false` return means the node is shutting down (see [`Self::send`]); a
+    /// caller with further effects to forward should stop rather than keep working.
+    pub(crate) async fn forward_pool_event(&self, event: PoolEvent) -> bool {
         self.send(&self.pool_events, event, "Votor pool-event")
-            .await;
+            .await
     }
 
     /// Forwards a drained [`PoolOutbox`], replaying the effects in the order the
     /// Pool produced them.
     pub(crate) async fn forward_pool_outbox(&self, outbox: PoolOutbox) {
-        for effect in outbox.effects {
+        for effect in outbox {
             let sent = match effect {
                 PoolEffect::VotorEvent(event) => {
                     self.send(&self.pool_events, event, "Votor pool-event")
@@ -591,12 +616,14 @@ mod tests {
             .forward_blockstore_events(vec![BlockstoreEvent::FirstShred(Slot::new(1))])
             .await;
         forwarder
-            .forward_pool_outbox(PoolOutbox {
-                effects: vec![
+            .forward_pool_outbox(
+                [
                     PoolEffect::VotorEvent(PoolEvent::SafeToSkip(Slot::new(1))),
                     PoolEffect::Repair((Slot::new(1), GENESIS_BLOCK_HASH)),
-                ],
-            })
+                ]
+                .into_iter()
+                .collect(),
+            )
             .await;
     }
 
@@ -620,6 +647,40 @@ mod tests {
         assert!(cancel_token.is_cancelled());
     }
 
+    /// A *full* channel at shutdown must not park the forwarder forever. Only the
+    /// consumer can make room, and by then there may be none left to do so, so the
+    /// send races the shutdown token. What still fits is delivered; the rest drops.
+    #[tokio::test]
+    async fn full_channel_at_shutdown_does_not_hang() {
+        // Receivers are alive but never drained, so the channel stays full.
+        let (bs_tx, mut bs_rx) = mpsc::channel(1);
+        let (pool_tx, _pool_rx) = mpsc::channel(1);
+        let (repair_tx, _repair_rx) = mpsc::channel(1);
+        let cancel_token = CancellationToken::new();
+        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx, cancel_token.clone());
+        cancel_token.cancel();
+
+        // The first event fits, so it is sent even though the token is already
+        // cancelled; the second would block and loses the race instead.
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            forwarder.forward_blockstore_events(vec![
+                BlockstoreEvent::FirstShred(Slot::new(1)),
+                BlockstoreEvent::FirstShred(Slot::new(2)),
+            ]),
+        )
+        .await
+        .expect("a cancelled token must release a forwarder blocked on a full channel");
+
+        assert!(
+            matches!(bs_rx.try_recv(), Ok(BlockstoreEvent::FirstShred(s)) if s == Slot::new(1))
+        );
+        assert!(
+            bs_rx.try_recv().is_err(),
+            "second event should have dropped"
+        );
+    }
+
     /// A drained outbox is replayed in the order the Pool produced it: a repair
     /// request buffered before a Votor event is issued before it, not held back
     /// until every Votor event has drained.
@@ -632,13 +693,13 @@ mod tests {
         let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx, CancellationToken::new());
 
         let block = (Slot::new(3), GENESIS_BLOCK_HASH);
-        let outbox = PoolOutbox {
-            effects: vec![
-                PoolEffect::Repair(block.clone()),
-                PoolEffect::VotorEvent(PoolEvent::SafeToSkip(Slot::new(3))),
-                PoolEffect::VotorEvent(PoolEvent::SafeToSkip(Slot::new(4))),
-            ],
-        };
+        let outbox: PoolOutbox = [
+            PoolEffect::Repair(block.clone()),
+            PoolEffect::VotorEvent(PoolEvent::SafeToSkip(Slot::new(3))),
+            PoolEffect::VotorEvent(PoolEvent::SafeToSkip(Slot::new(4))),
+        ]
+        .into_iter()
+        .collect();
         let handle = tokio::spawn(async move { forwarder.forward_pool_outbox(outbox).await });
 
         let repaired = tokio::time::timeout(Duration::from_secs(1), repair_rx.recv())
@@ -672,12 +733,14 @@ mod tests {
 
         let block = (Slot::new(3), GENESIS_BLOCK_HASH);
         forwarder
-            .forward_pool_outbox(PoolOutbox {
-                effects: vec![
+            .forward_pool_outbox(
+                [
                     PoolEffect::VotorEvent(PoolEvent::SafeToSkip(Slot::new(3))),
                     PoolEffect::Repair(block.clone()),
-                ],
-            })
+                ]
+                .into_iter()
+                .collect(),
+            )
             .await;
         assert!(matches!(pool_rx.try_recv(), Ok(PoolEvent::SafeToSkip(s)) if s == Slot::new(3)));
         assert_eq!(repair_rx.try_recv().unwrap(), block);

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -35,7 +35,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use fastrace::Span;
 use fastrace::future::FutureExt;
-use log::{trace, warn};
+use log::{debug, trace, warn};
 use tokio::sync::{RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 use wincode::{SchemaRead, SchemaWrite};
@@ -47,7 +47,7 @@ pub use self::cert::{Cert, CertError, NotarCert};
 pub use self::epoch_info::{EpochInfo, ValidatorEpochInfo};
 #[cfg(feature = "test-utils")]
 pub use self::pool::bench_replay_votes;
-pub use self::pool::{AddVoteError, Pool, PoolEvent, PoolImpl, SharedPool};
+pub use self::pool::{AddVoteError, Pool, PoolEvent, PoolImpl, PoolOutbox, SharedPool};
 pub use self::validated_cert::{CertValidationError, ValidatedCert};
 pub use self::validated_vote::{ValidatedVote, VoteValidationError};
 pub use self::vote::{FinalVote, NotarFallbackVote, NotarVote, SkipFallbackVote, SkipVote, Vote};
@@ -58,7 +58,7 @@ use crate::network::{RepairRequesterNetwork, RepairResponderNetwork, Transaction
 use crate::repair::{Repair, RepairRequestHandler};
 use crate::shredder::{Shred, ValidatedShred};
 use crate::types::Fraction;
-use crate::{All2All, Disseminator, Slot, ValidatorInfo};
+use crate::{All2All, BlockId, Disseminator, Slot, ValidatorInfo};
 
 /// Time bound assumed on network transmission delays during periods of synchrony.
 pub const DELTA: Duration = Duration::from_millis(250);
@@ -103,6 +103,79 @@ impl From<Cert> for ConsensusMessage {
     }
 }
 
+/// Forwards side-effects drained from the Blockstore and Pool outboxes to Votor
+/// and the repair loop *after* the producing task has released the write lock.
+///
+/// The Blockstore and Pool buffer their events instead of sending them while
+/// holding their write lock: a blocking send under the lock would let a slow or
+/// stalled Votor jam every other task contending for that lock, while a
+/// non-blocking send would have to drop the event (which for a reconstructed-block
+/// event silently costs this node its vote for that block, with no retry path).
+/// Each task that mutates the Blockstore/Pool drains the outbox (with
+/// [`Blockstore::take_events`] / [`Pool::take_outbox`]) and hands it here; the
+/// blocking send then back-pressures that (ingest) task instead of dropping the
+/// event or stalling the lock.
+///
+/// Cloneable so the message loop, the repair loop and the block producer can each
+/// forward the events they produce.
+#[derive(Clone)]
+pub(crate) struct EventForwarder {
+    /// Blockstore events destined for Votor.
+    blockstore_events: mpsc::Sender<BlockstoreEvent>,
+    /// Pool events destined for Votor.
+    pool_events: mpsc::Sender<PoolEvent>,
+    /// Repair requests destined for the repair loop.
+    repairs: mpsc::Sender<BlockId>,
+}
+
+impl EventForwarder {
+    /// Creates a forwarder over Votor's event channels and the repair channel.
+    pub(crate) fn new(
+        blockstore_events: mpsc::Sender<BlockstoreEvent>,
+        pool_events: mpsc::Sender<PoolEvent>,
+        repairs: mpsc::Sender<BlockId>,
+    ) -> Self {
+        Self {
+            blockstore_events,
+            pool_events,
+            repairs,
+        }
+    }
+
+    /// Forwards buffered blockstore events to Votor with a blocking send.
+    ///
+    /// A closed channel (Votor shutting down) is logged and the remaining events
+    /// dropped, rather than panicking.
+    pub(crate) async fn forward_blockstore_events(&self, events: Vec<BlockstoreEvent>) {
+        for event in events {
+            if self.blockstore_events.send(event).await.is_err() {
+                debug!("Votor event channel closed, dropping blockstore events");
+                break;
+            }
+        }
+    }
+
+    /// Forwards a drained [`PoolOutbox`] (Votor events, then repair requests) with
+    /// blocking sends.
+    ///
+    /// A closed channel (Votor or the repair loop shutting down) is logged and the
+    /// remaining items dropped, rather than panicking.
+    pub(crate) async fn forward_pool_outbox(&self, outbox: PoolOutbox) {
+        for event in outbox.votor_events {
+            if self.pool_events.send(event).await.is_err() {
+                debug!("Votor event channel closed, dropping pool events");
+                break;
+            }
+        }
+        for block in outbox.repairs {
+            if self.repairs.send(block).await.is_err() {
+                debug!("repair channel closed, dropping repair requests");
+                break;
+            }
+        }
+    }
+}
+
 /// Alpenglow consensus protocol implementation.
 pub struct Alpenglow<A: All2All, D: Disseminator, T>
 where
@@ -123,6 +196,9 @@ where
     all2all: Arc<A>,
     /// Block dissemination network protocol for shreds.
     disseminator: Arc<D>,
+
+    /// Forwards blockstore outbox events to Votor off the write lock.
+    event_forwarder: EventForwarder,
 
     /// Indicates whether the node is shutting down.
     cancel_token: CancellationToken,
@@ -172,23 +248,21 @@ where
         RP: RepairResponderNetwork + 'static,
     {
         let cancel_token = CancellationToken::new();
-        // Producers (blockstore/pool) send on these with a non-blocking `try_send`
-        // so they never hold a write lock waiting on Votor; the buffer must be deep
-        // enough to absorb bursts, since on overflow events are dropped (and only
-        // recovered later via standstill recovery). Keep these capacities generous.
+        // Votor's event channels. The Blockstore/Pool buffer events into an outbox
+        // under their write lock and the producing task forwards them here *after*
+        // releasing the lock (see `EventForwarder`), so a full channel back-pressures
+        // the ingest task rather than jamming the lock or dropping the event. The
+        // buffer is sized to absorb ordinary bursts without back-pressuring.
         let (blockstore_tx, blockstore_rx) = mpsc::channel(1024);
         let (pool_tx, pool_rx) = mpsc::channel(1024);
         let (repair_tx, repair_rx) = mpsc::channel(1024);
         let all2all = Arc::new(all2all);
 
-        let blockstore: SharedBlockstore =
-            Arc::new(RwLock::new(BlockstoreImpl::new(blockstore_tx)));
+        let event_forwarder = EventForwarder::new(blockstore_tx, pool_tx, repair_tx);
 
-        let pool: SharedPool = Arc::new(RwLock::new(PoolImpl::new(
-            epoch_info.clone(),
-            pool_tx,
-            repair_tx,
-        )));
+        let blockstore: SharedBlockstore = Arc::new(RwLock::new(BlockstoreImpl::new()));
+
+        let pool: SharedPool = Arc::new(RwLock::new(PoolImpl::new(epoch_info.clone())));
 
         let repair_request_handler = RepairRequestHandler::new(
             epoch_info.clone(),
@@ -203,6 +277,7 @@ where
             Arc::clone(&pool),
             repair_requester_network,
             epoch_info.clone(),
+            event_forwarder.clone(),
         );
 
         let _repair_handle = tokio::spawn(
@@ -231,6 +306,7 @@ where
             txs_receiver,
             blockstore.clone(),
             pool.clone(),
+            event_forwarder.clone(),
             cancel_token.clone(),
             DELTA_BLOCK,
             DELTA_FIRST_SLICE,
@@ -243,6 +319,7 @@ where
             block_producer,
             all2all,
             disseminator,
+            event_forwarder,
             cancel_token,
             votor_handle,
         }
@@ -328,7 +405,8 @@ where
                 finalized_slot = slot;
                 last_progress = Instant::now();
             } else if last_progress.elapsed() > DELTA_STANDSTILL {
-                self.pool.read().await.recover_from_standstill().await;
+                let outbox = self.pool.read().await.recover_from_standstill();
+                self.event_forwarder.forward_pool_outbox(outbox).await;
                 last_progress = Instant::now();
             }
             tokio::time::sleep(DELTA_BLOCK).await;
@@ -351,13 +429,19 @@ where
                         return;
                     }
                 };
-                match self.pool.write().await.add_vote(vote).await {
-                    Ok(()) => {}
-                    Err(AddVoteError::Slashable(offence)) => {
-                        warn!("slashable offence detected: {offence}");
+                // Add under the lock, then forward the buffered events off the lock.
+                let outbox = {
+                    let mut pool = self.pool.write().await;
+                    match pool.add_vote(vote).await {
+                        Ok(()) => {}
+                        Err(AddVoteError::Slashable(offence)) => {
+                            warn!("slashable offence detected: {offence}");
+                        }
+                        Err(err) => trace!("ignoring invalid vote: {err}"),
                     }
-                    Err(err) => trace!("ignoring invalid vote: {err}"),
-                }
+                    pool.take_outbox()
+                };
+                self.event_forwarder.forward_pool_outbox(outbox).await;
             }
             ConsensusMessage::Cert(c) => {
                 let cert = match ValidatedCert::try_new(c, epoch_info) {
@@ -367,10 +451,15 @@ where
                         return;
                     }
                 };
-                match self.pool.write().await.add_cert(cert).await {
-                    Ok(()) => {}
-                    Err(err) => trace!("ignoring invalid cert: {err}"),
-                }
+                let outbox = {
+                    let mut pool = self.pool.write().await;
+                    match pool.add_cert(cert).await {
+                        Ok(()) => {}
+                        Err(err) => trace!("ignoring invalid cert: {err}"),
+                    }
+                    pool.take_outbox()
+                };
+                self.event_forwarder.forward_pool_outbox(outbox).await;
             }
         }
     }
@@ -401,21 +490,87 @@ where
             return Ok(());
         }
 
-        // otherwise, ingest into blockstore
-        let res = self
-            .blockstore
-            .write()
-            .await
-            .add_shred_from_dissemination(validated)
-            .await;
+        // Ingest into the blockstore, then forward the buffered events to Votor
+        // *after* releasing the write lock (see `EventForwarder`).
+        let (res, events) = {
+            let mut blockstore = self.blockstore.write().await;
+            let res = blockstore.add_shred_from_dissemination(validated).await;
+            (res, blockstore.take_events())
+        };
+        self.event_forwarder.forward_blockstore_events(events).await;
+
         if let Ok(Some(block_info)) = res {
             let block_id = (slot, block_info.hash);
-            self.pool
-                .write()
-                .await
-                .add_block(block_id, block_info.parent)
-                .await;
+            let outbox = {
+                let mut pool = self.pool.write().await;
+                pool.add_block(block_id, block_info.parent).await;
+                pool.take_outbox()
+            };
+            self.event_forwarder.forward_pool_outbox(outbox).await;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::merkle::GENESIS_BLOCK_HASH;
+
+    /// A closed Votor / repair channel (a shutting-down node) must not panic the
+    /// forwarder: the send fails, is logged, and the remaining items are dropped.
+    #[tokio::test]
+    async fn forward_to_closed_channels_does_not_panic() {
+        let (bs_tx, bs_rx) = mpsc::channel(1);
+        let (pool_tx, pool_rx) = mpsc::channel(1);
+        let (repair_tx, repair_rx) = mpsc::channel(1);
+        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx);
+        // Votor and the repair loop have shut down.
+        drop(bs_rx);
+        drop(pool_rx);
+        drop(repair_rx);
+
+        forwarder
+            .forward_blockstore_events(vec![BlockstoreEvent::FirstShred(Slot::new(1))])
+            .await;
+        forwarder
+            .forward_pool_outbox(PoolOutbox {
+                votor_events: vec![PoolEvent::SafeToSkip(Slot::new(1))],
+                repairs: vec![(Slot::new(1), GENESIS_BLOCK_HASH)],
+            })
+            .await;
+    }
+
+    /// Forwarding delivers all buffered items, in order, to open channels.
+    #[tokio::test]
+    async fn forward_delivers_all_events_in_order() {
+        let (bs_tx, mut bs_rx) = mpsc::channel(8);
+        let (pool_tx, mut pool_rx) = mpsc::channel(8);
+        let (repair_tx, mut repair_rx) = mpsc::channel(8);
+        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx);
+
+        forwarder
+            .forward_blockstore_events(vec![
+                BlockstoreEvent::FirstShred(Slot::new(1)),
+                BlockstoreEvent::InvalidBlock(Slot::new(2)),
+            ])
+            .await;
+        assert!(
+            matches!(bs_rx.try_recv(), Ok(BlockstoreEvent::FirstShred(s)) if s == Slot::new(1))
+        );
+        assert!(
+            matches!(bs_rx.try_recv(), Ok(BlockstoreEvent::InvalidBlock(s)) if s == Slot::new(2))
+        );
+        assert!(bs_rx.try_recv().is_err());
+
+        let block = (Slot::new(3), GENESIS_BLOCK_HASH);
+        forwarder
+            .forward_pool_outbox(PoolOutbox {
+                votor_events: vec![PoolEvent::SafeToSkip(Slot::new(3))],
+                repairs: vec![block.clone()],
+            })
+            .await;
+        assert!(matches!(pool_rx.try_recv(), Ok(PoolEvent::SafeToSkip(s)) if s == Slot::new(3)));
+        assert_eq!(repair_rx.try_recv().unwrap(), block);
     }
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -172,6 +172,10 @@ where
         RP: RepairResponderNetwork + 'static,
     {
         let cancel_token = CancellationToken::new();
+        // Producers (blockstore/pool) send on these with a non-blocking `try_send`
+        // so they never hold a write lock waiting on Votor; the buffer must be deep
+        // enough to absorb bursts, since on overflow events are dropped (and only
+        // recovered later via standstill recovery). Keep these capacities generous.
         let (blockstore_tx, blockstore_rx) = mpsc::channel(1024);
         let (pool_tx, pool_rx) = mpsc::channel(1024);
         let (repair_tx, repair_rx) = mpsc::channel(1024);

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -699,7 +699,8 @@ mod tests {
         let (bs_event_tx, _bs_event_rx) = tokio::sync::mpsc::channel(100);
         let (pool_event_tx, _pool_event_rx) = tokio::sync::mpsc::channel(100);
         let (repair_tx, _repair_rx) = tokio::sync::mpsc::channel(100);
-        let event_forwarder = EventForwarder::new(bs_event_tx, pool_event_tx, repair_tx);
+        let event_forwarder =
+            EventForwarder::new(bs_event_tx, pool_event_tx, repair_tx, cancel_token.clone());
 
         BlockProducer::new(
             secret_key,

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -15,7 +15,7 @@ use tokio::sync::oneshot;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-use crate::consensus::{SharedBlockstore, SharedPool, ValidatorEpochInfo};
+use crate::consensus::{EventForwarder, SharedBlockstore, SharedPool, ValidatorEpochInfo};
 use crate::crypto::merkle::{BlockHash, GENESIS_BLOCK_HASH};
 use crate::crypto::signature;
 use crate::network::{Network, TransactionNetwork};
@@ -40,6 +40,8 @@ pub(super) struct BlockProducer<D: Disseminator, T: Network> {
     blockstore: SharedBlockstore,
     /// Pool of votes and certificates.
     pool: SharedPool,
+    /// Forwards blockstore outbox events to Votor off the write lock.
+    event_forwarder: EventForwarder,
 
     /// Block dissemination network protocol for shreds.
     disseminator: Arc<D>,
@@ -75,6 +77,7 @@ where
         txs_receiver: T,
         blockstore: SharedBlockstore,
         pool: SharedPool,
+        event_forwarder: EventForwarder,
         cancel_token: CancellationToken,
         delta_block: Duration,
         delta_first_slice: Duration,
@@ -85,6 +88,7 @@ where
             epoch_info,
             blockstore,
             pool,
+            event_forwarder,
             disseminator,
             txs_receiver,
             // block production is sequential, so a single shredder is enough
@@ -363,13 +367,14 @@ where
 
         // Fast path: we already have every shred and the decoded payload, so the
         // blockstore can skip RS-decode, Merkle verification and the per-shred
-        // lock churn. The completed block hands back (slot, hash).
-        let block_info = self
-            .blockstore
-            .write()
-            .await
-            .add_own_slice(payload, shreds)
-            .await;
+        // lock churn. The completed block hands back (slot, hash). Forward the
+        // buffered events to Votor after releasing the write lock.
+        let (block_info, events) = {
+            let mut blockstore = self.blockstore.write().await;
+            let block_info = blockstore.add_own_slice(payload, shreds).await;
+            (block_info, blockstore.take_events())
+        };
+        self.event_forwarder.forward_blockstore_events(events).await;
 
         if let Some(e) = first_err {
             warn!(
@@ -384,11 +389,12 @@ where
                 // followers can never reconstruct. Crash loudly instead.
                 assert!(is_last, "block completed before its last slice");
                 let block_id = (slot, block_info.hash.clone());
-                self.pool
-                    .write()
-                    .await
-                    .add_block(block_id, block_info.parent)
-                    .await;
+                let outbox = {
+                    let mut pool = self.pool.write().await;
+                    pool.add_block(block_id, block_info.parent).await;
+                    pool.take_outbox()
+                };
+                self.event_forwarder.forward_pool_outbox(outbox).await;
                 Ok(Some(block_info.hash))
             }
             None => {
@@ -566,7 +572,7 @@ mod tests {
     use super::*;
     use crate::consensus::blockstore::MockBlockstore;
     use crate::consensus::pool::MockPool;
-    use crate::consensus::{BlockInfo, ValidatorEpochInfo};
+    use crate::consensus::{BlockInfo, PoolOutbox, ValidatorEpochInfo};
     use crate::crypto::Hash;
     use crate::disseminator::MockDisseminator;
     use crate::network::{UdpNetwork, localhost_ip_sockaddr};
@@ -690,6 +696,10 @@ mod tests {
         let disseminator = Arc::new(disseminator);
         let txs_receiver = UdpNetwork::new_with_any_port();
         let cancel_token = CancellationToken::new();
+        let (bs_event_tx, _bs_event_rx) = tokio::sync::mpsc::channel(100);
+        let (pool_event_tx, _pool_event_rx) = tokio::sync::mpsc::channel(100);
+        let (repair_tx, _repair_rx) = tokio::sync::mpsc::channel(100);
+        let event_forwarder = EventForwarder::new(bs_event_tx, pool_event_tx, repair_tx);
 
         BlockProducer::new(
             secret_key,
@@ -698,6 +708,7 @@ mod tests {
             txs_receiver,
             blockstore,
             pool,
+            event_forwarder,
             cancel_token,
             delta_block,
             delta_first_slice,
@@ -725,6 +736,7 @@ mod tests {
                 let bi = bi.clone();
                 Box::pin(async move { Some(bi) })
             });
+        blockstore.expect_take_events().returning(Vec::new);
 
         let mut pool = MockPool::new();
         let bi = block_info.clone();
@@ -734,6 +746,7 @@ mod tests {
                 assert_eq!(bi.parent, ret_parent_block_id);
                 Box::pin(async {})
             });
+        pool.expect_take_outbox().returning(PoolOutbox::default);
 
         let mut disseminator = MockDisseminator::new();
         disseminator
@@ -800,6 +813,7 @@ mod tests {
                 let nbi = nbi.clone();
                 Box::pin(async move { Some(nbi) })
             });
+        blockstore.expect_take_events().returning(Vec::new);
 
         let mut pool = MockPool::new();
         let nbi = new_block_info.clone();
@@ -809,6 +823,7 @@ mod tests {
                 assert_eq!(nbi.parent, ret_parent_block_id);
                 Box::pin(async {})
             });
+        pool.expect_take_outbox().returning(PoolOutbox::default);
 
         let mut disseminator = MockDisseminator::new();
         disseminator

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -9,10 +9,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use log::{debug, warn};
+use log::debug;
 use tokio::sync::RwLock;
-use tokio::sync::mpsc::Sender;
-use tokio::sync::mpsc::error::TrySendError;
 
 pub use self::slot_block_data::AddShredError;
 use self::slot_block_data::SlotBlockData;
@@ -83,6 +81,12 @@ pub trait Blockstore {
         shreds: Box<[ValidatedShred; TOTAL_SHREDS]>,
     ) -> Option<BlockInfo>;
     async fn flag_leader_misbehavior(&mut self, slot: Slot);
+    /// Drains and returns the [`BlockstoreEvent`]s buffered since the last call.
+    ///
+    /// The caller must forward these to Votor *after* releasing the blockstore
+    /// lock, so that a slow Votor back-pressures the ingest task instead of
+    /// jamming the lock. See `BlockstoreImpl::emit` for the rationale.
+    fn take_events(&mut self) -> Vec<BlockstoreEvent>;
     #[expect(
         clippy::needless_lifetimes,
         reason = "explicit lifetime is required by mockall::automock"
@@ -114,23 +118,34 @@ pub struct BlockstoreImpl {
     block_data: BTreeMap<Slot, SlotBlockData>,
     /// Shredders used for reconstructing blocks.
     shredders: ShredderPool<RegularShredder>,
-    /// Event channel for sending notifications to Votor.
-    votor_channel: Sender<BlockstoreEvent>,
+    /// Buffer of events to be delivered to Votor, drained via [`Blockstore::take_events`].
+    ///
+    /// Events are buffered here (under whatever lock guards the blockstore) rather
+    /// than sent directly, so the caller can forward them to Votor *after* dropping
+    /// the write lock. See `BlockstoreImpl::emit` for the rationale.
+    events: Vec<BlockstoreEvent>,
+}
+
+impl Default for BlockstoreImpl {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl BlockstoreImpl {
     /// Initializes a new empty blockstore.
     ///
-    /// Blockstore will send the following [`BlockstoreEvent`]s to the provided `votor_channel`:
+    /// The blockstore records the following [`BlockstoreEvent`]s into its outbox, to
+    /// be drained by the caller via [`Blockstore::take_events`] and forwarded to Votor:
     /// - [`BlockstoreEvent::FirstShred`] when receiving the first shred for a slot
     ///   from the block dissemination protocol
     /// - [`BlockstoreEvent::Block`] for any reconstructed block
     /// - [`BlockstoreEvent::InvalidBlock`] if leader misbehavior is detected for a block
-    pub fn new(votor_channel: Sender<BlockstoreEvent>) -> Self {
+    pub fn new() -> Self {
         Self {
             block_data: BTreeMap::new(),
             shredders: ShredderPool::with_size(1),
-            votor_channel,
+            events: Vec::new(),
         }
     }
 
@@ -139,19 +154,19 @@ impl BlockstoreImpl {
         self.block_data = self.block_data.split_off(&slot);
     }
 
-    /// Forwards a [`BlockstoreEvent`] to Votor, returning the [`BlockInfo`] of a
+    /// Records a [`BlockstoreEvent`] in the outbox, returning the [`BlockInfo`] of a
     /// newly reconstructed block iff `event` is a [`BlockstoreEvent::Block`].
     ///
-    /// This uses a non-blocking [`Sender::try_send`] on purpose: the shred-ingest
-    /// path holds the blockstore write lock while adding a shred (see
-    /// [`super::Alpenglow::handle_disseminator_shred`]), so a blocking send would
-    /// let a slow or stalled Votor apply back-pressure that jams every other task
-    /// waiting on that lock. Instead, on overflow (channel full) or a closed
-    /// channel (Votor shutting down) we drop the event with a log message rather
-    /// than panicking. The block itself is still stored and handed to the Pool by
-    /// the caller, so a dropped event only costs this node its own vote for that
-    /// block under extreme back-pressure.
-    fn send_blockstore_event(&self, event: BlockstoreEvent) -> Option<BlockInfo> {
+    /// The event is buffered rather than sent on purpose: the shred-ingest path
+    /// holds the blockstore write lock while adding a shred (see
+    /// [`super::Alpenglow::handle_disseminator_shred`]), so a *blocking* send here
+    /// would let a slow or stalled Votor apply back-pressure that jams every other
+    /// task waiting on that lock. Instead the caller drains the outbox via
+    /// [`Blockstore::take_events`] and forwards it to Votor *after* dropping the
+    /// lock, where a blocking send is safe: it back-pressures the ingest task only,
+    /// never dropping the event. Losing a reconstructed-block event would otherwise
+    /// silently cost this node its vote for that block, with no retry path.
+    fn emit(&mut self, event: BlockstoreEvent) -> Option<BlockInfo> {
         let block_info = if let BlockstoreEvent::Block { slot, block_info } = &event {
             debug!(
                 "reconstructed block {} in slot {} with parent {} in slot {}",
@@ -164,15 +179,7 @@ impl BlockstoreImpl {
         } else {
             None
         };
-        match self.votor_channel.try_send(event) {
-            Ok(()) => {}
-            Err(TrySendError::Full(event)) => {
-                warn!("Votor event channel full, dropping blockstore event: {event:?}");
-            }
-            Err(TrySendError::Closed(event)) => {
-                debug!("Votor event channel closed, dropping blockstore event: {event:?}");
-            }
-        }
+        self.events.push(event);
         block_info
     }
 
@@ -276,7 +283,7 @@ impl Blockstore for BlockstoreImpl {
             .slot_data_mut(slot)
             .add_shred_from_dissemination(shred, &mut shredder)
         {
-            Ok(Some(event)) => Ok(self.send_blockstore_event(event)),
+            Ok(Some(event)) => Ok(self.emit(event)),
             Ok(None) => Ok(None),
             Err(err @ (AddShredError::Equivocation | AddShredError::InvalidShred)) => {
                 self.flag_leader_misbehavior(slot).await;
@@ -320,7 +327,7 @@ impl Blockstore for BlockstoreImpl {
             self.flag_leader_misbehavior(slot).await;
         }
         match result? {
-            Some(event) => Ok(self.send_blockstore_event(event)),
+            Some(event) => Ok(self.emit(event)),
             None => Ok(None),
         }
     }
@@ -342,12 +349,10 @@ impl Blockstore for BlockstoreImpl {
         let slot = shreds[0].payload().header.slot;
         let (first_shred, completed) = self.slot_data_mut(slot).add_own_slice(payload, *shreds);
         if first_shred {
-            self.send_blockstore_event(BlockstoreEvent::FirstShred(slot));
+            self.emit(BlockstoreEvent::FirstShred(slot));
         }
         match completed {
-            Some(block_info) => {
-                self.send_blockstore_event(BlockstoreEvent::Block { slot, block_info })
-            }
+            Some(block_info) => self.emit(BlockstoreEvent::Block { slot, block_info }),
             None => None,
         }
     }
@@ -357,8 +362,12 @@ impl Blockstore for BlockstoreImpl {
     /// Emits [`BlockstoreEvent::InvalidBlock`] the first time the slot is flagged.
     async fn flag_leader_misbehavior(&mut self, slot: Slot) {
         if self.slot_data_mut(slot).mark_leader_misbehaved() {
-            self.send_blockstore_event(BlockstoreEvent::InvalidBlock(slot));
+            self.emit(BlockstoreEvent::InvalidBlock(slot));
         }
+    }
+
+    fn take_events(&mut self) -> Vec<BlockstoreEvent> {
+        std::mem::take(&mut self.events)
     }
 
     /// Gives the disseminated block hash for a given `slot`, if any.
@@ -454,7 +463,6 @@ impl Blockstore for BlockstoreImpl {
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use tokio::sync::mpsc;
 
     use super::*;
     use crate::crypto::merkle::DoubleMerkleTree;
@@ -466,18 +474,12 @@ mod tests {
     struct TestContext {
         sk: SecretKey,
         blockstore: BlockstoreImpl,
-        _rx: mpsc::Receiver<BlockstoreEvent>,
     }
 
     fn setup() -> TestContext {
         let sk = SecretKey::new(&mut rand::rng());
-        let (tx, _rx) = mpsc::channel(1000);
-        let blockstore = BlockstoreImpl::new(tx);
-        TestContext {
-            sk,
-            blockstore,
-            _rx,
-        }
+        let blockstore = BlockstoreImpl::new();
+        TestContext { sk, blockstore }
     }
 
     async fn add_shred_ignore_duplicate(
@@ -503,8 +505,8 @@ mod tests {
     /// Feeds every shred of a fresh single-slice block into `blockstore` and
     /// returns the [`BlockInfo`] of the reconstructed block.
     ///
-    /// Reconstruction makes the blockstore emit `FirstShred` + `Block` events to
-    /// Votor via the (non-blocking) `send_blockstore_event`.
+    /// Reconstruction records `FirstShred` + `Block` events in the blockstore's
+    /// outbox, to be drained via [`Blockstore::take_events`].
     async fn store_full_block(blockstore: &mut BlockstoreImpl, sk: &SecretKey) -> BlockInfo {
         let slot = Slot::genesis().next();
         let (block_hash, _, shreds) = create_random_shredded_block(slot, 1, sk);
@@ -519,28 +521,30 @@ mod tests {
         info
     }
 
-    /// A full Votor channel must not panic or block the blockstore: the event is
-    /// dropped on overflow, yet the block is still reconstructed and returned.
+    /// Reconstructing a block must record its `FirstShred` and `Block` events in the
+    /// outbox (rather than sending them under the lock), so the caller can forward
+    /// them to Votor losslessly after releasing the write lock.
     #[tokio::test]
-    async fn block_event_dropped_when_channel_full() {
-        let sk = SecretKey::new(&mut rand::rng());
-        // Capacity 1, never drained: `FirstShred` fills it, `Block` overflows.
-        let (tx, _rx) = mpsc::channel(1);
-        let mut blockstore = BlockstoreImpl::new(tx);
+    async fn reconstruction_events_are_recorded() {
+        let mut ctx = setup();
+        let info = store_full_block(&mut ctx.blockstore, &ctx.sk).await;
 
-        store_full_block(&mut blockstore, &sk).await;
-    }
-
-    /// A closed Votor channel (Votor shutting down) must not panic the blockstore;
-    /// the event is dropped and the block is still reconstructed and returned.
-    #[tokio::test]
-    async fn block_event_dropped_when_channel_closed() {
-        let sk = SecretKey::new(&mut rand::rng());
-        let (tx, rx) = mpsc::channel(1000);
-        let mut blockstore = BlockstoreImpl::new(tx);
-        drop(rx);
-
-        store_full_block(&mut blockstore, &sk).await;
+        let events = ctx.blockstore.take_events();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, BlockstoreEvent::FirstShred(_))),
+            "expected a FirstShred event, got {events:?}"
+        );
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                BlockstoreEvent::Block { block_info, .. } if block_info.hash == info.hash
+            )),
+            "expected a Block event for the reconstructed block, got {events:?}"
+        );
+        // Draining leaves the outbox empty.
+        assert!(ctx.blockstore.take_events().is_empty());
     }
 
     #[tokio::test]
@@ -769,21 +773,19 @@ mod tests {
         Ok(())
     }
 
-    fn count_invalid_block_events(rx: &mut mpsc::Receiver<BlockstoreEvent>, slot: Slot) -> usize {
-        let mut count = 0;
-        while let Ok(event) = rx.try_recv() {
-            if matches!(event, BlockstoreEvent::InvalidBlock(s) if s == slot) {
-                count += 1;
-            }
-        }
-        count
+    /// Drains the blockstore outbox and counts `InvalidBlock` events for `slot`.
+    fn count_invalid_block_events(blockstore: &mut BlockstoreImpl, slot: Slot) -> usize {
+        blockstore
+            .take_events()
+            .iter()
+            .filter(|e| matches!(e, BlockstoreEvent::InvalidBlock(s) if *s == slot))
+            .count()
     }
 
     #[tokio::test]
     async fn dissemination_equivocation() -> Result<()> {
         let sk = SecretKey::new(&mut rand::rng());
-        let (tx, mut rx) = mpsc::channel(1000);
-        let mut blockstore = BlockstoreImpl::new(tx);
+        let mut blockstore = BlockstoreImpl::new();
         let slot = Slot::genesis().next();
 
         // disseminate two distinct blocks for the same slot
@@ -798,11 +800,11 @@ mod tests {
 
         // equivocation detected, Votor should be notified
         assert_eq!(res, Err(AddShredError::Equivocation));
-        assert_eq!(count_invalid_block_events(&mut rx, slot), 1);
+        assert_eq!(count_invalid_block_events(&mut blockstore, slot), 1);
 
         // idempotent: later misbehavior does not re-notify
         blockstore.flag_leader_misbehavior(slot).await;
-        assert_eq!(count_invalid_block_events(&mut rx, slot), 0);
+        assert_eq!(count_invalid_block_events(&mut blockstore, slot), 0);
 
         Ok(())
     }
@@ -810,8 +812,7 @@ mod tests {
     #[tokio::test]
     async fn repair_conflicting_block_not_flagged_as_equivocation() -> Result<()> {
         let sk = SecretKey::new(&mut rand::rng());
-        let (tx, mut rx) = mpsc::channel(1000);
-        let mut blockstore = BlockstoreImpl::new(tx);
+        let mut blockstore = BlockstoreImpl::new();
         let slot = Slot::genesis().next();
 
         // see different blocks from dissemination and repair
@@ -826,7 +827,7 @@ mod tests {
 
         // TODO: Detect equivocation across the dissemination and repair spots.
         assert_eq!(res, Ok(None));
-        assert_eq!(count_invalid_block_events(&mut rx, slot), 0);
+        assert_eq!(count_invalid_block_events(&mut blockstore, slot), 0);
 
         Ok(())
     }
@@ -904,8 +905,7 @@ mod tests {
         let slices = create_random_block(slot, num_slices);
 
         // reference: reconstruct the block via the dissemination path
-        let (dissem_tx, _dissem_rx) = mpsc::channel(1000);
-        let mut dissem = BlockstoreImpl::new(dissem_tx);
+        let mut dissem = BlockstoreImpl::new();
         for slice in &slices {
             let shreds = RegularShredder::default().shred(slice, &sk).unwrap();
             for shred in shreds {
@@ -915,8 +915,7 @@ mod tests {
         let expected_hash = dissem.disseminated_block_hash(slot).unwrap().clone();
 
         // fast path: feed the same slices through `add_own_slice`
-        let (own_tx, mut own_rx) = mpsc::channel(1000);
-        let mut own = BlockstoreImpl::new(own_tx);
+        let mut own = BlockstoreImpl::new();
         let mut completed = None;
         for slice in slices {
             let is_last = slice.is_last;
@@ -936,10 +935,10 @@ mod tests {
         assert_eq!(own.disseminated_block_hash(slot), Some(&expected_hash));
         assert!(own.get_block(&(slot, expected_hash.clone())).is_some());
 
-        // emits exactly one FirstShred and one Block event
+        // records exactly one FirstShred and one Block event in the outbox
         let mut first_shreds = 0;
         let mut blocks = 0;
-        while let Ok(event) = own_rx.try_recv() {
+        for event in own.take_events() {
             match event {
                 BlockstoreEvent::FirstShred(s) => {
                     assert_eq!(s, slot);

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -9,9 +9,10 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use log::debug;
+use log::{debug, warn};
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::error::TrySendError;
 
 pub use self::slot_block_data::AddShredError;
 use self::slot_block_data::SlotBlockData;
@@ -127,24 +128,40 @@ impl BlockstoreImpl {
         self.block_data = self.block_data.split_off(&slot);
     }
 
-    async fn send_blockstore_event(&self, event: BlockstoreEvent) -> Option<BlockInfo> {
-        let block_info = match &event {
-            BlockstoreEvent::FirstShred(_) | BlockstoreEvent::InvalidBlock(_) => None,
-            BlockstoreEvent::Block { slot, block_info } => {
-                debug!(
-                    "reconstructed block {} in slot {} with parent {} in slot {}",
-                    block_info.hash.short_hex(),
-                    slot,
-                    block_info.parent.1.short_hex(),
-                    block_info.parent.0,
-                );
-                Some(block_info.clone())
-            }
+    /// Forwards a [`BlockstoreEvent`] to Votor, returning the [`BlockInfo`] of a
+    /// newly reconstructed block iff `event` is a [`BlockstoreEvent::Block`].
+    ///
+    /// This uses a non-blocking [`Sender::try_send`] on purpose: the shred-ingest
+    /// path holds the blockstore write lock while adding a shred (see
+    /// [`super::Alpenglow::handle_disseminator_shred`]), so a blocking send would
+    /// let a slow or stalled Votor apply back-pressure that jams every other task
+    /// waiting on that lock. Instead, on overflow (channel full) or a closed
+    /// channel (Votor shutting down) we drop the event with a log message rather
+    /// than panicking. The block itself is still stored and handed to the Pool by
+    /// the caller, so a dropped event only costs this node its own vote for that
+    /// block under extreme back-pressure.
+    fn send_blockstore_event(&self, event: BlockstoreEvent) -> Option<BlockInfo> {
+        let block_info = if let BlockstoreEvent::Block { slot, block_info } = &event {
+            debug!(
+                "reconstructed block {} in slot {} with parent {} in slot {}",
+                block_info.hash.short_hex(),
+                slot,
+                block_info.parent.1.short_hex(),
+                block_info.parent.0,
+            );
+            Some(block_info.clone())
+        } else {
+            None
         };
-        self.votor_channel
-            .send(event)
-            .await
-            .expect("votor should not drop the event receiver");
+        match self.votor_channel.try_send(event) {
+            Ok(()) => {}
+            Err(TrySendError::Full(event)) => {
+                warn!("Votor event channel full, dropping blockstore event: {event:?}");
+            }
+            Err(TrySendError::Closed(event)) => {
+                debug!("Votor event channel closed, dropping blockstore event: {event:?}");
+            }
+        }
         block_info
     }
 
@@ -249,11 +266,10 @@ impl Blockstore for BlockstoreImpl {
             .slot_data_mut(slot)
             .add_shred_from_dissemination(shred, &mut shredder)
         {
-            Ok(Some(event)) => Ok(self.send_blockstore_event(event).await),
+            Ok(Some(event)) => Ok(self.send_blockstore_event(event)),
             Ok(None) => Ok(None),
             Err(AddShredError::InvalidShred) => {
-                self.send_blockstore_event(BlockstoreEvent::InvalidBlock(slot))
-                    .await;
+                self.send_blockstore_event(BlockstoreEvent::InvalidBlock(slot));
                 Err(AddShredError::InvalidShred)
             }
             Err(e) => Err(e),
@@ -288,7 +304,7 @@ impl Blockstore for BlockstoreImpl {
             .slot_data_mut(slot)
             .add_shred_from_repair(hash, shred, &mut shredder)?
         {
-            Some(event) => Ok(self.send_blockstore_event(event).await),
+            Some(event) => Ok(self.send_blockstore_event(event)),
             None => Ok(None),
         }
     }
@@ -408,6 +424,49 @@ mod tests {
             Err(AddShredError::Duplicate) => Ok(None),
             Err(e) => Err(e),
         }
+    }
+
+    /// Feeds every shred of a fresh single-slice block into `blockstore` and
+    /// returns the [`BlockInfo`] of the reconstructed block.
+    ///
+    /// Reconstruction makes the blockstore emit `FirstShred` + `Block` events to
+    /// Votor via the (non-blocking) `send_blockstore_event`.
+    async fn store_full_block(blockstore: &mut BlockstoreImpl, sk: &SecretKey) -> BlockInfo {
+        let slot = Slot::genesis().next();
+        let (block_hash, _, shreds) = create_random_shredded_block(slot, 1, sk);
+        let mut reconstructed = None;
+        for shred in shreds.into_iter().flatten() {
+            if let Some(info) = add_shred_ignore_duplicate(blockstore, shred).await.unwrap() {
+                reconstructed = Some(info);
+            }
+        }
+        let info = reconstructed.expect("block should reconstruct from all its shreds");
+        assert_eq!(info.hash, block_hash);
+        info
+    }
+
+    /// A full Votor channel must not panic or block the blockstore: the event is
+    /// dropped on overflow, yet the block is still reconstructed and returned.
+    #[tokio::test]
+    async fn block_event_dropped_when_channel_full() {
+        let sk = SecretKey::new(&mut rand::rng());
+        // Capacity 1, never drained: `FirstShred` fills it, `Block` overflows.
+        let (tx, _rx) = mpsc::channel(1);
+        let mut blockstore = BlockstoreImpl::new(tx);
+
+        store_full_block(&mut blockstore, &sk).await;
+    }
+
+    /// A closed Votor channel (Votor shutting down) must not panic the blockstore;
+    /// the event is dropped and the block is still reconstructed and returned.
+    #[tokio::test]
+    async fn block_event_dropped_when_channel_closed() {
+        let sk = SecretKey::new(&mut rand::rng());
+        let (tx, rx) = mpsc::channel(1000);
+        let mut blockstore = BlockstoreImpl::new(tx);
+        drop(rx);
+
+        store_full_block(&mut blockstore, &sk).await;
     }
 
     #[tokio::test]

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -118,11 +118,8 @@ pub struct BlockstoreImpl {
     block_data: BTreeMap<Slot, SlotBlockData>,
     /// Shredders used for reconstructing blocks.
     shredders: ShredderPool<RegularShredder>,
-    /// Buffer of events to be delivered to Votor, drained via [`Blockstore::take_events`].
-    ///
-    /// Events are buffered here (under whatever lock guards the blockstore) rather
-    /// than sent directly, so the caller can forward them to Votor *after* dropping
-    /// the write lock. See `BlockstoreImpl::emit` for the rationale.
+    /// Events buffered for Votor, drained via [`Blockstore::take_events`].
+    /// See [`Self::emit`] for why they are buffered rather than sent.
     events: Vec<BlockstoreEvent>,
 }
 
@@ -157,15 +154,10 @@ impl BlockstoreImpl {
     /// Records a [`BlockstoreEvent`] in the outbox, returning the [`BlockInfo`] of a
     /// newly reconstructed block iff `event` is a [`BlockstoreEvent::Block`].
     ///
-    /// The event is buffered rather than sent on purpose: the shred-ingest path
-    /// holds the blockstore write lock while adding a shred (see
-    /// [`super::Alpenglow::handle_disseminator_shred`]), so a *blocking* send here
-    /// would let a slow or stalled Votor apply back-pressure that jams every other
-    /// task waiting on that lock. Instead the caller drains the outbox via
-    /// [`Blockstore::take_events`] and forwards it to Votor *after* dropping the
-    /// lock, where a blocking send is safe: it back-pressures the ingest task only,
-    /// never dropping the event. Losing a reconstructed-block event would otherwise
-    /// silently cost this node its vote for that block, with no retry path.
+    /// Events are buffered rather than sent so the caller can forward them off the
+    /// write lock (see [`super::EventForwarder`]). This matters most for the `Block`
+    /// event: dropping it would silently cost this node its vote for that block,
+    /// with no retry path.
     fn emit(&mut self, event: BlockstoreEvent) -> Option<BlockInfo> {
         let block_info = if let BlockstoreEvent::Block { slot, block_info } = &event {
             debug!(

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -9,9 +9,10 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use log::debug;
+use log::{debug, warn};
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::error::TrySendError;
 
 pub use self::slot_block_data::AddShredError;
 use self::slot_block_data::SlotBlockData;
@@ -138,24 +139,40 @@ impl BlockstoreImpl {
         self.block_data = self.block_data.split_off(&slot);
     }
 
-    async fn send_blockstore_event(&self, event: BlockstoreEvent) -> Option<BlockInfo> {
-        let block_info = match &event {
-            BlockstoreEvent::FirstShred(_) | BlockstoreEvent::InvalidBlock(_) => None,
-            BlockstoreEvent::Block { slot, block_info } => {
-                debug!(
-                    "reconstructed block {} in slot {} with parent {} in slot {}",
-                    block_info.hash.short_hex(),
-                    slot,
-                    block_info.parent.1.short_hex(),
-                    block_info.parent.0,
-                );
-                Some(block_info.clone())
-            }
+    /// Forwards a [`BlockstoreEvent`] to Votor, returning the [`BlockInfo`] of a
+    /// newly reconstructed block iff `event` is a [`BlockstoreEvent::Block`].
+    ///
+    /// This uses a non-blocking [`Sender::try_send`] on purpose: the shred-ingest
+    /// path holds the blockstore write lock while adding a shred (see
+    /// [`super::Alpenglow::handle_disseminator_shred`]), so a blocking send would
+    /// let a slow or stalled Votor apply back-pressure that jams every other task
+    /// waiting on that lock. Instead, on overflow (channel full) or a closed
+    /// channel (Votor shutting down) we drop the event with a log message rather
+    /// than panicking. The block itself is still stored and handed to the Pool by
+    /// the caller, so a dropped event only costs this node its own vote for that
+    /// block under extreme back-pressure.
+    fn send_blockstore_event(&self, event: BlockstoreEvent) -> Option<BlockInfo> {
+        let block_info = if let BlockstoreEvent::Block { slot, block_info } = &event {
+            debug!(
+                "reconstructed block {} in slot {} with parent {} in slot {}",
+                block_info.hash.short_hex(),
+                slot,
+                block_info.parent.1.short_hex(),
+                block_info.parent.0,
+            );
+            Some(block_info.clone())
+        } else {
+            None
         };
-        self.votor_channel
-            .send(event)
-            .await
-            .expect("votor should not drop the event receiver");
+        match self.votor_channel.try_send(event) {
+            Ok(()) => {}
+            Err(TrySendError::Full(event)) => {
+                warn!("Votor event channel full, dropping blockstore event: {event:?}");
+            }
+            Err(TrySendError::Closed(event)) => {
+                debug!("Votor event channel closed, dropping blockstore event: {event:?}");
+            }
+        }
         block_info
     }
 
@@ -259,7 +276,7 @@ impl Blockstore for BlockstoreImpl {
             .slot_data_mut(slot)
             .add_shred_from_dissemination(shred, &mut shredder)
         {
-            Ok(Some(event)) => Ok(self.send_blockstore_event(event).await),
+            Ok(Some(event)) => Ok(self.send_blockstore_event(event)),
             Ok(None) => Ok(None),
             Err(err @ (AddShredError::Equivocation | AddShredError::InvalidShred)) => {
                 self.flag_leader_misbehavior(slot).await;
@@ -303,7 +320,7 @@ impl Blockstore for BlockstoreImpl {
             self.flag_leader_misbehavior(slot).await;
         }
         match result? {
-            Some(event) => Ok(self.send_blockstore_event(event).await),
+            Some(event) => Ok(self.send_blockstore_event(event)),
             None => Ok(None),
         }
     }
@@ -325,13 +342,11 @@ impl Blockstore for BlockstoreImpl {
         let slot = shreds[0].payload().header.slot;
         let (first_shred, completed) = self.slot_data_mut(slot).add_own_slice(payload, *shreds);
         if first_shred {
-            self.send_blockstore_event(BlockstoreEvent::FirstShred(slot))
-                .await;
+            self.send_blockstore_event(BlockstoreEvent::FirstShred(slot));
         }
         match completed {
             Some(block_info) => {
                 self.send_blockstore_event(BlockstoreEvent::Block { slot, block_info })
-                    .await
             }
             None => None,
         }
@@ -342,8 +357,7 @@ impl Blockstore for BlockstoreImpl {
     /// Emits [`BlockstoreEvent::InvalidBlock`] the first time the slot is flagged.
     async fn flag_leader_misbehavior(&mut self, slot: Slot) {
         if self.slot_data_mut(slot).mark_leader_misbehaved() {
-            self.send_blockstore_event(BlockstoreEvent::InvalidBlock(slot))
-                .await;
+            self.send_blockstore_event(BlockstoreEvent::InvalidBlock(slot));
         }
     }
 
@@ -484,6 +498,49 @@ mod tests {
         let shreds = RegularShredder::default().shred(&slice, sk).unwrap();
         let (_header, payload) = slice.deconstruct();
         (payload, shreds)
+    }
+
+    /// Feeds every shred of a fresh single-slice block into `blockstore` and
+    /// returns the [`BlockInfo`] of the reconstructed block.
+    ///
+    /// Reconstruction makes the blockstore emit `FirstShred` + `Block` events to
+    /// Votor via the (non-blocking) `send_blockstore_event`.
+    async fn store_full_block(blockstore: &mut BlockstoreImpl, sk: &SecretKey) -> BlockInfo {
+        let slot = Slot::genesis().next();
+        let (block_hash, _, shreds) = create_random_shredded_block(slot, 1, sk);
+        let mut reconstructed = None;
+        for shred in shreds.into_iter().flatten() {
+            if let Some(info) = add_shred_ignore_duplicate(blockstore, shred).await.unwrap() {
+                reconstructed = Some(info);
+            }
+        }
+        let info = reconstructed.expect("block should reconstruct from all its shreds");
+        assert_eq!(info.hash, block_hash);
+        info
+    }
+
+    /// A full Votor channel must not panic or block the blockstore: the event is
+    /// dropped on overflow, yet the block is still reconstructed and returned.
+    #[tokio::test]
+    async fn block_event_dropped_when_channel_full() {
+        let sk = SecretKey::new(&mut rand::rng());
+        // Capacity 1, never drained: `FirstShred` fills it, `Block` overflows.
+        let (tx, _rx) = mpsc::channel(1);
+        let mut blockstore = BlockstoreImpl::new(tx);
+
+        store_full_block(&mut blockstore, &sk).await;
+    }
+
+    /// A closed Votor channel (Votor shutting down) must not panic the blockstore;
+    /// the event is dropped and the block is still reconstructed and returned.
+    #[tokio::test]
+    async fn block_event_dropped_when_channel_closed() {
+        let sk = SecretKey::new(&mut rand::rng());
+        let (tx, rx) = mpsc::channel(1000);
+        let mut blockstore = BlockstoreImpl::new(tx);
+        drop(rx);
+
+        store_full_block(&mut blockstore, &sk).await;
     }
 
     #[tokio::test]

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -86,6 +86,19 @@ pub trait Blockstore {
     /// The caller must forward these to Votor *after* releasing the blockstore
     /// lock, so that a slow Votor back-pressures the ingest task instead of
     /// jamming the lock. See `BlockstoreImpl::emit` for the rationale.
+    ///
+    /// `Vec` carries no `must_use` of its own, so this says it explicitly: silently
+    /// dropping a drained [`BlockstoreEvent::Block`] costs this node its vote for
+    /// that block, with no retry path.
+    ///
+    /// NOTE: scoped to non-test builds because `mockall::automock` copies the
+    /// attribute into the generated mock's `impl` block, where `#[must_use]` on a
+    /// trait method is deprecated. Every caller that matters is non-test code, so
+    /// the guard still covers what it needs to.
+    #[cfg_attr(
+        not(test),
+        must_use = "drained events are lost unless forwarded, see `EventForwarder::forward_blockstore_events`"
+    )]
     fn take_events(&mut self) -> Vec<BlockstoreEvent>;
     #[expect(
         clippy::needless_lifetimes,

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -69,17 +69,31 @@ impl PoolEvent {
     }
 }
 
+/// A single side-effect the Pool buffered while processing under its write lock.
+// PERF: Short-lived outbox entry, moved out on drain; boxing isn't worth the allocation.
+#[expect(clippy::large_enum_variant)]
+#[derive(Clone, Debug)]
+pub enum PoolEffect {
+    /// An event destined for Votor.
+    VotorEvent(PoolEvent),
+    /// A request to repair the given block, destined for the repair loop.
+    Repair(BlockId),
+}
+
 /// Side-effects the Pool produces while processing under its write lock, to be
 /// drained via [`Pool::take_outbox`] and forwarded to Votor and the repair loop
 /// once the lock is released (a blocking send under the lock would jam every task
 /// contending for it).
+///
+/// Effects are kept in the single order the Pool produced them. Splitting them
+/// into a per-destination queue would reorder the two against each other, e.g.
+/// delaying the repair request for a newly certified block behind every Votor
+/// event that certification produced.
 #[derive(Debug, Default)]
-#[must_use = "buffered effects are lost unless forwarded, see `Alpenglow::forward_pool_outbox`"]
+#[must_use = "buffered effects are lost unless forwarded, see `EventForwarder::forward_pool_outbox`"]
 pub struct PoolOutbox {
-    /// Events destined for Votor.
-    pub votor_events: Vec<PoolEvent>,
-    /// Repair requests destined for the repair loop.
-    pub repairs: Vec<BlockId>,
+    /// Buffered effects, in the order the Pool produced them.
+    pub effects: Vec<PoolEffect>,
 }
 
 /// Errors the Pool may return when adding a vote.
@@ -422,7 +436,7 @@ impl PoolImpl {
     /// (see [`super::EventForwarder`]); a blocking send under the lock would jam
     /// every task contending for it.
     fn enqueue_votor_event(&mut self, event: PoolEvent) {
-        self.outbox.votor_events.push(event);
+        self.outbox.effects.push(PoolEffect::VotorEvent(event));
     }
 
     /// Records a repair request for the given block in the outbox.
@@ -430,7 +444,7 @@ impl PoolImpl {
     /// Buffered rather than sent, for the same reason as
     /// [`Self::enqueue_votor_event`].
     fn enqueue_repair(&mut self, block_id: BlockId) {
-        self.outbox.repairs.push(block_id);
+        self.outbox.effects.push(PoolEffect::Repair(block_id));
     }
 }
 
@@ -560,10 +574,15 @@ impl Pool for PoolImpl {
     /// them as a [`PoolOutbox`] holding a single [`PoolEvent::Standstill`] for the
     /// caller to forward to Votor. Should be called after not seeing any progress
     /// for the standstill duration.
+    ///
+    /// NOTE: The bundle may legitimately come out empty. A node that has not
+    /// finalized anything yet has no final cert for the genesis slot, which is
+    /// exactly the case for a node that booted into a partition or started ahead
+    /// of the rest of the cluster. That is a standstill worth reporting, not an
+    /// invariant violation, so the recovery path must not assume a final cert.
     fn recover_from_standstill(&self) -> PoolOutbox {
         let slot = self.finalized_slot();
         let mut certs = self.get_final_certs(slot);
-        assert!(!certs.is_empty(), "no final cert");
         certs.extend(self.get_certs(slot.next()..));
         let votes = self.get_own_votes(slot.next()..);
 
@@ -583,8 +602,7 @@ impl Pool for PoolImpl {
 
         // return to the caller for (off-lock) forwarding to Votor
         PoolOutbox {
-            votor_events: vec![event],
-            ..Default::default()
+            effects: vec![PoolEffect::VotorEvent(event)],
         }
     }
 
@@ -695,15 +713,17 @@ mod tests {
         ///
         /// [`EventForwarder`]: crate::consensus::EventForwarder
         fn forward(&mut self, outbox: PoolOutbox) {
-            for event in outbox.votor_events {
-                self.votor_tx
-                    .try_send(event)
-                    .expect("test votor channel should have capacity");
-            }
-            for block in outbox.repairs {
-                self.repair_tx
-                    .try_send(block)
-                    .expect("test repair channel should have capacity");
+            for effect in outbox.effects {
+                match effect {
+                    PoolEffect::VotorEvent(event) => self
+                        .votor_tx
+                        .try_send(event)
+                        .expect("test votor channel should have capacity"),
+                    PoolEffect::Repair(block) => self
+                        .repair_tx
+                        .try_send(block)
+                        .expect("test repair channel should have capacity"),
+                }
             }
         }
 
@@ -839,16 +859,16 @@ mod tests {
 
         let outbox = ctx.pool.take_outbox();
         assert!(
-            outbox
-                .votor_events
-                .iter()
-                .any(|e| matches!(e, PoolEvent::CertCreated(Cert::Notar(_)))),
+            outbox.effects.iter().any(|e| matches!(
+                e,
+                PoolEffect::VotorEvent(PoolEvent::CertCreated(Cert::Notar(_)))
+            )),
             "expected a CertCreated event, got {:?}",
-            outbox.votor_events
+            outbox.effects
         );
         // Draining leaves the outbox empty.
         let drained = ctx.pool.take_outbox();
-        assert!(drained.votor_events.is_empty() && drained.repairs.is_empty());
+        assert!(drained.effects.is_empty());
     }
 
     #[tokio::test]
@@ -1378,6 +1398,27 @@ mod tests {
 
         // `gap_slot` is propagated as a ready parent exactly once
         assert_eq!(ctx.pool.parents_ready(next_start).iter().count(), 1);
+    }
+
+    /// A node that has not finalized anything yet has no final cert for the
+    /// genesis slot. Standstill recovery must still produce a bundle (an empty one)
+    /// rather than panic — booting into a partition, or ahead of the rest of the
+    /// cluster, is exactly when recovery needs to run.
+    #[tokio::test]
+    async fn standstill_recovery_without_any_final_cert() {
+        let mut ctx = setup();
+
+        assert_eq!(ctx.pool.finalized_slot(), Slot::genesis());
+        let outbox = ctx.pool.recover_from_standstill();
+        ctx.forward(outbox);
+
+        let event = ctx.votor_rx.recv().await.unwrap();
+        let PoolEvent::Standstill(slot, certs, votes) = event else {
+            unreachable!("unexpected event {event:?}");
+        };
+        assert_eq!(slot, Slot::genesis().next());
+        assert!(certs.is_empty());
+        assert!(votes.is_empty());
     }
 
     #[tokio::test]

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -19,8 +19,6 @@ use async_trait::async_trait;
 use either::Either;
 use log::{debug, info, trace, warn};
 use thiserror::Error;
-use tokio::sync::mpsc::Sender;
-use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{RwLock, oneshot};
 
 use self::finality_tracker::FinalityTracker;
@@ -71,6 +69,21 @@ impl PoolEvent {
     }
 }
 
+/// Side-effects the Pool produces while processing under its write lock, to be
+/// drained via [`Pool::take_outbox`] and forwarded once the lock is released.
+///
+/// The Pool buffers these here instead of sending them under the lock: a blocking
+/// send would let a slow Votor or repair loop jam every task contending for the
+/// Pool lock, while a non-blocking send would have to drop events. See
+/// `PoolImpl::enqueue_votor_event` for the rationale.
+#[derive(Debug, Default)]
+pub struct PoolOutbox {
+    /// Events destined for Votor.
+    pub votor_events: Vec<PoolEvent>,
+    /// Repair requests destined for the repair loop.
+    pub repairs: Vec<BlockId>,
+}
+
 /// Errors the Pool may return when adding a vote.
 ///
 /// Signature and signer validity are checked up front by [`ValidatedVote`],
@@ -119,7 +132,13 @@ pub trait Pool {
     async fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError>;
     async fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError>;
     async fn add_block(&mut self, block_id: BlockId, parent_id: BlockId);
-    async fn recover_from_standstill(&self);
+    /// Builds the standstill-recovery bundle to re-broadcast; see [`PoolImpl::recover_from_standstill`].
+    fn recover_from_standstill(&self) -> PoolOutbox;
+    /// Drains and returns the side-effects buffered since the last call.
+    ///
+    /// The caller must forward these to Votor and the repair loop *after* releasing
+    /// the Pool lock; see `PoolImpl::enqueue_votor_event`.
+    fn take_outbox(&mut self) -> PoolOutbox;
     fn finalized_slot(&self) -> Slot;
     fn parents_ready(&self, slot: Slot) -> &[BlockId];
     fn wait_for_parent_ready(&mut self, slot: Slot) -> Either<BlockId, oneshot::Receiver<BlockId>>;
@@ -145,29 +164,26 @@ pub struct PoolImpl {
 
     /// Information about all active validators.
     epoch_info: Arc<ValidatorEpochInfo>,
-    /// Channel for sending events related to voting logic to Votor.
-    votor_event_channel: Sender<PoolEvent>,
-    /// Channel for sending repair requests to the repair loop.
-    repair_channel: Sender<BlockId>,
+    /// Buffered side-effects (Votor events + repair requests) produced under the
+    /// write lock, drained by the caller via [`Pool::take_outbox`].
+    outbox: PoolOutbox,
 }
 
 impl PoolImpl {
     /// Creates a new empty pool containing no votes or certificates.
     ///
-    /// Any later emitted events will be sent on provided `votor_event_channel`.
-    pub fn new(
-        epoch_info: Arc<ValidatorEpochInfo>,
-        votor_event_channel: Sender<PoolEvent>,
-        repair_channel: Sender<BlockId>,
-    ) -> Self {
+    /// Any events the pool emits are buffered in its [`PoolOutbox`] and must be
+    /// drained by the caller via [`Pool::take_outbox`], then forwarded to Votor and
+    /// the repair loop after the write lock is released; see
+    /// `PoolImpl::enqueue_votor_event`.
+    pub fn new(epoch_info: Arc<ValidatorEpochInfo>) -> Self {
         Self {
             slot_states: BTreeMap::new(),
             parent_ready_tracker: ParentReadyTracker::default(),
             finality_tracker: FinalityTracker::default(),
             s2n_waiting_parent_cert: BTreeMap::new(),
             epoch_info,
-            votor_event_channel,
-            repair_channel,
+            outbox: PoolOutbox::default(),
         }
     }
 
@@ -210,8 +226,8 @@ impl PoolImpl {
                         .notify_parent_certified(child_hash)
                 {
                     match output {
-                        Either::Left(event) => self.send_votor_event(event),
-                        Either::Right((slot, hash)) => self.request_repair((slot, hash)),
+                        Either::Left(event) => self.enqueue_votor_event(event),
+                        Either::Right((slot, hash)) => self.enqueue_repair((slot, hash)),
                     }
                 }
 
@@ -220,7 +236,7 @@ impl PoolImpl {
                 self.send_parent_ready_events(new_parents_ready);
 
                 // repair this block, if necessary
-                self.request_repair((slot, block_hash));
+                self.enqueue_repair((slot, block_hash));
             }
             Cert::Skip(_) => {
                 warn!("skipped slot {slot}");
@@ -242,7 +258,7 @@ impl PoolImpl {
 
         // send to votor for broadcasting
         let event = PoolEvent::CertCreated(cert);
-        self.send_votor_event(event);
+        self.enqueue_votor_event(event);
     }
 
     /// Mutably accesses the [`SlotState`] for the given `slot`.
@@ -395,49 +411,32 @@ impl PoolImpl {
         self.prune();
     }
 
-    fn send_parent_ready_events(&self, parents: impl IntoIterator<Item = (Slot, BlockId)>) {
+    fn send_parent_ready_events(&mut self, parents: impl IntoIterator<Item = (Slot, BlockId)>) {
         for (slot, parent) in parents {
             debug_assert!(slot.is_start_of_window());
-            self.send_votor_event(PoolEvent::ParentReady { slot, parent });
+            self.enqueue_votor_event(PoolEvent::ParentReady { slot, parent });
         }
     }
 
-    /// Forwards an event to Votor, returning without blocking.
+    /// Records an event for Votor in the outbox.
     ///
-    /// This uses a non-blocking [`Sender::try_send`] on purpose: the vote/cert
-    /// ingest path holds the Pool write lock while adding to the pool (see
-    /// [`super::Alpenglow::handle_all2all_message`]), so a blocking send would let
-    /// a slow or stalled Votor apply back-pressure that jams every other task
-    /// waiting on that lock. On overflow (channel full) or a closed channel (Votor
-    /// shutting down) the event is dropped with a log message rather than panicking.
-    fn send_votor_event(&self, event: PoolEvent) {
-        match self.votor_event_channel.try_send(event) {
-            Ok(()) => {}
-            Err(TrySendError::Full(event)) => {
-                warn!("Votor event channel full, dropping pool event: {event:?}");
-            }
-            Err(TrySendError::Closed(event)) => {
-                debug!("Votor event channel closed, dropping pool event: {event:?}");
-            }
-        }
+    /// The event is buffered rather than sent on purpose: the vote/cert ingest path
+    /// holds the Pool write lock while adding to the pool (see
+    /// [`super::Alpenglow::handle_all2all_message`]), so a *blocking* send under the
+    /// lock would let a slow or stalled Votor jam every other task waiting on that
+    /// lock. The caller drains the outbox via [`Pool::take_outbox`] and forwards it
+    /// to Votor *after* dropping the lock, where a blocking send is safe: it
+    /// back-pressures the ingest task rather than dropping the event.
+    fn enqueue_votor_event(&mut self, event: PoolEvent) {
+        self.outbox.votor_events.push(event);
     }
 
-    /// Requests a repair of the given block, returning without blocking.
+    /// Records a repair request for the given block in the outbox.
     ///
-    /// Like [`Self::send_votor_event`], this uses a non-blocking
-    /// [`Sender::try_send`] so the Pool write lock is never held waiting on the
-    /// repair loop. On overflow or a closed channel the request is dropped with a
-    /// log message; the block can still be repaired later via standstill recovery.
-    fn request_repair(&self, block_id: BlockId) {
-        match self.repair_channel.try_send(block_id) {
-            Ok(()) => {}
-            Err(TrySendError::Full(block_id)) => {
-                warn!("repair channel full, dropping repair request for {block_id:?}");
-            }
-            Err(TrySendError::Closed(block_id)) => {
-                debug!("repair channel closed, dropping repair request for {block_id:?}");
-            }
-        }
+    /// Buffered rather than sent, for the same reason as
+    /// [`Self::enqueue_votor_event`].
+    fn enqueue_repair(&mut self, block_id: BlockId) {
+        self.outbox.repairs.push(block_id);
     }
 }
 
@@ -520,10 +519,10 @@ impl Pool for PoolImpl {
             self.add_valid_cert(cert).await;
         }
         for event in votor_events {
-            self.send_votor_event(event);
+            self.enqueue_votor_event(event);
         }
         for (slot, block_hash) in blocks_to_repair {
-            self.request_repair((slot, block_hash));
+            self.enqueue_repair((slot, block_hash));
         }
         Ok(())
     }
@@ -553,8 +552,8 @@ impl Pool for PoolImpl {
                 .notify_parent_certified(block_hash.clone())
         {
             match output {
-                Either::Left(event) => self.send_votor_event(event),
-                Either::Right((slot, hash)) => self.request_repair((slot, hash)),
+                Either::Left(event) => self.enqueue_votor_event(event),
+                Either::Right((slot, hash)) => self.enqueue_repair((slot, hash)),
             }
             return;
         }
@@ -563,10 +562,11 @@ impl Pool for PoolImpl {
 
     /// Triggers a recovery from a standstill.
     ///
-    /// Determines which certificates and votes need to be re-broadcast.
-    /// Emits the corresponding [`PoolEvent::Standstill`] event for Votor.
-    /// Should be called after not seeing any progress for the standstill duration.
-    async fn recover_from_standstill(&self) {
+    /// Determines which certificates and votes need to be re-broadcast and returns
+    /// them as a [`PoolOutbox`] holding a single [`PoolEvent::Standstill`] for the
+    /// caller to forward to Votor. Should be called after not seeing any progress
+    /// for the standstill duration.
+    fn recover_from_standstill(&self) -> PoolOutbox {
         let slot = self.finalized_slot();
         let mut certs = self.get_final_certs(slot);
         assert!(!certs.is_empty(), "no final cert");
@@ -587,8 +587,15 @@ impl Pool for PoolImpl {
         // otherwise drop a bundle that Pool emitted precisely because it is stuck.
         let event = PoolEvent::Standstill(slot.next(), certs, votes);
 
-        // send to votor for broadcasting
-        self.send_votor_event(event);
+        // return to the caller for (off-lock) forwarding to Votor
+        PoolOutbox {
+            votor_events: vec![event],
+            repairs: Vec::new(),
+        }
+    }
+
+    fn take_outbox(&mut self) -> PoolOutbox {
+        std::mem::take(&mut self.outbox)
     }
 
     /// Gives the currently highest finalized (fast or slow) slot.
@@ -660,7 +667,9 @@ mod tests {
         sks: Vec<SecretKey>,
         epoch_info: Arc<ValidatorEpochInfo>,
         pool: PoolImpl,
+        votor_tx: mpsc::Sender<PoolEvent>,
         votor_rx: mpsc::Receiver<PoolEvent>,
+        repair_tx: mpsc::Sender<BlockId>,
         _repair_rx: mpsc::Receiver<BlockId>,
     }
 
@@ -669,12 +678,14 @@ mod tests {
         let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
-        let pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
+        let pool = PoolImpl::new(epoch_info.clone());
         TestContext {
             sks,
             epoch_info,
             pool,
+            votor_tx,
             votor_rx,
+            repair_tx,
             _repair_rx,
         }
     }
@@ -685,12 +696,37 @@ mod tests {
             self.epoch_info.epoch_info().validators()
         }
 
+        /// Forwards the given pool outbox into the test channels, mirroring what
+        /// [`EventForwarder`] does in production after releasing the write lock.
+        ///
+        /// [`EventForwarder`]: crate::consensus::EventForwarder
+        fn forward(&mut self, outbox: PoolOutbox) {
+            for event in outbox.votor_events {
+                self.votor_tx
+                    .try_send(event)
+                    .expect("test votor channel should have capacity");
+            }
+            for block in outbox.repairs {
+                self.repair_tx
+                    .try_send(block)
+                    .expect("test repair channel should have capacity");
+            }
+        }
+
+        /// Drains the pool's outbox into the test channels.
+        fn forward_outbox(&mut self) {
+            let outbox = self.pool.take_outbox();
+            self.forward(outbox);
+        }
+
         /// Verifies `vote` into a [`ValidatedVote`] and adds it to the pool.
         async fn add_vote(&mut self, vote: Vote) -> Result<(), AddVoteError> {
             // NOTE: signature-rejection is covered by the [`ValidatedVote`] tests
             let vote = ValidatedVote::try_new(vote, self.epoch_info.epoch_info())
                 .expect("test vote should pass verification");
-            self.pool.add_vote(vote).await
+            let res = self.pool.add_vote(vote).await;
+            self.forward_outbox();
+            res
         }
 
         /// Verifies `cert` into a [`ValidatedCert`] and adds it to the pool.
@@ -698,7 +734,9 @@ mod tests {
             // NOTE: certificate rejection is covered by the [`ValidatedCert`] tests
             let cert = ValidatedCert::try_new(cert, self.epoch_info.epoch_info())
                 .expect("test cert should pass verification");
-            self.pool.add_cert(cert).await
+            let res = self.pool.add_cert(cert).await;
+            self.forward_outbox();
+            res
         }
 
         /// Adds a notarization [`Vote`] for `hash` in `slot` from each of `validators` to the pool.
@@ -788,49 +826,35 @@ mod tests {
         }
     }
 
-    /// Notarizes a block in slot 0, which makes the Pool emit a `CertCreated`
-    /// event to Votor via the (non-blocking) `send_votor_event`.
-    async fn notarize_genesis(
-        pool: &mut PoolImpl,
-        sks: &[SecretKey],
-        epoch_info: &ValidatorEpochInfo,
-    ) {
+    /// Notarizing a block must record a `CertCreated` event in the pool's outbox
+    /// (rather than sending it under the lock), so the caller can forward it to
+    /// Votor losslessly after releasing the write lock.
+    #[tokio::test]
+    async fn cert_created_event_is_recorded() {
+        let mut ctx = setup();
+
+        // Notarize genesis directly on the pool, bypassing the test helpers so the
+        // outbox is not drained before we can inspect it.
         for v in (0..11).map(ValidatorIndex::new) {
-            let vote = Vote::new_notar(Slot::new(0), GENESIS_BLOCK_HASH, &sks[v.as_usize()], v);
-            let vote = ValidatedVote::try_new(vote, epoch_info.epoch_info())
+            let vote = Vote::new_notar(Slot::new(0), GENESIS_BLOCK_HASH, &ctx.sks[v.as_usize()], v);
+            let vote = ValidatedVote::try_new(vote, ctx.epoch_info.epoch_info())
                 .expect("test vote should pass verification");
-            assert_eq!(pool.add_vote(vote).await, Ok(()));
+            ctx.pool.add_vote(vote).await.unwrap();
         }
-        assert!(pool.has_notar_cert(Slot::new(0)));
-    }
+        assert!(ctx.pool.has_notar_cert(Slot::new(0)));
 
-    /// A full Votor channel must not panic or block the Pool: `send_votor_event`
-    /// uses a non-blocking `try_send` and drops the event on overflow.
-    #[tokio::test]
-    async fn votor_event_dropped_when_channel_full() {
-        let (sks, epoch_info) = generate_validators(11);
-        let epoch_info = wrap_epoch_info(epoch_info);
-        // Capacity 1, never drained: the first event fills it, the rest overflow.
-        let (votor_tx, _votor_rx) = mpsc::channel(1);
-        let (repair_tx, _repair_rx) = mpsc::channel(1);
-        let mut pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
-
-        notarize_genesis(&mut pool, &sks, &epoch_info).await;
-    }
-
-    /// A closed Votor channel (Votor shutting down) must not panic the Pool;
-    /// `send_votor_event` drops the event on `TrySendError::Closed`.
-    #[tokio::test]
-    async fn votor_event_dropped_when_channel_closed() {
-        let (sks, epoch_info) = generate_validators(11);
-        let epoch_info = wrap_epoch_info(epoch_info);
-        let (votor_tx, votor_rx) = mpsc::channel(1024);
-        let (repair_tx, repair_rx) = mpsc::channel(1024);
-        let mut pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
-        drop(votor_rx);
-        drop(repair_rx);
-
-        notarize_genesis(&mut pool, &sks, &epoch_info).await;
+        let outbox = ctx.pool.take_outbox();
+        assert!(
+            outbox
+                .votor_events
+                .iter()
+                .any(|e| matches!(e, PoolEvent::CertCreated(Cert::Notar(_)))),
+            "expected a CertCreated event, got {:?}",
+            outbox.votor_events
+        );
+        // Draining leaves the outbox empty.
+        let drained = ctx.pool.take_outbox();
+        assert!(drained.votor_events.is_empty() && drained.repairs.is_empty());
     }
 
     #[tokio::test]
@@ -1381,7 +1405,8 @@ mod tests {
         ctx.add_notar_votes(slot3, &hash3, 0..1).await;
 
         // initiate standstill
-        ctx.pool.recover_from_standstill().await;
+        let outbox = ctx.pool.recover_from_standstill();
+        ctx.forward(outbox);
 
         // wait for standstill event
         let (slot, certs, votes) = loop {
@@ -1448,6 +1473,7 @@ mod tests {
         // add its ancestors
         ctx.pool.add_block(block2.clone(), block1.clone()).await;
         ctx.pool.add_block(block1.clone(), block0.clone()).await;
+        ctx.forward_outbox();
 
         // should emit ParentReady as a result
         let Ok(event) = ctx.votor_rx.try_recv() else {

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -19,6 +19,7 @@ use either::Either;
 use log::{debug, info, trace, warn};
 use thiserror::Error;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{RwLock, oneshot};
 
 use self::finality_tracker::FinalityTracker;
@@ -208,22 +209,22 @@ impl PoolImpl {
                         .notify_parent_certified(child_hash)
                 {
                     match output {
-                        Either::Left(event) => self.send_votor_event(event).await,
-                        Either::Right((slot, hash)) => self.send_repair((slot, hash)).await,
+                        Either::Left(event) => self.send_votor_event(event),
+                        Either::Right((slot, hash)) => self.request_repair((slot, hash)),
                     }
                 }
 
                 // add block to parent-ready tracker, send any new parents to Votor.
                 let new_parents_ready = self.parent_ready_tracker.mark_notar_fallback(&block_id);
-                self.send_parent_ready_events(new_parents_ready).await;
+                self.send_parent_ready_events(new_parents_ready);
 
                 // repair this block, if necessary
-                self.send_repair((slot, block_hash)).await;
+                self.request_repair((slot, block_hash));
             }
             Cert::Skip(_) => {
                 warn!("skipped slot {slot}");
                 let new_parents_ready = self.parent_ready_tracker.mark_skipped(slot);
-                self.send_parent_ready_events(new_parents_ready).await;
+                self.send_parent_ready_events(new_parents_ready);
             }
             Cert::FastFinal(ff_cert) => {
                 info!("fast finalized slot {slot}");
@@ -240,7 +241,7 @@ impl PoolImpl {
 
         // send to votor for broadcasting
         let event = PoolEvent::CertCreated(Box::new(cert));
-        self.send_votor_event(event).await;
+        self.send_votor_event(event);
     }
 
     /// Mutably accesses the [`SlotState`] for the given `slot`.
@@ -389,32 +390,53 @@ impl PoolImpl {
 
     async fn handle_finalization(&mut self, event: FinalizationEvent) {
         let new_parents_ready = self.parent_ready_tracker.handle_finalization(event);
-        self.send_parent_ready_events(new_parents_ready).await;
+        self.send_parent_ready_events(new_parents_ready);
         self.prune();
     }
 
-    async fn send_parent_ready_events(&self, parents: impl IntoIterator<Item = (Slot, BlockId)>) {
+    fn send_parent_ready_events(&self, parents: impl IntoIterator<Item = (Slot, BlockId)>) {
         for (slot, parent) in parents {
             debug_assert!(slot.is_start_of_window());
-            self.send_votor_event(PoolEvent::ParentReady { slot, parent })
-                .await;
+            self.send_votor_event(PoolEvent::ParentReady { slot, parent });
         }
     }
 
-    /// Sends an event to Votor, panicking if Votor dropped the receiver.
-    async fn send_votor_event(&self, event: PoolEvent) {
-        self.votor_event_channel
-            .send(event)
-            .await
-            .expect("votor should not drop the event receiver");
+    /// Forwards an event to Votor, returning without blocking.
+    ///
+    /// This uses a non-blocking [`Sender::try_send`] on purpose: the vote/cert
+    /// ingest path holds the Pool write lock while adding to the pool (see
+    /// [`super::Alpenglow::handle_all2all_message`]), so a blocking send would let
+    /// a slow or stalled Votor apply back-pressure that jams every other task
+    /// waiting on that lock. On overflow (channel full) or a closed channel (Votor
+    /// shutting down) the event is dropped with a log message rather than panicking.
+    fn send_votor_event(&self, event: PoolEvent) {
+        match self.votor_event_channel.try_send(event) {
+            Ok(()) => {}
+            Err(TrySendError::Full(event)) => {
+                warn!("Votor event channel full, dropping pool event: {event:?}");
+            }
+            Err(TrySendError::Closed(event)) => {
+                debug!("Votor event channel closed, dropping pool event: {event:?}");
+            }
+        }
     }
 
-    /// Requests repair of the given block, panicking if the repair loop dropped the receiver.
-    async fn send_repair(&self, block: BlockId) {
-        self.repair_channel
-            .send(block)
-            .await
-            .expect("repair loop should not drop the receiver");
+    /// Requests a repair of the given block, returning without blocking.
+    ///
+    /// Like [`Self::send_votor_event`], this uses a non-blocking
+    /// [`Sender::try_send`] so the Pool write lock is never held waiting on the
+    /// repair loop. On overflow or a closed channel the request is dropped with a
+    /// log message; the block can still be repaired later via standstill recovery.
+    fn request_repair(&self, block_id: BlockId) {
+        match self.repair_channel.try_send(block_id) {
+            Ok(()) => {}
+            Err(TrySendError::Full(block_id)) => {
+                warn!("repair channel full, dropping repair request for {block_id:?}");
+            }
+            Err(TrySendError::Closed(block_id)) => {
+                debug!("repair channel closed, dropping repair request for {block_id:?}");
+            }
+        }
     }
 }
 
@@ -500,10 +522,10 @@ impl Pool for PoolImpl {
             self.add_valid_cert(cert).await;
         }
         for event in votor_events {
-            self.send_votor_event(event).await;
+            self.send_votor_event(event);
         }
         for (slot, block_hash) in blocks_to_repair {
-            self.send_repair((slot, block_hash)).await;
+            self.request_repair((slot, block_hash));
         }
         Ok(())
     }
@@ -523,7 +545,7 @@ impl Pool for PoolImpl {
         let new_parents_ready = self
             .parent_ready_tracker
             .handle_finalization(finalization_event);
-        self.send_parent_ready_events(new_parents_ready).await;
+        self.send_parent_ready_events(new_parents_ready);
 
         self.slot_state(*slot)
             .notify_parent_known(block_hash.clone());
@@ -534,8 +556,8 @@ impl Pool for PoolImpl {
                 .notify_parent_certified(block_hash.clone())
         {
             match output {
-                Either::Left(event) => self.send_votor_event(event).await,
-                Either::Right((slot, hash)) => self.send_repair((slot, hash)).await,
+                Either::Left(event) => self.send_votor_event(event),
+                Either::Right((slot, hash)) => self.request_repair((slot, hash)),
             }
             return;
         }
@@ -569,7 +591,7 @@ impl Pool for PoolImpl {
         let event = PoolEvent::Standstill(slot.next(), certs, votes);
 
         // send to votor for broadcasting
-        self.send_votor_event(event).await;
+        self.send_votor_event(event);
     }
 
     /// Gives the currently highest finalized (fast or slow) slot.
@@ -685,6 +707,45 @@ mod tests {
                 FastFinalCert::try_new(&votes, self.epoch_info.epoch_info().validators()).unwrap();
             assert_eq!(self.pool.add_cert(Cert::FastFinal(ff_cert)).await, Ok(()));
         }
+    }
+
+    /// Notarizes a block in slot 0, which makes the Pool emit a `CertCreated`
+    /// event to Votor via the (non-blocking) `send_votor_event`.
+    async fn notarize_genesis(pool: &mut PoolImpl, sks: &[SecretKey]) {
+        for v in (0..11).map(ValidatorIndex::new) {
+            let vote = Vote::new_notar(Slot::new(0), GENESIS_BLOCK_HASH, &sks[v.as_usize()], v);
+            assert_eq!(pool.add_vote(vote).await, Ok(()));
+        }
+        assert!(pool.has_notar_cert(Slot::new(0)));
+    }
+
+    /// A full Votor channel must not panic or block the Pool: `send_votor_event`
+    /// uses a non-blocking `try_send` and drops the event on overflow.
+    #[tokio::test]
+    async fn votor_event_dropped_when_channel_full() {
+        let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
+        // Capacity 1, never drained: the first event fills it, the rest overflow.
+        let (votor_tx, _votor_rx) = mpsc::channel(1);
+        let (repair_tx, _repair_rx) = mpsc::channel(1);
+        let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
+
+        notarize_genesis(&mut pool, &sks).await;
+    }
+
+    /// A closed Votor channel (Votor shutting down) must not panic the Pool;
+    /// `send_votor_event` drops the event on `TrySendError::Closed`.
+    #[tokio::test]
+    async fn votor_event_dropped_when_channel_closed() {
+        let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
+        let (votor_tx, votor_rx) = mpsc::channel(1024);
+        let (repair_tx, repair_rx) = mpsc::channel(1024);
+        let mut pool = PoolImpl::new(epoch_info, votor_tx, repair_tx);
+        drop(votor_rx);
+        drop(repair_rx);
+
+        notarize_genesis(&mut pool, &sks).await;
     }
 
     #[tokio::test]

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -74,6 +74,7 @@ impl PoolEvent {
 /// once the lock is released (a blocking send under the lock would jam every task
 /// contending for it).
 #[derive(Debug, Default)]
+#[must_use = "buffered effects are lost unless forwarded, see `Alpenglow::forward_pool_outbox`"]
 pub struct PoolOutbox {
     /// Events destined for Votor.
     pub votor_events: Vec<PoolEvent>,

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -20,6 +20,7 @@ use either::Either;
 use log::{debug, info, trace, warn};
 use thiserror::Error;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{RwLock, oneshot};
 
 use self::finality_tracker::FinalityTracker;
@@ -209,22 +210,22 @@ impl PoolImpl {
                         .notify_parent_certified(child_hash)
                 {
                     match output {
-                        Either::Left(event) => self.send_votor_event(event).await,
-                        Either::Right((slot, hash)) => self.send_repair((slot, hash)).await,
+                        Either::Left(event) => self.send_votor_event(event),
+                        Either::Right((slot, hash)) => self.request_repair((slot, hash)),
                     }
                 }
 
                 // add block to parent-ready tracker, send any new parents to Votor.
                 let new_parents_ready = self.parent_ready_tracker.mark_notar_fallback(&block_id);
-                self.send_parent_ready_events(new_parents_ready).await;
+                self.send_parent_ready_events(new_parents_ready);
 
                 // repair this block, if necessary
-                self.send_repair((slot, block_hash)).await;
+                self.request_repair((slot, block_hash));
             }
             Cert::Skip(_) => {
                 warn!("skipped slot {slot}");
                 let new_parents_ready = self.parent_ready_tracker.mark_skipped(slot);
-                self.send_parent_ready_events(new_parents_ready).await;
+                self.send_parent_ready_events(new_parents_ready);
             }
             Cert::FastFinal(ff_cert) => {
                 info!("fast finalized slot {slot}");
@@ -241,7 +242,7 @@ impl PoolImpl {
 
         // send to votor for broadcasting
         let event = PoolEvent::CertCreated(cert);
-        self.send_votor_event(event).await;
+        self.send_votor_event(event);
     }
 
     /// Mutably accesses the [`SlotState`] for the given `slot`.
@@ -390,32 +391,53 @@ impl PoolImpl {
 
     async fn handle_finalization(&mut self, event: FinalizationEvent) {
         let new_parents_ready = self.parent_ready_tracker.handle_finalization(event);
-        self.send_parent_ready_events(new_parents_ready).await;
+        self.send_parent_ready_events(new_parents_ready);
         self.prune();
     }
 
-    async fn send_parent_ready_events(&self, parents: impl IntoIterator<Item = (Slot, BlockId)>) {
+    fn send_parent_ready_events(&self, parents: impl IntoIterator<Item = (Slot, BlockId)>) {
         for (slot, parent) in parents {
             debug_assert!(slot.is_start_of_window());
-            self.send_votor_event(PoolEvent::ParentReady { slot, parent })
-                .await;
+            self.send_votor_event(PoolEvent::ParentReady { slot, parent });
         }
     }
 
-    /// Sends an event to Votor, panicking if Votor dropped the receiver.
-    async fn send_votor_event(&self, event: PoolEvent) {
-        self.votor_event_channel
-            .send(event)
-            .await
-            .expect("votor should not drop the event receiver");
+    /// Forwards an event to Votor, returning without blocking.
+    ///
+    /// This uses a non-blocking [`Sender::try_send`] on purpose: the vote/cert
+    /// ingest path holds the Pool write lock while adding to the pool (see
+    /// [`super::Alpenglow::handle_all2all_message`]), so a blocking send would let
+    /// a slow or stalled Votor apply back-pressure that jams every other task
+    /// waiting on that lock. On overflow (channel full) or a closed channel (Votor
+    /// shutting down) the event is dropped with a log message rather than panicking.
+    fn send_votor_event(&self, event: PoolEvent) {
+        match self.votor_event_channel.try_send(event) {
+            Ok(()) => {}
+            Err(TrySendError::Full(event)) => {
+                warn!("Votor event channel full, dropping pool event: {event:?}");
+            }
+            Err(TrySendError::Closed(event)) => {
+                debug!("Votor event channel closed, dropping pool event: {event:?}");
+            }
+        }
     }
 
-    /// Requests repair of the given block, panicking if the repair loop dropped the receiver.
-    async fn send_repair(&self, block: BlockId) {
-        self.repair_channel
-            .send(block)
-            .await
-            .expect("repair loop should not drop the receiver");
+    /// Requests a repair of the given block, returning without blocking.
+    ///
+    /// Like [`Self::send_votor_event`], this uses a non-blocking
+    /// [`Sender::try_send`] so the Pool write lock is never held waiting on the
+    /// repair loop. On overflow or a closed channel the request is dropped with a
+    /// log message; the block can still be repaired later via standstill recovery.
+    fn request_repair(&self, block_id: BlockId) {
+        match self.repair_channel.try_send(block_id) {
+            Ok(()) => {}
+            Err(TrySendError::Full(block_id)) => {
+                warn!("repair channel full, dropping repair request for {block_id:?}");
+            }
+            Err(TrySendError::Closed(block_id)) => {
+                debug!("repair channel closed, dropping repair request for {block_id:?}");
+            }
+        }
     }
 }
 
@@ -498,10 +520,10 @@ impl Pool for PoolImpl {
             self.add_valid_cert(cert).await;
         }
         for event in votor_events {
-            self.send_votor_event(event).await;
+            self.send_votor_event(event);
         }
         for (slot, block_hash) in blocks_to_repair {
-            self.send_repair((slot, block_hash)).await;
+            self.request_repair((slot, block_hash));
         }
         Ok(())
     }
@@ -521,7 +543,7 @@ impl Pool for PoolImpl {
         let new_parents_ready = self
             .parent_ready_tracker
             .handle_finalization(finalization_event);
-        self.send_parent_ready_events(new_parents_ready).await;
+        self.send_parent_ready_events(new_parents_ready);
 
         self.slot_state(*slot).notify_parent_known(block_hash);
         if let Some(parent_state) = self.slot_states.get(parent_slot)
@@ -531,8 +553,8 @@ impl Pool for PoolImpl {
                 .notify_parent_certified(block_hash.clone())
         {
             match output {
-                Either::Left(event) => self.send_votor_event(event).await,
-                Either::Right((slot, hash)) => self.send_repair((slot, hash)).await,
+                Either::Left(event) => self.send_votor_event(event),
+                Either::Right((slot, hash)) => self.request_repair((slot, hash)),
             }
             return;
         }
@@ -566,7 +588,7 @@ impl Pool for PoolImpl {
         let event = PoolEvent::Standstill(slot.next(), certs, votes);
 
         // send to votor for broadcasting
-        self.send_votor_event(event).await;
+        self.send_votor_event(event);
     }
 
     /// Gives the currently highest finalized (fast or slow) slot.
@@ -764,6 +786,51 @@ mod tests {
             }
             seen
         }
+    }
+
+    /// Notarizes a block in slot 0, which makes the Pool emit a `CertCreated`
+    /// event to Votor via the (non-blocking) `send_votor_event`.
+    async fn notarize_genesis(
+        pool: &mut PoolImpl,
+        sks: &[SecretKey],
+        epoch_info: &ValidatorEpochInfo,
+    ) {
+        for v in (0..11).map(ValidatorIndex::new) {
+            let vote = Vote::new_notar(Slot::new(0), GENESIS_BLOCK_HASH, &sks[v.as_usize()], v);
+            let vote = ValidatedVote::try_new(vote, epoch_info.epoch_info())
+                .expect("test vote should pass verification");
+            assert_eq!(pool.add_vote(vote).await, Ok(()));
+        }
+        assert!(pool.has_notar_cert(Slot::new(0)));
+    }
+
+    /// A full Votor channel must not panic or block the Pool: `send_votor_event`
+    /// uses a non-blocking `try_send` and drops the event on overflow.
+    #[tokio::test]
+    async fn votor_event_dropped_when_channel_full() {
+        let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
+        // Capacity 1, never drained: the first event fills it, the rest overflow.
+        let (votor_tx, _votor_rx) = mpsc::channel(1);
+        let (repair_tx, _repair_rx) = mpsc::channel(1);
+        let mut pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
+
+        notarize_genesis(&mut pool, &sks, &epoch_info).await;
+    }
+
+    /// A closed Votor channel (Votor shutting down) must not panic the Pool;
+    /// `send_votor_event` drops the event on `TrySendError::Closed`.
+    #[tokio::test]
+    async fn votor_event_dropped_when_channel_closed() {
+        let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
+        let (votor_tx, votor_rx) = mpsc::channel(1024);
+        let (repair_tx, repair_rx) = mpsc::channel(1024);
+        let mut pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
+        drop(votor_rx);
+        drop(repair_rx);
+
+        notarize_genesis(&mut pool, &sks, &epoch_info).await;
     }
 
     #[tokio::test]

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -70,12 +70,9 @@ impl PoolEvent {
 }
 
 /// Side-effects the Pool produces while processing under its write lock, to be
-/// drained via [`Pool::take_outbox`] and forwarded once the lock is released.
-///
-/// The Pool buffers these here instead of sending them under the lock: a blocking
-/// send would let a slow Votor or repair loop jam every task contending for the
-/// Pool lock, while a non-blocking send would have to drop events. See
-/// `PoolImpl::enqueue_votor_event` for the rationale.
+/// drained via [`Pool::take_outbox`] and forwarded to Votor and the repair loop
+/// once the lock is released (a blocking send under the lock would jam every task
+/// contending for it).
 #[derive(Debug, Default)]
 pub struct PoolOutbox {
     /// Events destined for Votor.
@@ -420,13 +417,9 @@ impl PoolImpl {
 
     /// Records an event for Votor in the outbox.
     ///
-    /// The event is buffered rather than sent on purpose: the vote/cert ingest path
-    /// holds the Pool write lock while adding to the pool (see
-    /// [`super::Alpenglow::handle_all2all_message`]), so a *blocking* send under the
-    /// lock would let a slow or stalled Votor jam every other task waiting on that
-    /// lock. The caller drains the outbox via [`Pool::take_outbox`] and forwards it
-    /// to Votor *after* dropping the lock, where a blocking send is safe: it
-    /// back-pressures the ingest task rather than dropping the event.
+    /// Buffered rather than sent so the caller can forward it off the write lock
+    /// (see [`super::EventForwarder`]); a blocking send under the lock would jam
+    /// every task contending for it.
     fn enqueue_votor_event(&mut self, event: PoolEvent) {
         self.outbox.votor_events.push(event);
     }
@@ -590,7 +583,7 @@ impl Pool for PoolImpl {
         // return to the caller for (off-lock) forwarding to Votor
         PoolOutbox {
             votor_events: vec![event],
-            repairs: Vec::new(),
+            ..Default::default()
         }
     }
 

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -89,11 +89,47 @@ pub enum PoolEffect {
 /// into a per-destination queue would reorder the two against each other, e.g.
 /// delaying the repair request for a newly certified block behind every Votor
 /// event that certification produced.
+/// The effects are deliberately not reachable as a field: the [`must_use`] above
+/// only fires on an unused [`PoolOutbox`], so a public field would let a caller
+/// take the effects and drop them without the compiler noticing. Consuming the
+/// outbox via [`IntoIterator`] is the only way to get at them.
+///
+/// [`must_use`]: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute
 #[derive(Debug, Default)]
 #[must_use = "buffered effects are lost unless forwarded, see `EventForwarder::forward_pool_outbox`"]
 pub struct PoolOutbox {
     /// Buffered effects, in the order the Pool produced them.
-    pub effects: Vec<PoolEffect>,
+    effects: Vec<PoolEffect>,
+}
+
+impl PoolOutbox {
+    /// Returns `true` iff no effects are buffered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.effects.is_empty()
+    }
+
+    /// Buffers a single effect, preserving production order.
+    fn push(&mut self, effect: PoolEffect) {
+        self.effects.push(effect);
+    }
+}
+
+impl FromIterator<PoolEffect> for PoolOutbox {
+    fn from_iter<I: IntoIterator<Item = PoolEffect>>(iter: I) -> Self {
+        Self {
+            effects: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl IntoIterator for PoolOutbox {
+    type Item = PoolEffect;
+    type IntoIter = std::vec::IntoIter<PoolEffect>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.effects.into_iter()
+    }
 }
 
 /// Errors the Pool may return when adding a vote.
@@ -436,7 +472,7 @@ impl PoolImpl {
     /// (see [`super::EventForwarder`]); a blocking send under the lock would jam
     /// every task contending for it.
     fn enqueue_votor_event(&mut self, event: PoolEvent) {
-        self.outbox.effects.push(PoolEffect::VotorEvent(event));
+        self.outbox.push(PoolEffect::VotorEvent(event));
     }
 
     /// Records a repair request for the given block in the outbox.
@@ -444,7 +480,7 @@ impl PoolImpl {
     /// Buffered rather than sent, for the same reason as
     /// [`Self::enqueue_votor_event`].
     fn enqueue_repair(&mut self, block_id: BlockId) {
-        self.outbox.effects.push(PoolEffect::Repair(block_id));
+        self.outbox.push(PoolEffect::Repair(block_id));
     }
 }
 
@@ -601,9 +637,7 @@ impl Pool for PoolImpl {
         let event = PoolEvent::Standstill(slot.next(), certs, votes);
 
         // return to the caller for (off-lock) forwarding to Votor
-        PoolOutbox {
-            effects: vec![PoolEffect::VotorEvent(event)],
-        }
+        [PoolEffect::VotorEvent(event)].into_iter().collect()
     }
 
     fn take_outbox(&mut self) -> PoolOutbox {
@@ -713,7 +747,7 @@ mod tests {
         ///
         /// [`EventForwarder`]: crate::consensus::EventForwarder
         fn forward(&mut self, outbox: PoolOutbox) {
-            for effect in outbox.effects {
+            for effect in outbox {
                 match effect {
                     PoolEffect::VotorEvent(event) => self
                         .votor_tx
@@ -857,18 +891,16 @@ mod tests {
         }
         assert!(ctx.pool.has_notar_cert(Slot::new(0)));
 
-        let outbox = ctx.pool.take_outbox();
+        let effects: Vec<_> = ctx.pool.take_outbox().into_iter().collect();
         assert!(
-            outbox.effects.iter().any(|e| matches!(
+            effects.iter().any(|e| matches!(
                 e,
                 PoolEffect::VotorEvent(PoolEvent::CertCreated(Cert::Notar(_)))
             )),
-            "expected a CertCreated event, got {:?}",
-            outbox.effects
+            "expected a CertCreated event, got {effects:?}"
         );
         // Draining leaves the outbox empty.
-        let drained = ctx.pool.take_outbox();
-        assert!(drained.effects.is_empty());
+        assert!(ctx.pool.take_outbox().is_empty());
     }
 
     #[tokio::test]

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -193,24 +193,24 @@ impl<A: All2All> Votor<A> {
                 debug!("voted notar-fallback in slot {slot}");
                 let vote =
                     Vote::new_notar_fallback(slot, hash, &self.voting_key, self.validator_index);
-                self.broadcast(vote.into()).await;
+                self.broadcast(vote).await;
                 self.try_skip_window(slot).await;
                 self.state_mut(slot).bad_window = true;
             }
             PoolEvent::SafeToSkip(slot) => {
                 debug!("voted skip-fallback in slot {slot}");
                 let vote = Vote::new_skip_fallback(slot, &self.voting_key, self.validator_index);
-                self.broadcast(vote.into()).await;
+                self.broadcast(vote).await;
                 self.try_skip_window(slot).await;
                 self.state_mut(slot).bad_window = true;
             }
             PoolEvent::CertCreated(cert) => self.handle_cert_created(cert).await,
             PoolEvent::Standstill(_, certs, votes) => {
                 for cert in certs {
-                    self.broadcast(cert.into()).await;
+                    self.broadcast(cert).await;
                 }
                 for vote in votes {
-                    self.broadcast(vote.into()).await;
+                    self.broadcast(vote).await;
                 }
             }
         }
@@ -238,17 +238,25 @@ impl<A: All2All> Votor<A> {
             }
             _ => {}
         }
-        self.broadcast(ConsensusMessage::from(*cert)).await;
+        self.broadcast(*cert).await;
     }
 
-    /// Broadcasts a consensus message to all validators.
+    /// Broadcasts a consensus message to all other nodes on a best-effort basis.
     ///
-    /// Panics on I/O failure: broadcasting votes and certs is liveness-critical.
-    async fn broadcast(&self, msg: ConsensusMessage) {
-        self.all2all
-            .broadcast(&msg)
-            .await
-            .expect("vote/cert broadcast is liveness-critical; a network failure here is fatal");
+    /// A failure of the underlying [`All2All`] network is logged and otherwise
+    /// ignored. Broadcasts are best-effort by contract, and a transient network
+    /// error must not bring down the voting loop, which has to keep running to
+    /// preserve liveness. A dropped vote/cert is re-broadcast later via standstill
+    /// recovery, so a one-off failure self-heals.
+    ///
+    /// NOTE: a *persistent* failure here (e.g. a misconfigured firewall or a full
+    /// partition) means this node silently stops contributing to consensus while
+    /// only logging. Once there is a metrics system, this should also bump a
+    /// failure counter so persistent failures become alertable.
+    async fn broadcast(&self, msg: impl Into<ConsensusMessage>) {
+        if let Err(err) = self.all2all.broadcast(&msg.into()).await {
+            warn!("failed to broadcast consensus message: {err}");
+        }
     }
 
     async fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
@@ -366,7 +374,7 @@ impl<A: All2All> Votor<A> {
         }
         debug!("voted notar for slot {slot}");
         let vote = Vote::new_notar(slot, hash.clone(), &self.voting_key, self.validator_index);
-        self.broadcast(vote.into()).await;
+        self.broadcast(vote).await;
         let state = self.state_mut(slot);
         state.voted = true;
         state.voted_notar = Some(hash.clone());
@@ -384,7 +392,7 @@ impl<A: All2All> Votor<A> {
         let not_bad = !state.is_some_and(|s| s.bad_window);
         if notarized && voted_notar && not_bad {
             let vote = Vote::new_final(slot, &self.voting_key, self.validator_index);
-            self.broadcast(vote.into()).await;
+            self.broadcast(vote).await;
             self.state_mut(slot).retired = true;
         }
     }
@@ -401,7 +409,7 @@ impl<A: All2All> Votor<A> {
             state.voted = true;
             state.bad_window = true;
             let vote = Vote::new_skip(s, &self.voting_key, self.validator_index);
-            self.broadcast(vote.into()).await;
+            self.broadcast(vote).await;
             debug!("voted skip for slot {s}");
         }
     }
@@ -473,6 +481,7 @@ struct SlotState {
 mod tests {
     use std::time::Duration;
 
+    use async_trait::async_trait;
     use tokio::sync::mpsc;
 
     use super::*;
@@ -487,6 +496,21 @@ mod tests {
     use crate::types::SLOTS_PER_WINDOW;
 
     type A2A = TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>;
+
+    /// An [`All2All`] whose `broadcast` always fails, to exercise Votor's
+    /// best-effort error handling. `receive` never resolves.
+    struct FailingAll2All;
+
+    #[async_trait]
+    impl All2All for FailingAll2All {
+        async fn broadcast(&self, _msg: &ConsensusMessage) -> std::io::Result<()> {
+            Err(std::io::Error::other("simulated broadcast failure"))
+        }
+
+        async fn receive(&self) -> std::io::Result<ConsensusMessage> {
+            std::future::pending().await
+        }
+    }
 
     struct TestContext {
         other_a2a: A2A,
@@ -560,6 +584,31 @@ mod tests {
             votor.voting_loop().await;
         });
         ctx
+    }
+
+    /// A failing network broadcast must be logged and swallowed, never panic the
+    /// voting loop (which has to keep running to preserve liveness).
+    #[tokio::test]
+    async fn broadcast_failure_does_not_panic() {
+        let (sks, _epoch_info) = generate_validators(2);
+        let (_pool_tx, pool_rx) = mpsc::channel(100);
+        let (_blockstore_tx, blockstore_rx) = mpsc::channel(100);
+        let mut votor = Votor::new(
+            ValidatorIndex::new(0),
+            sks[0].clone(),
+            pool_rx,
+            blockstore_rx,
+            Arc::new(FailingAll2All),
+        );
+
+        // `SafeToSkip` makes Votor broadcast a skip-fallback vote (and, via
+        // `try_skip_window`, skip votes for the window). All broadcasts fail here;
+        // the handler must still return normally rather than unwrap a network error.
+        // Use a non-genesis slot: the genesis slot starts out retired and would be
+        // ignored before any broadcast.
+        votor
+            .handle_pool_event(PoolEvent::SafeToSkip(Slot::new(1)))
+            .await;
     }
 
     #[tokio::test]

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -12,7 +12,7 @@
 //!
 //! Votor has access to an instance of [`All2All`] for broadcasting votes.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::Arc;
 
 use log::{debug, trace, warn};
@@ -55,7 +55,13 @@ pub struct Votor<A: All2All> {
     timeout_sender: Sender<VotorTimeout>,
     /// [`All2All`] instance used to broadcast votes.
     all2all: Arc<A>,
+    /// Messages whose broadcast failed, awaiting retry (oldest first).
+    pending_broadcasts: VecDeque<ConsensusMessage>,
 }
+
+/// Upper bound on [`Votor::pending_broadcasts`], so a network that stays down
+/// cannot grow the buffer without limit.
+const MAX_PENDING_BROADCASTS: usize = 256;
 
 impl<A: All2All> Votor<A> {
     /// Creates a new Votor instance with empty state.
@@ -96,6 +102,7 @@ impl<A: All2All> Votor<A> {
             timeout_receiver,
             timeout_sender,
             all2all,
+            pending_broadcasts: VecDeque::new(),
         };
         votor.set_timeouts(Slot::new(0));
         votor
@@ -113,6 +120,9 @@ impl<A: All2All> Votor<A> {
                 Some(event) = self.timeout_receiver.recv() => self.handle_timeout_event(event).await,
                 else => break,
             }
+            // A node whose sends are failing keeps receiving from the rest of the
+            // network, so every event handled here doubles as a retry opportunity.
+            self.retry_pending_broadcasts().await;
         }
     }
 
@@ -244,21 +254,48 @@ impl<A: All2All> Votor<A> {
         self.broadcast(cert).await;
     }
 
-    /// Broadcasts a consensus message to all other nodes on a best-effort basis.
+    /// Broadcasts a consensus message to all other nodes.
     ///
-    /// A failure of the underlying [`All2All`] network is logged and otherwise
-    /// ignored. Broadcasts are best-effort by contract, and a transient network
-    /// error must not bring down the voting loop, which has to keep running to
-    /// preserve liveness. A dropped vote/cert is re-broadcast later via standstill
-    /// recovery, so a one-off failure self-heals.
+    /// A failure of the underlying [`All2All`] network must not bring down the
+    /// voting loop, which has to keep running to preserve liveness. The message is
+    /// therefore buffered for retry (see [`Self::retry_pending_broadcasts`]) rather
+    /// than propagated or dropped.
     ///
-    /// NOTE: a *persistent* failure here (e.g. a misconfigured firewall or a full
-    /// partition) means this node silently stops contributing to consensus while
-    /// only logging. Once there is a metrics system, this should also bump a
-    /// failure counter so persistent failures become alertable.
-    async fn broadcast(&self, msg: impl Into<ConsensusMessage>) {
-        if let Err(err) = self.all2all.broadcast(&msg.into()).await {
-            warn!("failed to broadcast consensus message: {err}");
+    /// Dropping it is not an option: the callers commit the state transition the
+    /// vote represents (`voted`, `retired`) as soon as this returns, so there is no
+    /// later attempt. Standstill recovery cannot stand in either — it re-broadcasts
+    /// what Pool has, and this node's own votes only reach its Pool by coming back
+    /// over [`All2All`], which is exactly what failed here.
+    ///
+    /// NOTE: a *persistent* failure (e.g. a misconfigured firewall or a full
+    /// partition) still means this node stops contributing to consensus while only
+    /// logging. Once there is a metrics system, this should also bump a failure
+    /// counter so persistent failures become alertable.
+    async fn broadcast(&mut self, msg: impl Into<ConsensusMessage>) {
+        let msg = msg.into();
+        if let Err(err) = self.all2all.broadcast(&msg).await {
+            warn!("failed to broadcast consensus message, buffering for retry: {err}");
+            if self.pending_broadcasts.len() == MAX_PENDING_BROADCASTS {
+                // SAFETY: dropping the oldest bounds the buffer; a node this far
+                // behind has lost its window for those votes anyway.
+                self.pending_broadcasts.pop_front();
+            }
+            self.pending_broadcasts.push_back(msg);
+        }
+    }
+
+    /// Retries buffered broadcasts that previously failed, oldest first.
+    ///
+    /// Stops at the first message that fails again, keeping it and everything after
+    /// it buffered, so an unreachable network costs at most one extra send attempt
+    /// per event handled.
+    async fn retry_pending_broadcasts(&mut self) {
+        while let Some(msg) = self.pending_broadcasts.pop_front() {
+            if let Err(err) = self.all2all.broadcast(&msg).await {
+                trace!("buffered broadcast still failing: {err}");
+                self.pending_broadcasts.push_front(msg);
+                return;
+            }
         }
     }
 
@@ -482,6 +519,8 @@ struct SlotState {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
     use tokio::sync::mpsc;
@@ -499,18 +538,41 @@ mod tests {
 
     type A2A = TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>;
 
-    /// An [`All2All`] whose `broadcast` always fails, to exercise Votor's
-    /// best-effort error handling. `receive` never resolves.
-    struct FailingAll2All;
+    /// An [`All2All`] whose `broadcast` fails while `up` is `false`, to exercise
+    /// Votor's error handling. Successful broadcasts are recorded in `sent`.
+    /// `receive` never resolves.
+    #[derive(Default)]
+    struct FlakyAll2All {
+        up: AtomicBool,
+        sent: Mutex<Vec<ConsensusMessage>>,
+    }
 
-    impl All2All for FailingAll2All {
-        async fn broadcast(&self, _msg: &ConsensusMessage) -> std::io::Result<()> {
-            Err(std::io::Error::other("simulated broadcast failure"))
+    impl All2All for FlakyAll2All {
+        async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()> {
+            if !self.up.load(Ordering::Relaxed) {
+                return Err(std::io::Error::other("simulated broadcast failure"));
+            }
+            self.sent.lock().unwrap().push(msg.clone());
+            Ok(())
         }
 
         async fn receive(&self) -> std::io::Result<ConsensusMessage> {
             std::future::pending().await
         }
+    }
+
+    /// Builds a Votor wired to the given [`FlakyAll2All`], with dangling channels.
+    fn votor_with(all2all: Arc<FlakyAll2All>) -> Votor<FlakyAll2All> {
+        let (sks, _epoch_info) = generate_validators(2);
+        let (_pool_tx, pool_rx) = mpsc::channel(100);
+        let (_blockstore_tx, blockstore_rx) = mpsc::channel(100);
+        Votor::new(
+            ValidatorIndex::new(0),
+            sks[0].clone(),
+            pool_rx,
+            blockstore_rx,
+            all2all,
+        )
     }
 
     struct TestContext {
@@ -587,20 +649,11 @@ mod tests {
         ctx
     }
 
-    /// A failing network broadcast must be logged and swallowed, never panic the
+    /// A failing network broadcast must be logged and buffered, never panic the
     /// voting loop (which has to keep running to preserve liveness).
     #[tokio::test]
     async fn broadcast_failure_does_not_panic() {
-        let (sks, _epoch_info) = generate_validators(2);
-        let (_pool_tx, pool_rx) = mpsc::channel(100);
-        let (_blockstore_tx, blockstore_rx) = mpsc::channel(100);
-        let mut votor = Votor::new(
-            ValidatorIndex::new(0),
-            sks[0].clone(),
-            pool_rx,
-            blockstore_rx,
-            Arc::new(FailingAll2All),
-        );
+        let mut votor = votor_with(Arc::new(FlakyAll2All::default()));
 
         // `SafeToSkip` makes Votor broadcast a skip-fallback vote (and, via
         // `try_skip_window`, skip votes for the window). All broadcasts fail here;
@@ -610,6 +663,42 @@ mod tests {
         votor
             .handle_pool_event(PoolEvent::SafeToSkip(Slot::new(1)))
             .await;
+    }
+
+    /// Votes lost to a failing broadcast must be retried once the network comes
+    /// back, not silently dropped: the callers mark the slot voted/retired either
+    /// way, and this node's own votes only reach its own Pool over [`All2All`], so
+    /// nothing else can replay them.
+    #[tokio::test]
+    async fn failed_broadcasts_are_retried_when_network_recovers() {
+        let all2all = Arc::new(FlakyAll2All::default());
+        let mut votor = votor_with(Arc::clone(&all2all));
+
+        votor
+            .handle_pool_event(PoolEvent::SafeToSkip(Slot::new(1)))
+            .await;
+        let buffered = votor.pending_broadcasts.len();
+        assert!(buffered > 0, "failed broadcasts should be buffered");
+        assert!(all2all.sent.lock().unwrap().is_empty());
+
+        all2all.up.store(true, Ordering::Relaxed);
+        votor.retry_pending_broadcasts().await;
+
+        assert!(votor.pending_broadcasts.is_empty());
+        assert_eq!(all2all.sent.lock().unwrap().len(), buffered);
+    }
+
+    /// A network that stays down must not grow the retry buffer without bound.
+    #[tokio::test]
+    async fn pending_broadcast_buffer_is_bounded() {
+        let mut votor = votor_with(Arc::new(FlakyAll2All::default()));
+
+        for slot in 1..=(MAX_PENDING_BROADCASTS as u64 + 10) {
+            let vote = Vote::new_skip(Slot::new(slot), &votor.voting_key, votor.validator_index);
+            votor.broadcast(vote).await;
+        }
+
+        assert_eq!(votor.pending_broadcasts.len(), MAX_PENDING_BROADCASTS);
     }
 
     #[tokio::test]

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -484,7 +484,6 @@ struct SlotState {
 mod tests {
     use std::time::Duration;
 
-    use async_trait::async_trait;
     use tokio::sync::mpsc;
 
     use super::*;
@@ -504,7 +503,6 @@ mod tests {
     /// best-effort error handling. `receive` never resolves.
     struct FailingAll2All;
 
-    #[async_trait]
     impl All2All for FailingAll2All {
         async fn broadcast(&self, _msg: &ConsensusMessage) -> std::io::Result<()> {
             Err(std::io::Error::other("simulated broadcast failure"))

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -195,24 +195,24 @@ impl<A: All2All> Votor<A> {
                 debug!("voted notar-fallback in slot {slot}");
                 let vote =
                     Vote::new_notar_fallback(slot, hash, &self.voting_key, self.validator_index);
-                self.broadcast(vote.into()).await;
+                self.broadcast(vote).await;
                 self.try_skip_window(slot).await;
                 self.state_mut(slot).bad_window = true;
             }
             PoolEvent::SafeToSkip(slot) => {
                 debug!("voted skip-fallback in slot {slot}");
                 let vote = Vote::new_skip_fallback(slot, &self.voting_key, self.validator_index);
-                self.broadcast(vote.into()).await;
+                self.broadcast(vote).await;
                 self.try_skip_window(slot).await;
                 self.state_mut(slot).bad_window = true;
             }
             PoolEvent::CertCreated(cert) => self.handle_cert_created(cert).await,
             PoolEvent::Standstill(_, certs, votes) => {
                 for cert in certs {
-                    self.broadcast(cert.into()).await;
+                    self.broadcast(cert).await;
                 }
                 for vote in votes {
-                    self.broadcast(vote.into()).await;
+                    self.broadcast(vote).await;
                 }
             }
         }
@@ -241,17 +241,25 @@ impl<A: All2All> Votor<A> {
             Cert::Skip(_) | Cert::NotarFallback(_) => {}
         }
 
-        self.broadcast(ConsensusMessage::from(cert)).await;
+        self.broadcast(cert).await;
     }
 
-    /// Broadcasts a consensus message to all validators.
+    /// Broadcasts a consensus message to all other nodes on a best-effort basis.
     ///
-    /// Panics on I/O failure: broadcasting votes and certs is liveness-critical.
-    async fn broadcast(&self, msg: ConsensusMessage) {
-        self.all2all
-            .broadcast(&msg)
-            .await
-            .expect("vote/cert broadcast is liveness-critical; a network failure here is fatal");
+    /// A failure of the underlying [`All2All`] network is logged and otherwise
+    /// ignored. Broadcasts are best-effort by contract, and a transient network
+    /// error must not bring down the voting loop, which has to keep running to
+    /// preserve liveness. A dropped vote/cert is re-broadcast later via standstill
+    /// recovery, so a one-off failure self-heals.
+    ///
+    /// NOTE: a *persistent* failure here (e.g. a misconfigured firewall or a full
+    /// partition) means this node silently stops contributing to consensus while
+    /// only logging. Once there is a metrics system, this should also bump a
+    /// failure counter so persistent failures become alertable.
+    async fn broadcast(&self, msg: impl Into<ConsensusMessage>) {
+        if let Err(err) = self.all2all.broadcast(&msg.into()).await {
+            warn!("failed to broadcast consensus message: {err}");
+        }
     }
 
     async fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
@@ -369,7 +377,7 @@ impl<A: All2All> Votor<A> {
         }
         debug!("voted notar for slot {slot}");
         let vote = Vote::new_notar(slot, hash.clone(), &self.voting_key, self.validator_index);
-        self.broadcast(vote.into()).await;
+        self.broadcast(vote).await;
         let state = self.state_mut(slot);
         state.voted = true;
         state.voted_notar = Some(hash.clone());
@@ -387,7 +395,7 @@ impl<A: All2All> Votor<A> {
         let not_bad = !state.is_some_and(|s| s.bad_window);
         if notarized && voted_notar && not_bad {
             let vote = Vote::new_final(slot, &self.voting_key, self.validator_index);
-            self.broadcast(vote.into()).await;
+            self.broadcast(vote).await;
             self.state_mut(slot).retired = true;
         }
     }
@@ -404,7 +412,7 @@ impl<A: All2All> Votor<A> {
             state.voted = true;
             state.bad_window = true;
             let vote = Vote::new_skip(s, &self.voting_key, self.validator_index);
-            self.broadcast(vote.into()).await;
+            self.broadcast(vote).await;
             debug!("voted skip for slot {s}");
         }
     }
@@ -476,6 +484,7 @@ struct SlotState {
 mod tests {
     use std::time::Duration;
 
+    use async_trait::async_trait;
     use tokio::sync::mpsc;
 
     use super::*;
@@ -490,6 +499,21 @@ mod tests {
     use crate::types::SLOTS_PER_WINDOW;
 
     type A2A = TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>;
+
+    /// An [`All2All`] whose `broadcast` always fails, to exercise Votor's
+    /// best-effort error handling. `receive` never resolves.
+    struct FailingAll2All;
+
+    #[async_trait]
+    impl All2All for FailingAll2All {
+        async fn broadcast(&self, _msg: &ConsensusMessage) -> std::io::Result<()> {
+            Err(std::io::Error::other("simulated broadcast failure"))
+        }
+
+        async fn receive(&self) -> std::io::Result<ConsensusMessage> {
+            std::future::pending().await
+        }
+    }
 
     struct TestContext {
         other_a2a: A2A,
@@ -563,6 +587,31 @@ mod tests {
             votor.voting_loop().await;
         });
         ctx
+    }
+
+    /// A failing network broadcast must be logged and swallowed, never panic the
+    /// voting loop (which has to keep running to preserve liveness).
+    #[tokio::test]
+    async fn broadcast_failure_does_not_panic() {
+        let (sks, _epoch_info) = generate_validators(2);
+        let (_pool_tx, pool_rx) = mpsc::channel(100);
+        let (_blockstore_tx, blockstore_rx) = mpsc::channel(100);
+        let mut votor = Votor::new(
+            ValidatorIndex::new(0),
+            sks[0].clone(),
+            pool_rx,
+            blockstore_rx,
+            Arc::new(FailingAll2All),
+        );
+
+        // `SafeToSkip` makes Votor broadcast a skip-fallback vote (and, via
+        // `try_skip_window`, skip votes for the window). All broadcasts fail here;
+        // the handler must still return normally rather than unwrap a network error.
+        // Use a non-genesis slot: the genesis slot starts out retired and would be
+        // ignored before any broadcast.
+        votor
+            .handle_pool_event(PoolEvent::SafeToSkip(Slot::new(1)))
+            .await;
     }
 
     #[tokio::test]

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -197,14 +197,12 @@ impl<A: All2All> Votor<A> {
                     Vote::new_notar_fallback(slot, hash, &self.voting_key, self.validator_index);
                 self.broadcast(vote).await;
                 self.try_skip_window(slot).await;
-                self.state_mut(slot).bad_window = true;
             }
             PoolEvent::SafeToSkip(slot) => {
                 debug!("voted skip-fallback in slot {slot}");
                 let vote = Vote::new_skip_fallback(slot, &self.voting_key, self.validator_index);
                 self.broadcast(vote).await;
                 self.try_skip_window(slot).await;
-                self.state_mut(slot).bad_window = true;
             }
             PoolEvent::CertCreated(cert) => self.handle_cert_created(cert).await,
             PoolEvent::Standstill(_, certs, votes) => {
@@ -416,16 +414,26 @@ impl<A: All2All> Votor<A> {
     }
 
     /// Sends skip votes for all unvoted slots in the window that `slot` belongs to.
+    ///
+    /// Marks the whole window bad, including slots we already voted on. We only get
+    /// here because the window's leader misbehaved or timed out, and that verdict
+    /// does not depend on how far we happened to get first: a slot notarized before
+    /// we learned of it stays notarized (that vote is already out), but `bad_window`
+    /// stops [`Self::try_final`] from following it with a final vote. Leaving voted
+    /// slots unmarked would instead make this depend on the order blockstore events
+    /// happen to arrive in, which is not guaranteed — they are forwarded off the
+    /// write lock and can be reordered across tasks. Withholding a final vote is
+    /// always safe: it can cost this slot the fast path, never liveness.
     async fn try_skip_window(&mut self, slot: Slot) {
         assert!(slot >= self.first_unpruned_slot());
         trace!("try skip window of slot {slot}");
         for s in slot.slots_in_window() {
-            if self.has_voted(s) {
+            let state = self.state_mut(s);
+            state.bad_window = true;
+            if state.voted {
                 continue;
             }
-            let state = self.state_mut(s);
             state.voted = true;
-            state.bad_window = true;
             let vote = Vote::new_skip(s, &self.voting_key, self.validator_index);
             self.broadcast(vote).await;
             debug!("voted skip for slot {s}");
@@ -674,6 +682,55 @@ mod tests {
             }
             m => panic!("other msg: {m:?}"),
         }
+    }
+
+    /// An `InvalidBlock` handled *after* we already voted notar for the slot must
+    /// still taint the window, so the notar cert that follows produces no final vote.
+    ///
+    /// Blockstore events are forwarded off the write lock and can be reordered
+    /// across tasks, so `Block` beating `InvalidBlock` is expected rather than
+    /// exceptional. The notar vote is already out and cannot be recalled; the final
+    /// vote is what must be withheld. The handlers are driven directly, because the
+    /// ordering under test is precisely what `voting_loop`'s `select!` leaves
+    /// unspecified.
+    #[tokio::test]
+    async fn late_invalid_block_suppresses_final_vote() {
+        let (mut votor, ctx) = build_votor().await;
+        let slot = Slot::genesis().next();
+        let hash: BlockHash = Hash::random_for_test().into();
+
+        // vote notar on the block, before learning the leader misbehaved
+        let block_info = BlockInfo {
+            hash: hash.clone(),
+            parent: genesis_block_id(),
+        };
+        votor
+            .handle_blockstore_event(BlockstoreEvent::Block { slot, block_info })
+            .await;
+        assert_eq!(votor.slots[&slot].voted_notar.as_ref(), Some(&hash));
+
+        // only now does the leader's misbehavior surface
+        votor
+            .handle_blockstore_event(BlockstoreEvent::InvalidBlock(slot))
+            .await;
+        assert!(
+            votor.slots[&slot].bad_window,
+            "an invalid block must taint the window even for an already-voted slot"
+        );
+
+        // with the window untainted this cert would make `try_final` cast a final
+        // vote; `retired` is set only by that broadcast, so it proxies for it
+        let vote = Vote::new_notar(slot, hash, &ctx.sks[0], ValidatorIndex::new(0));
+        let Vote::Notar(notar_vote) = vote else {
+            unreachable!()
+        };
+        let cert = Cert::Notar(NotarCert::new(&[notar_vote], ctx.epoch_info.validators()));
+        votor.handle_pool_event(PoolEvent::CertCreated(cert)).await;
+
+        assert!(
+            !votor.slots[&slot].retired,
+            "cast a final vote for a slot whose leader we proved misbehaving"
+        );
     }
 
     #[tokio::test]

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -12,7 +12,7 @@
 //!
 //! Votor has access to an instance of [`All2All`] for broadcasting votes.
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use log::{debug, trace, warn};
@@ -55,13 +55,7 @@ pub struct Votor<A: All2All> {
     timeout_sender: Sender<VotorTimeout>,
     /// [`All2All`] instance used to broadcast votes.
     all2all: Arc<A>,
-    /// Messages whose broadcast failed, awaiting retry (oldest first).
-    pending_broadcasts: VecDeque<ConsensusMessage>,
 }
-
-/// Upper bound on [`Votor::pending_broadcasts`], so a network that stays down
-/// cannot grow the buffer without limit.
-const MAX_PENDING_BROADCASTS: usize = 256;
 
 impl<A: All2All> Votor<A> {
     /// Creates a new Votor instance with empty state.
@@ -102,7 +96,6 @@ impl<A: All2All> Votor<A> {
             timeout_receiver,
             timeout_sender,
             all2all,
-            pending_broadcasts: VecDeque::new(),
         };
         votor.set_timeouts(Slot::new(0));
         votor
@@ -120,9 +113,6 @@ impl<A: All2All> Votor<A> {
                 Some(event) = self.timeout_receiver.recv() => self.handle_timeout_event(event).await,
                 else => break,
             }
-            // A node whose sends are failing keeps receiving from the rest of the
-            // network, so every event handled here doubles as a retry opportunity.
-            self.retry_pending_broadcasts().await;
         }
     }
 
@@ -254,48 +244,36 @@ impl<A: All2All> Votor<A> {
         self.broadcast(cert).await;
     }
 
-    /// Broadcasts a consensus message to all other nodes.
+    /// Broadcasts a consensus message to all other nodes, best-effort.
     ///
-    /// A failure of the underlying [`All2All`] network must not bring down the
-    /// voting loop, which has to keep running to preserve liveness. The message is
-    /// therefore buffered for retry (see [`Self::retry_pending_broadcasts`]) rather
-    /// than propagated or dropped.
+    /// A failure of the underlying [`All2All`] network is logged and otherwise
+    /// ignored: it must not bring down the voting loop, which has to keep running
+    /// to preserve liveness.
     ///
-    /// Dropping it is not an option: the callers commit the state transition the
-    /// vote represents (`voted`, `retired`) as soon as this returns, so there is no
-    /// later attempt. Standstill recovery cannot stand in either — it re-broadcasts
-    /// what Pool has, and this node's own votes only reach its Pool by coming back
-    /// over [`All2All`], which is exactly what failed here.
+    /// The message is genuinely lost — the callers commit the state transition the
+    /// vote represents (`voted`, `retired`) as soon as this returns, and nothing
+    /// re-sends it. That is deliberate rather than an oversight. [`All2All`] rides
+    /// on UDP, where a successful send only means the datagram reached the kernel,
+    /// so votes are dropped in flight as a matter of course; a vote lost to a local
+    /// send error is no different, protocol-wise, from one lost on the wire, and
+    /// the protocol already covers that case with timeouts, skip votes and
+    /// standstill recovery. Retrying here would buy back only the sliver of losses
+    /// that surface as an errno, at the cost of reordering this node's own votes
+    /// against each other.
     ///
     /// NOTE: a *persistent* failure (e.g. a misconfigured firewall or a full
-    /// partition) still means this node stops contributing to consensus while only
+    /// partition) means this node stops contributing to consensus while only
     /// logging. Once there is a metrics system, this should also bump a failure
     /// counter so persistent failures become alertable.
-    async fn broadcast(&mut self, msg: impl Into<ConsensusMessage>) {
-        let msg = msg.into();
-        if let Err(err) = self.all2all.broadcast(&msg).await {
-            warn!("failed to broadcast consensus message, buffering for retry: {err}");
-            if self.pending_broadcasts.len() == MAX_PENDING_BROADCASTS {
-                // SAFETY: dropping the oldest bounds the buffer; a node this far
-                // behind has lost its window for those votes anyway.
-                self.pending_broadcasts.pop_front();
-            }
-            self.pending_broadcasts.push_back(msg);
-        }
-    }
-
-    /// Retries buffered broadcasts that previously failed, oldest first.
     ///
-    /// Stops at the first message that fails again, keeping it and everything after
-    /// it buffered, so an unreachable network costs at most one extra send attempt
-    /// per event handled.
-    async fn retry_pending_broadcasts(&mut self) {
-        while let Some(msg) = self.pending_broadcasts.pop_front() {
-            if let Err(err) = self.all2all.broadcast(&msg).await {
-                trace!("buffered broadcast still failing: {err}");
-                self.pending_broadcasts.push_front(msg);
-                return;
-            }
+    /// NOTE: this node's own votes reach its own [`super::Pool`] only by coming
+    /// back over [`All2All`] — Votor has no direct path to Pool — so a failure here
+    /// also means [`super::Pool::recover_from_standstill`] cannot replay the vote:
+    /// it re-broadcasts what Pool holds, and Pool never saw it. Removing that
+    /// dependency means delivering own votes to Pool directly, not retrying sends.
+    async fn broadcast(&self, msg: impl Into<ConsensusMessage>) {
+        if let Err(err) = self.all2all.broadcast(&msg.into()).await {
+            warn!("failed to broadcast consensus message: {err}");
         }
     }
 
@@ -519,8 +497,6 @@ struct SlotState {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
-    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
     use tokio::sync::mpsc;
@@ -538,41 +514,18 @@ mod tests {
 
     type A2A = TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>;
 
-    /// An [`All2All`] whose `broadcast` fails while `up` is `false`, to exercise
-    /// Votor's error handling. Successful broadcasts are recorded in `sent`.
-    /// `receive` never resolves.
-    #[derive(Default)]
-    struct FlakyAll2All {
-        up: AtomicBool,
-        sent: Mutex<Vec<ConsensusMessage>>,
-    }
+    /// An [`All2All`] whose `broadcast` always fails, to exercise Votor's
+    /// best-effort error handling. `receive` never resolves.
+    struct FailingAll2All;
 
-    impl All2All for FlakyAll2All {
-        async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()> {
-            if !self.up.load(Ordering::Relaxed) {
-                return Err(std::io::Error::other("simulated broadcast failure"));
-            }
-            self.sent.lock().unwrap().push(msg.clone());
-            Ok(())
+    impl All2All for FailingAll2All {
+        async fn broadcast(&self, _msg: &ConsensusMessage) -> std::io::Result<()> {
+            Err(std::io::Error::other("simulated broadcast failure"))
         }
 
         async fn receive(&self) -> std::io::Result<ConsensusMessage> {
             std::future::pending().await
         }
-    }
-
-    /// Builds a Votor wired to the given [`FlakyAll2All`], with dangling channels.
-    fn votor_with(all2all: Arc<FlakyAll2All>) -> Votor<FlakyAll2All> {
-        let (sks, _epoch_info) = generate_validators(2);
-        let (_pool_tx, pool_rx) = mpsc::channel(100);
-        let (_blockstore_tx, blockstore_rx) = mpsc::channel(100);
-        Votor::new(
-            ValidatorIndex::new(0),
-            sks[0].clone(),
-            pool_rx,
-            blockstore_rx,
-            all2all,
-        )
     }
 
     struct TestContext {
@@ -649,11 +602,20 @@ mod tests {
         ctx
     }
 
-    /// A failing network broadcast must be logged and buffered, never panic the
+    /// A failing network broadcast must be logged and swallowed, never panic the
     /// voting loop (which has to keep running to preserve liveness).
     #[tokio::test]
     async fn broadcast_failure_does_not_panic() {
-        let mut votor = votor_with(Arc::new(FlakyAll2All::default()));
+        let (sks, _epoch_info) = generate_validators(2);
+        let (_pool_tx, pool_rx) = mpsc::channel(100);
+        let (_blockstore_tx, blockstore_rx) = mpsc::channel(100);
+        let mut votor = Votor::new(
+            ValidatorIndex::new(0),
+            sks[0].clone(),
+            pool_rx,
+            blockstore_rx,
+            Arc::new(FailingAll2All),
+        );
 
         // `SafeToSkip` makes Votor broadcast a skip-fallback vote (and, via
         // `try_skip_window`, skip votes for the window). All broadcasts fail here;
@@ -663,42 +625,6 @@ mod tests {
         votor
             .handle_pool_event(PoolEvent::SafeToSkip(Slot::new(1)))
             .await;
-    }
-
-    /// Votes lost to a failing broadcast must be retried once the network comes
-    /// back, not silently dropped: the callers mark the slot voted/retired either
-    /// way, and this node's own votes only reach its own Pool over [`All2All`], so
-    /// nothing else can replay them.
-    #[tokio::test]
-    async fn failed_broadcasts_are_retried_when_network_recovers() {
-        let all2all = Arc::new(FlakyAll2All::default());
-        let mut votor = votor_with(Arc::clone(&all2all));
-
-        votor
-            .handle_pool_event(PoolEvent::SafeToSkip(Slot::new(1)))
-            .await;
-        let buffered = votor.pending_broadcasts.len();
-        assert!(buffered > 0, "failed broadcasts should be buffered");
-        assert!(all2all.sent.lock().unwrap().is_empty());
-
-        all2all.up.store(true, Ordering::Relaxed);
-        votor.retry_pending_broadcasts().await;
-
-        assert!(votor.pending_broadcasts.is_empty());
-        assert_eq!(all2all.sent.lock().unwrap().len(), buffered);
-    }
-
-    /// A network that stays down must not grow the retry buffer without bound.
-    #[tokio::test]
-    async fn pending_broadcast_buffer_is_bounded() {
-        let mut votor = votor_with(Arc::new(FlakyAll2All::default()));
-
-        for slot in 1..=(MAX_PENDING_BROADCASTS as u64 + 10) {
-            let vote = Vote::new_skip(Slot::new(slot), &votor.voting_key, votor.validator_index);
-            votor.broadcast(vote).await;
-        }
-
-        assert_eq!(votor.pending_broadcasts.len(), MAX_PENDING_BROADCASTS);
     }
 
     #[tokio::test]

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 use log::{debug, trace, warn};
 use wincode::{SchemaRead, SchemaWrite};
 
-use crate::consensus::{DELTA, SharedBlockstore, SharedPool, ValidatorEpochInfo};
+use crate::consensus::{DELTA, EventForwarder, SharedBlockstore, SharedPool, ValidatorEpochInfo};
 use crate::crypto::merkle::{DoubleMerkleProof, DoubleMerkleTree, SliceRoot};
 use crate::crypto::{Hash, hash};
 use crate::disseminator::rotor::{SamplingStrategy, StakeWeightedSampler};
@@ -244,6 +244,8 @@ pub struct Repair<N: Network> {
     network: N,
     sampler: StakeWeightedSampler,
     epoch_info: Arc<ValidatorEpochInfo>,
+    /// Forwards blockstore outbox events to Votor off the write lock.
+    event_forwarder: EventForwarder,
 }
 
 impl<N> Repair<N>
@@ -254,11 +256,12 @@ where
     ///
     /// Given `network` will be used for sending repair requests and receiving repair responses.
     /// Any repaired shreds will be written into the provided `blockstore`.
-    pub fn new(
+    pub(crate) fn new(
         blockstore: SharedBlockstore,
         pool: SharedPool,
         network: N,
         epoch_info: Arc<ValidatorEpochInfo>,
+        event_forwarder: EventForwarder,
     ) -> Self {
         let validators = epoch_info.epoch_info().validators().to_vec();
         let sampler = StakeWeightedSampler::new(validators);
@@ -271,6 +274,7 @@ where
             network,
             sampler,
             epoch_info,
+            event_forwarder,
         }
     }
 
@@ -436,20 +440,24 @@ where
                     return;
                 };
 
-                // store shred
-                let res = self
-                    .blockstore
-                    .write()
-                    .await
-                    .add_shred_from_repair(block_hash.clone(), validated)
-                    .await;
+                // store shred, then forward buffered events off the write lock
+                let (res, events) = {
+                    let mut blockstore = self.blockstore.write().await;
+                    let res = blockstore
+                        .add_shred_from_repair(block_hash.clone(), validated)
+                        .await;
+                    (res, blockstore.take_events())
+                };
+                self.event_forwarder.forward_blockstore_events(events).await;
                 if let Ok(Some(block_info)) = res {
                     assert_eq!(block_info.hash, *block_hash);
-                    self.pool
-                        .write()
-                        .await
-                        .add_block((*slot, block_info.hash), block_info.parent)
-                        .await;
+                    let outbox = {
+                        let mut pool = self.pool.write().await;
+                        pool.add_block((*slot, block_info.hash), block_info.parent)
+                            .await;
+                        pool.take_outbox()
+                    };
+                    self.event_forwarder.forward_pool_outbox(outbox).await;
                     debug!(
                         "successfully repaired block {} in slot {}",
                         block_hash.short_hex(),
@@ -554,17 +562,14 @@ mod tests {
 
         // set up blockstore
         let (blockstore_tx, blockstore_rx) = tokio::sync::mpsc::channel(100);
-        let blockstore: SharedBlockstore =
-            Arc::new(RwLock::new(BlockstoreImpl::new(blockstore_tx)));
+        let blockstore: SharedBlockstore = Arc::new(RwLock::new(BlockstoreImpl::new()));
 
         // set up pool
         let (pool_tx, pool_rx) = tokio::sync::mpsc::channel(100);
         let (repair_tx, repair_rx) = tokio::sync::mpsc::channel(100);
-        let pool: SharedPool = Arc::new(RwLock::new(PoolImpl::new(
-            epoch_info.clone(),
-            pool_tx,
-            repair_tx.clone(),
-        )));
+        let pool: SharedPool = Arc::new(RwLock::new(PoolImpl::new(epoch_info.clone())));
+
+        let event_forwarder = EventForwarder::new(blockstore_tx, pool_tx, repair_tx.clone());
 
         // create and start Repair instance
         let mut repair = Repair::new(
@@ -572,6 +577,7 @@ mod tests {
             pool,
             v1_repair_requester_network,
             epoch_info.clone(),
+            event_forwarder,
         );
         tokio::spawn(async move {
             repair.repair_loop(repair_rx).await;

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -18,7 +18,9 @@ use std::time::{Duration, Instant};
 use log::{debug, trace, warn};
 use wincode::{SchemaRead, SchemaWrite};
 
-use crate::consensus::{DELTA, EventForwarder, SharedBlockstore, SharedPool, ValidatorEpochInfo};
+use crate::consensus::{
+    DELTA, EventForwarder, PoolEffect, PoolOutbox, SharedBlockstore, SharedPool, ValidatorEpochInfo,
+};
 use crate::crypto::merkle::{DoubleMerkleProof, DoubleMerkleTree, SliceRoot};
 use crate::crypto::{Hash, hash};
 use crate::disseminator::rotor::{SamplingStrategy, StakeWeightedSampler};
@@ -99,7 +101,7 @@ impl RepairResponse {
 
 /// Handle repair requests from other nodes.
 ///
-/// This is separated from [`Repair`] to handle repair requests and responses on separate sockets and tokio tasks.
+/// This is separated from `Repair` to handle repair requests and responses on separate sockets and tokio tasks.
 /// This allows us to prioritise repairing blocks for ourselves over serving repair requests for other nodes.
 pub struct RepairRequestHandler<N: Network> {
     epoch_info: Arc<ValidatorEpochInfo>,
@@ -234,7 +236,10 @@ where
 ///
 /// This is used by the node to repair blocks that it is missing.
 /// This does not answer repair requests from other nodes, that is handled by [`RepairRequestHandler`].
-pub struct Repair<N: Network> {
+///
+/// Internal to the crate: it is wired up by `Alpenglow::new`, and constructing one
+/// requires an [`EventForwarder`] over that node's internal channels.
+pub(crate) struct Repair<N: Network> {
     blockstore: SharedBlockstore,
     pool: SharedPool,
     slice_roots: BTreeMap<(BlockId, SliceIndex), SliceRoot>,
@@ -282,7 +287,10 @@ where
     ///
     /// Listens to incoming requests for blocks to repair on `self.repair_channel`.
     /// Initiates the corresponding repair process and handles ongoing repairs.
-    pub async fn repair_loop(&mut self, mut repair_receiver: tokio::sync::mpsc::Receiver<BlockId>) {
+    pub(crate) async fn repair_loop(
+        &mut self,
+        mut repair_receiver: tokio::sync::mpsc::Receiver<BlockId>,
+    ) {
         loop {
             let next_timeout = self.request_timeouts.peek().map(|Reverse((t, _))| t);
             let sleep_duration = match next_timeout {
@@ -315,8 +323,27 @@ where
         }
     }
 
+    /// Applies a drained [`PoolOutbox`]: Votor events are forwarded to Votor,
+    /// repair requests are started directly.
+    ///
+    /// NOTE: The repair requests must *not* go back through the repair channel.
+    /// [`Self::repair_loop`] is that channel's only consumer, so a blocking send
+    /// from inside the loop wedges the task for good as soon as the channel fills:
+    /// nothing would be left to drain it. Starting the repair here is what the
+    /// loop would do with the message anyway, minus the channel hop.
+    async fn apply_pool_outbox(&mut self, outbox: PoolOutbox) {
+        for effect in outbox.effects {
+            match effect {
+                PoolEffect::VotorEvent(event) => {
+                    self.event_forwarder.forward_pool_event(event).await;
+                }
+                PoolEffect::Repair(block_id) => self.repair_block(block_id).await,
+            }
+        }
+    }
+
     /// Starts repair process for the block specified by `slot` and `block_hash`.
-    pub async fn repair_block(&mut self, block_id: BlockId) {
+    pub(crate) async fn repair_block(&mut self, block_id: BlockId) {
         let (slot, block_hash) = &block_id;
         if self.blockstore.read().await.get_block(&block_id).is_some() {
             trace!(
@@ -457,7 +484,7 @@ where
                             .await;
                         pool.take_outbox()
                     };
-                    self.event_forwarder.forward_pool_outbox(outbox).await;
+                    self.apply_pool_outbox(outbox).await;
                     debug!(
                         "successfully repaired block {} in slot {}",
                         block_hash.short_hex(),
@@ -510,6 +537,7 @@ mod tests {
 
     use tokio::sync::RwLock;
     use tokio::sync::mpsc::Sender;
+    use tokio_util::sync::CancellationToken;
 
     use super::*;
     use crate::ValidatorIndex;
@@ -569,7 +597,12 @@ mod tests {
         let (repair_tx, repair_rx) = tokio::sync::mpsc::channel(100);
         let pool: SharedPool = Arc::new(RwLock::new(PoolImpl::new(epoch_info.clone())));
 
-        let event_forwarder = EventForwarder::new(blockstore_tx, pool_tx, repair_tx.clone());
+        let event_forwarder = EventForwarder::new(
+            blockstore_tx,
+            pool_tx,
+            repair_tx.clone(),
+            CancellationToken::new(),
+        );
 
         // create and start Repair instance
         let mut repair = Repair::new(

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -450,7 +450,7 @@ where
                 };
                 self.event_forwarder.forward_blockstore_events(events).await;
                 if let Ok(Some(block_info)) = res {
-                    assert_eq!(block_info.hash, *block_hash);
+                    assert_eq!(&block_info.hash, block_hash);
                     let outbox = {
                         let mut pool = self.pool.write().await;
                         pool.add_block((*slot, block_info.hash), block_info.parent)

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -331,11 +331,18 @@ where
     /// from inside the loop wedges the task for good as soon as the channel fills:
     /// nothing would be left to drain it. Starting the repair here is what the
     /// loop would do with the message anyway, minus the channel hop.
+    ///
+    /// Stops at the first undelivered Votor event, matching
+    /// [`EventForwarder::forward_pool_outbox`]: the forwarder only reports failure
+    /// once the node is shutting down, and starting fresh repairs for the remaining
+    /// effects would be work on a node that is on its way out.
     async fn apply_pool_outbox(&mut self, outbox: PoolOutbox) {
-        for effect in outbox.effects {
+        for effect in outbox {
             match effect {
                 PoolEffect::VotorEvent(event) => {
-                    self.event_forwarder.forward_pool_event(event).await;
+                    if !self.event_forwarder.forward_pool_event(event).await {
+                        return;
+                    }
                 }
                 PoolEffect::Repair(block_id) => self.repair_block(block_id).await,
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consensus/repair reliability by buffering generated side-effects and emitting them after related state updates, reducing lock contention and avoiding missed events.
  * Updated vote/certificate propagation to be best-effort: failures are now logged and no longer cause panics, improving stability when receivers close.
* **Tests**
  * Added/updated coverage to ensure forwarding to closed receivers never panics (and safely drops remaining buffered items) and that buffered events are delivered in order when drained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->