### PR TITLE
test: tests for last-slice equivocation

### DIFF
--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -644,4 +644,38 @@ mod tests {
             _ => panic!(),
         }
     }
+
+    fn assert_conflicting_slice_is_equivocation(index: usize, is_last: bool) {
+        let sk = SecretKey::new(&mut rand::rng());
+        let slot = Slot::new(123);
+
+        // declare slice 2 as the block's last slice
+        let base = create_random_block(slot, 3);
+        let mut block_data = BlockData::new(slot);
+        let (_, res) = handle_slice(&mut block_data, base[2].clone(), &sk);
+        res.expect("valid last slice should be accepted");
+        assert_eq!(block_data.last_slice, Some(SliceIndex::new_for_test(2)));
+
+        // construct a conflicting slice with valid payload
+        let mut conflicting = base[1].clone();
+        conflicting.slice_index = SliceIndex::new_for_test(index);
+        conflicting.is_last = is_last;
+        let (_, res) = handle_slice(&mut block_data, conflicting, &sk);
+        assert_eq!(res, Err(AddShredError::Equivocation));
+    }
+
+    #[test]
+    fn second_last_slice_before_declared_last_is_equivocation() {
+        assert_conflicting_slice_is_equivocation(1, true);
+    }
+
+    #[test]
+    fn second_last_slice_after_declared_last_is_equivocation() {
+        assert_conflicting_slice_is_equivocation(3, true);
+    }
+
+    #[test]
+    fn non_last_slice_beyond_declared_last_is_equivocation() {
+        assert_conflicting_slice_is_equivocation(3, false);
+    }
 }

--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -675,6 +675,11 @@ mod tests {
     }
 
     #[test]
+    fn non_last_slice_with_same_index_is_equivocation() {
+        assert_conflicting_slice_is_equivocation(2, false);
+    }
+
+    #[test]
     fn non_last_slice_beyond_declared_last_is_equivocation() {
         assert_conflicting_slice_is_equivocation(3, false);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new test helper to validate equivocation detection when inserting conflicting slices.
  * Added additional test cases covering edge scenarios around the declared “last slice,” including conflicts for slices before/after it and mismatched last/non-last flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->