### PR TITLE
refactor: rename `ReconstrcutedSlice::from_shreds` to `from_parts`

### DIFF
--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -290,7 +290,7 @@ impl BlockData {
         );
         // build the slice from the shreds so the two can't disagree
         let slice =
-            ReconstructedSlice::from_shreds(payload, any_shred, any_shred.slice_root().clone());
+            ReconstructedSlice::from_parts(payload, any_shred, any_shred.slice_root().clone());
         debug_assert_eq!(slice.slot, slot);
         let is_first = self.shreds.is_empty();
 

--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -303,7 +303,7 @@ pub trait Shredder: Default {
         let tree = check_merkle_tree(&raw_shreds, &slice_root)?;
 
         let payload = SlicePayload::try_from(payload_bytes.as_slice())?;
-        let slice = ReconstructedSlice::from_shreds(payload, any_shred, slice_root);
+        let slice = ReconstructedSlice::from_parts(payload, any_shred, slice_root);
 
         // reconstruct missing output shreds (with root, path, sig) in place
         fill_missing_shreds(shreds, header, raw_shreds, &tree, slice_sig);

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -92,7 +92,7 @@ pub struct ReconstructedSlice {
 impl ReconstructedSlice {
     /// Creates a [`ReconstructedSlice`] from its component parts.
     #[must_use]
-    pub(crate) fn from_shreds(
+    pub(crate) fn from_parts(
         payload: SlicePayload,
         any_shred: &ValidatedShred,
         slice_root: SliceRoot,


### PR DESCRIPTION
Closes #552 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slice reconstruction reliability during block processing and shred deshredding.
  * Preserved validation and consistency checks while updating how reconstructed slices are assembled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->