### PR TITLE
perf: avoid slice payload clone when producing block

### DIFF
--- a/benches/disseminator.rs
+++ b/benches/disseminator.rs
@@ -58,7 +58,7 @@ fn turbine_tree(bencher: divan::Bencher) {
             let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
             let mut rng = rand::rng();
             let sk = SecretKey::new(&mut rng);
-            let shreds = RegularShredder::default().shred(slice, &sk).unwrap();
+            let shreds = RegularShredder::default().shred(&slice, &sk).unwrap();
             let shred = shreds[shreds.len() - 1].clone();
 
             (shred, turbine1, turbine2)

--- a/benches/network.rs
+++ b/benches/network.rs
@@ -97,7 +97,7 @@ fn serialize_slice(bencher: divan::Bencher) {
             let mut rng = rand::rng();
             let sk = signature::SecretKey::new(&mut rng);
             RegularShredder::default()
-                .shred(slice, &sk)
+                .shred(&slice, &sk)
                 .unwrap()
                 .into_iter()
                 .map(|v| v.into_shred())
@@ -120,7 +120,7 @@ fn serialize_slice_into(bencher: divan::Bencher) {
             let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
             let sk = signature::SecretKey::new(&mut rng);
             let shreds = RegularShredder::default()
-                .shred(slice, &sk)
+                .shred(&slice, &sk)
                 .unwrap()
                 .into_iter()
                 .map(|v| v.into_shred())
@@ -144,7 +144,7 @@ fn deserialize_slice(bencher: divan::Bencher) {
             let mut rng = rand::rng();
             let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
             let sk = signature::SecretKey::new(&mut rng);
-            let shreds = RegularShredder::default().shred(slice, &sk).unwrap();
+            let shreds = RegularShredder::default().shred(&slice, &sk).unwrap();
             let mut serialized = Vec::new();
             for shred in shreds {
                 let bytes = wincode::serialize(&shred.into_shred()).unwrap();

--- a/benches/shredder.rs
+++ b/benches/shredder.rs
@@ -30,7 +30,7 @@ fn shred<S: Shredder>(bencher: divan::Bencher) {
             (shredder, slice, sk)
         })
         .bench_values(|(mut shredder, slice, sk): (S, Slice, SecretKey)| {
-            let _ = shredder.shred(slice, &sk).unwrap();
+            let _ = shredder.shred(&slice, &sk).unwrap();
         });
 }
 
@@ -45,7 +45,7 @@ fn deshred<S: Shredder>(bencher: divan::Bencher) {
             let mut rng = rand::rng();
             let sk = SecretKey::new(&mut rng);
             let mut shredder = S::default();
-            let mut shreds = shredder.shred(slice, &sk).unwrap().map(Some);
+            let mut shreds = shredder.shred(&slice, &sk).unwrap().map(Some);
             // need at least DATA_SHREDS to reconstruct and want to include as many coding shreds as possible which should be at the end of the array
             // so mark the first TOTAL_SHREDS - DATA_SHREDS as None
             for shred in shreds.iter_mut().take(TOTAL_SHREDS - DATA_SHREDS) {

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -330,18 +330,21 @@ where
         let slot = header.slot;
         let slice_index = header.slice_index;
         let is_last = header.is_last;
-        // Keep the payload so we can hand a ready-made slice to the blockstore,
-        // instead of making it Reed-Solomon-decode our own data back out.
-        let slice = Slice::from_parts(header, payload.clone());
+        // Build the slice by moving the payload in, then shred it by reference.
+        // Shredding only reads the payload, so we can reclaim it afterwards and
+        // hand a ready-made slice to the blockstore, instead of making it
+        // Reed-Solomon-decode our own data back out.
+        let slice = Slice::from_parts(header, payload);
         // Box the shreds so the large array lives on the heap instead of bloating
         // this future across the dissemination and `add_own_slice` awaits below.
         let shreds = Box::new(
             self.shredders
                 .checkout()
                 .expect("pool always has a shredder, block production is sequential")
-                .shred(slice, &self.secret_key)
+                .shred(&slice, &self.secret_key)
                 .expect("shredding of valid slice should never fail"),
         );
+        let (_header, payload) = slice.deconstruct();
 
         // Disseminate every shred. Dissemination is best-effort: a send failure
         // is usually transient (e.g. a full socket buffer), so we try every

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -482,7 +482,7 @@ mod tests {
         sk: &SecretKey,
     ) -> (SlicePayload, [ValidatedShred; TOTAL_SHREDS]) {
         let shreds = RegularShredder::default().shred(&slice, sk).unwrap();
-        let payload = slice.deconstruct().1;
+        let (_header, payload) = slice.deconstruct();
         (payload, shreds)
     }
 

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -481,8 +481,8 @@ mod tests {
         slice: Slice,
         sk: &SecretKey,
     ) -> (SlicePayload, [ValidatedShred; TOTAL_SHREDS]) {
-        let payload = slice.clone().deconstruct().1;
-        let shreds = RegularShredder::default().shred(slice, sk).unwrap();
+        let shreds = RegularShredder::default().shred(&slice, sk).unwrap();
+        let payload = slice.deconstruct().1;
         (payload, shreds)
     }
 
@@ -850,9 +850,7 @@ mod tests {
         let (dissem_tx, _dissem_rx) = mpsc::channel(1000);
         let mut dissem = BlockstoreImpl::new(dissem_tx);
         for slice in &slices {
-            let shreds = RegularShredder::default()
-                .shred(slice.clone(), &sk)
-                .unwrap();
+            let shreds = RegularShredder::default().shred(slice, &sk).unwrap();
             for shred in shreds {
                 add_shred_ignore_duplicate(&mut dissem, shred).await?;
             }

--- a/src/consensus/blockstore/slot_block_data.rs
+++ b/src/consensus/blockstore/slot_block_data.rs
@@ -468,7 +468,7 @@ mod tests {
         sk: &SecretKey,
     ) -> (Vec<BlockstoreEvent>, Result<(), AddShredError>) {
         let mut shredder = RegularShredder::default();
-        let shreds = shredder.shred(slice, sk).unwrap();
+        let shreds = shredder.shred(&slice, sk).unwrap();
         let mut events = vec![];
         for shred in shreds {
             match block_data.add_shred(shred, &mut shredder) {
@@ -501,7 +501,7 @@ mod tests {
         let slices = create_random_block(slot, 1);
         let mut block_data = BlockData::new(slot);
         let mut shredder = RegularShredder::default();
-        let shreds = shredder.shred(slices[0].clone(), &sk).unwrap();
+        let shreds = shredder.shred(&slices[0], &sk).unwrap();
         let mut events = vec![];
         for shred in shreds.into_iter().skip(TOTAL_SHREDS - DATA_SHREDS) {
             if let Some(event) = block_data.add_shred(shred, &mut shredder).unwrap() {

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -249,7 +249,7 @@ mod tests {
     async fn test_rotor_dissemination(count: u64, base_port: u16) {
         let (sks, mut rotors) = create_rotor_instances(count, base_port);
         let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
-        let shreds = RegularShredder::default().shred(slice, &sks[0]).unwrap();
+        let shreds = RegularShredder::default().shred(&slice, &sks[0]).unwrap();
 
         let mut shreds_received = Vec::with_capacity(rotors.len());
         (0..rotors.len()).for_each(|_| shreds_received.push(Arc::new(Mutex::new(HashSet::new()))));

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -102,7 +102,7 @@ mod tests {
     async fn dissemination() {
         let (sks, mut disseminators) = create_disseminator_instances(20, 5000);
         let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
-        let shreds = RegularShredder::default().shred(slice, &sks[0]).unwrap();
+        let shreds = RegularShredder::default().shred(&slice, &sks[0]).unwrap();
 
         let shreds_received = Arc::new(Mutex::new(0_usize));
         let mut tasks = Vec::new();

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -350,7 +350,7 @@ mod tests {
         let (sks, mut validators) = create_validator_info(10);
         let mut disseminators = create_turbine_instances(&mut validators).await;
         let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
-        let shreds = RegularShredder::default().shred(slice, &sks[0]).unwrap();
+        let shreds = RegularShredder::default().shred(&slice, &sks[0]).unwrap();
 
         let shreds_received = Arc::new(Mutex::new(0_usize));
         let mut tasks = Vec::new();

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -182,7 +182,7 @@ mod tests {
                 is_last: slice_index == final_slice_index,
             };
             let slice = Slice::from_parts(header, payload);
-            let slice_shreds = shredder.shred(slice, &sk).unwrap();
+            let slice_shreds = shredder.shred(&slice, &sk).unwrap();
             shreds.extend(slice_shreds);
         }
 
@@ -246,7 +246,7 @@ mod tests {
                 is_last: slice_index == final_slice_index,
             };
             let slice = Slice::from_parts(header, payload);
-            let slice_shreds = shredder.shred(slice, &sk).unwrap();
+            let slice_shreds = shredder.shred(&slice, &sk).unwrap();
             shreds.extend(slice_shreds);
         }
 
@@ -308,7 +308,7 @@ mod tests {
                 is_last: slice_index == final_slice_index,
             };
             let slice = Slice::from_parts(header, payload);
-            let slice_shreds = shredder.shred(slice, &sk).unwrap();
+            let slice_shreds = shredder.shred(&slice, &sk).unwrap();
             shreds.extend(slice_shreds);
         }
 

--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -259,7 +259,7 @@ pub trait Shredder: Default {
     ///   too big, i.e., more than [`Shredder::MAX_DATA_SIZE`] bytes.
     fn shred(
         &mut self,
-        slice: Slice,
+        slice: &Slice,
         sk: &SecretKey,
     ) -> Result<[ValidatedShred; TOTAL_SHREDS], ShredError>;
 
@@ -336,12 +336,15 @@ impl Shredder for RegularShredder {
 
     fn shred(
         &mut self,
-        slice: Slice,
+        slice: &Slice,
         sk: &SecretKey,
     ) -> Result<[ValidatedShred; TOTAL_SHREDS], ShredError> {
-        let (header, payload) = slice.deconstruct();
-        let raw_shreds = self.0.shred(&payload.to_bytes())?;
-        Ok(data_and_coding_to_output_shreds(header, raw_shreds, sk))
+        let raw_shreds = self.0.shred(&slice.payload_bytes())?;
+        Ok(data_and_coding_to_output_shreds(
+            slice.header(),
+            raw_shreds,
+            sk,
+        ))
     }
 
     fn deshred_validated_shreds(
@@ -368,13 +371,16 @@ impl Shredder for CodingOnlyShredder {
 
     fn shred(
         &mut self,
-        slice: Slice,
+        slice: &Slice,
         sk: &SecretKey,
     ) -> Result<[ValidatedShred; TOTAL_SHREDS], ShredError> {
-        let (header, payload) = slice.deconstruct();
-        let mut raw_shreds = self.0.shred(&payload.to_bytes())?;
+        let mut raw_shreds = self.0.shred(&slice.payload_bytes())?;
         raw_shreds.data = vec![];
-        Ok(data_and_coding_to_output_shreds(header, raw_shreds, sk))
+        Ok(data_and_coding_to_output_shreds(
+            slice.header(),
+            raw_shreds,
+            sk,
+        ))
     }
 
     fn deshred_validated_shreds(
@@ -410,11 +416,10 @@ impl Shredder for PetsShredder {
 
     fn shred(
         &mut self,
-        slice: Slice,
+        slice: &Slice,
         sk: &SecretKey,
     ) -> Result<[ValidatedShred; TOTAL_SHREDS], ShredError> {
-        let (header, payload) = slice.deconstruct();
-        let mut payload: Vec<u8> = payload.into();
+        let mut payload = slice.payload_bytes();
 
         let key = cipher::encrypt_with_random_key(&mut payload);
         payload.extend_from_slice(&key);
@@ -423,7 +428,11 @@ impl Shredder for PetsShredder {
         // delete data shred containing key
         raw_shreds.data.pop();
 
-        Ok(data_and_coding_to_output_shreds(header, raw_shreds, sk))
+        Ok(data_and_coding_to_output_shreds(
+            slice.header(),
+            raw_shreds,
+            sk,
+        ))
     }
 
     fn deshred_validated_shreds(
@@ -461,11 +470,10 @@ impl Shredder for AontShredder {
 
     fn shred(
         &mut self,
-        slice: Slice,
+        slice: &Slice,
         sk: &SecretKey,
     ) -> Result<[ValidatedShred; TOTAL_SHREDS], ShredError> {
-        let (header, payload) = slice.deconstruct();
-        let mut payload: Vec<u8> = payload.into();
+        let mut payload = slice.payload_bytes();
 
         let key = cipher::encrypt_with_random_key(&mut payload);
         // append the key XORed with the hash of the ciphertext
@@ -473,7 +481,11 @@ impl Shredder for AontShredder {
         payload.extend(key.iter().zip(hash.as_ref()).map(|(k, h)| k ^ h));
 
         let raw_shreds = self.0.shred(&payload)?;
-        Ok(data_and_coding_to_output_shreds(header, raw_shreds, sk))
+        Ok(data_and_coding_to_output_shreds(
+            slice.header(),
+            raw_shreds,
+            sk,
+        ))
     }
 
     fn deshred_validated_shreds(
@@ -656,7 +668,7 @@ mod tests {
         let mut shredder = S::default();
         let sk = SecretKey::new(&mut rand::rng());
         let slice = create_slice_with_invalid_txs(S::MAX_DATA_SIZE);
-        let shreds = shredder.shred(slice.clone(), &sk)?;
+        let shreds = shredder.shred(&slice, &sk)?;
         assert_eq!(shreds.len(), TOTAL_SHREDS);
 
         // restore from all shreds
@@ -710,7 +722,7 @@ mod tests {
         let mut shredder = RegularShredder::default();
         let sk = SecretKey::new(&mut rand::rng());
         let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
-        let shreds = shredder.shred(slice, &sk)?;
+        let shreds = shredder.shred(&slice, &sk)?;
 
         // restore in place from only the data shreds
         let mut input = into_array(&shreds[..DATA_SHREDS]);
@@ -787,7 +799,7 @@ mod tests {
     fn deshred_rejects_wrong_shred_type_layout() {
         let sk = SecretKey::new(&mut rand::rng());
         let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
-        let shreds = CodingOnlyShredder::default().shred(slice, &sk).unwrap();
+        let shreds = CodingOnlyShredder::default().shred(&slice, &sk).unwrap();
 
         // `CodingOnlyShredder` outputs only coding shreds, but `RegularShredder`
         // expects data shreds in the first `DATA_SHREDS` positions
@@ -825,7 +837,7 @@ mod tests {
         let sk = SecretKey::new(&mut rand::rng());
         // one byte more than fits into this shredder's slice
         let slice = create_slice_with_invalid_txs(S::MAX_DATA_SIZE + 1);
-        let result = S::default().shred(slice, &sk);
+        let result = S::default().shred(&slice, &sk);
         assert_eq!(result.err(), Some(ShredError::TooMuchData));
     }
 

--- a/src/shredder.rs
+++ b/src/shredder.rs
@@ -339,12 +339,9 @@ impl Shredder for RegularShredder {
         slice: &Slice,
         sk: &SecretKey,
     ) -> Result<[ValidatedShred; TOTAL_SHREDS], ShredError> {
+        let header = slice.header();
         let raw_shreds = self.0.shred(&slice.payload_bytes())?;
-        Ok(data_and_coding_to_output_shreds(
-            slice.header(),
-            raw_shreds,
-            sk,
-        ))
+        Ok(data_and_coding_to_output_shreds(header, raw_shreds, sk))
     }
 
     fn deshred_validated_shreds(
@@ -374,13 +371,10 @@ impl Shredder for CodingOnlyShredder {
         slice: &Slice,
         sk: &SecretKey,
     ) -> Result<[ValidatedShred; TOTAL_SHREDS], ShredError> {
+        let header = slice.header();
         let mut raw_shreds = self.0.shred(&slice.payload_bytes())?;
         raw_shreds.data = vec![];
-        Ok(data_and_coding_to_output_shreds(
-            slice.header(),
-            raw_shreds,
-            sk,
-        ))
+        Ok(data_and_coding_to_output_shreds(header, raw_shreds, sk))
     }
 
     fn deshred_validated_shreds(
@@ -419,6 +413,7 @@ impl Shredder for PetsShredder {
         slice: &Slice,
         sk: &SecretKey,
     ) -> Result<[ValidatedShred; TOTAL_SHREDS], ShredError> {
+        let header = slice.header();
         let mut payload = slice.payload_bytes();
 
         let key = cipher::encrypt_with_random_key(&mut payload);
@@ -428,11 +423,7 @@ impl Shredder for PetsShredder {
         // delete data shred containing key
         raw_shreds.data.pop();
 
-        Ok(data_and_coding_to_output_shreds(
-            slice.header(),
-            raw_shreds,
-            sk,
-        ))
+        Ok(data_and_coding_to_output_shreds(header, raw_shreds, sk))
     }
 
     fn deshred_validated_shreds(
@@ -473,6 +464,7 @@ impl Shredder for AontShredder {
         slice: &Slice,
         sk: &SecretKey,
     ) -> Result<[ValidatedShred; TOTAL_SHREDS], ShredError> {
+        let header = slice.header();
         let mut payload = slice.payload_bytes();
 
         let key = cipher::encrypt_with_random_key(&mut payload);
@@ -481,11 +473,7 @@ impl Shredder for AontShredder {
         payload.extend(key.iter().zip(hash.as_ref()).map(|(k, h)| k ^ h));
 
         let raw_shreds = self.0.shred(&payload)?;
-        Ok(data_and_coding_to_output_shreds(
-            slice.header(),
-            raw_shreds,
-            sk,
-        ))
+        Ok(data_and_coding_to_output_shreds(header, raw_shreds, sk))
     }
 
     fn deshred_validated_shreds(

--- a/src/shredder/validated_shred.rs
+++ b/src/shredder/validated_shred.rs
@@ -150,7 +150,7 @@ mod tests {
         let mut shredder = RegularShredder::default();
         let sk = SecretKey::new(&mut rng());
         let slice = create_slice_with_invalid_txs(RegularShredder::MAX_DATA_SIZE);
-        let shreds = shredder.shred(slice, &sk).unwrap();
+        let shreds = shredder.shred(&slice, &sk).unwrap();
         let shred = shreds[shreds.len() - 1].clone().into_shred();
         (shred, sk)
     }

--- a/src/shredder/validated_shreds.rs
+++ b/src/shredder/validated_shreds.rs
@@ -130,16 +130,16 @@ mod tests {
         let slice = create_slice_with_invalid_txs(MAX_DATA_PER_SLICE);
 
         // there are data shreds in coding shred positions in the array
-        let shreds = shredder.shred(slice.clone(), &sk).unwrap().map(Some);
+        let shreds = shredder.shred(&slice, &sk).unwrap().map(Some);
         assert!(ValidatedShreds::try_new(&shreds, 1, TOTAL_SHREDS - 1).is_none());
 
         // there are coding shreds in data shred positions in the array
-        let shreds = shredder.shred(slice, &sk).unwrap().map(Some);
+        let shreds = shredder.shred(&slice, &sk).unwrap().map(Some);
         assert!(ValidatedShreds::try_new(&shreds, TOTAL_SHREDS - 1, 1).is_none());
 
         // mixing shreds of different sizes
         let small_slice = create_slice_with_invalid_txs(100);
-        let small_shreds = shredder.shred(small_slice, &sk).unwrap().map(Some);
+        let small_shreds = shredder.shred(&small_slice, &sk).unwrap().map(Some);
         let mut shreds = shreds;
         shreds[0] = small_shreds[0].clone();
         assert!(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -100,7 +100,7 @@ pub fn create_random_shredded_block(
     for slice in create_random_block(slot, num_slices) {
         shreds.push(
             shredder
-                .shred(slice.clone(), sk)
+                .shred(&slice, sk)
                 .expect("shredding a valid slice cannot fail")
                 .to_vec(),
         );

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -67,16 +67,15 @@ impl Slice {
 
     /// Serializes this slice's payload (its `parent` and `data`) into bytes.
     ///
-    /// Produces exactly the same bytes as [`SlicePayload::to_bytes`] for the
-    /// equivalent payload, but reads straight from the slice's fields so no
-    /// owned [`SlicePayload`] (and hence no copy of `data`) has to be
-    /// materialized first. Used by shredders, which only need the serialized
-    /// payload and never the owned [`Slice`].
+    /// Produces exactly the same bytes as [`SlicePayload::to_bytes`].
+    /// However, it reads straight from the slice's fields without owned [`SlicePayload`].
+    /// Used by shredders, which only need the serialized payload.
     pub(crate) fn payload_bytes(&self) -> Vec<u8> {
-        // A wincode struct is the concatenation of its fields with no framing,
-        // so serializing `parent` then `data` matches `SlicePayload`'s layout.
-        // Guarded by the `payload_bytes_matches_slice_payload` test below.
-        let mut buf = Vec::new();
+        let parent_len = wincode::serialized_size(&self.parent)
+            .expect("computing serialized size of parent should not fail")
+            as usize;
+        // parent + 8-byte `data` length prefix (wincode fixint) + data
+        let mut buf = Vec::with_capacity(parent_len + 8 + self.data.len());
         wincode::serialize_into(&mut buf, &self.parent)
             .expect("serializing slice parent should not fail");
         wincode::serialize_into(&mut buf, &self.data)
@@ -263,6 +262,7 @@ pub fn create_slice_with_invalid_txs(desired_size: usize) -> Slice {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::crypto::merkle::GENESIS_BLOCK_HASH;
 
     #[test]
     fn payload_roundtrip() {
@@ -273,15 +273,14 @@ mod tests {
 
     #[test]
     fn payload_bytes_matches_slice_payload() {
-        // `Slice::payload_bytes` must be byte-identical to serializing the
-        // equivalent `SlicePayload`, for both `parent` variants.
+        // `Slice::payload_bytes` must be identical to the equivalent `SlicePayload::to_bytes`
         let header = SliceHeader {
             slot: Slot::new(7),
             slice_index: SliceIndex::first(),
             is_last: true,
         };
-        let genesis = crate::crypto::merkle::GENESIS_BLOCK_HASH;
-        for parent in [None, Some((Slot::new(6), genesis))] {
+        // check with and without parent
+        for parent in [None, Some((Slot::new(6), GENESIS_BLOCK_HASH))] {
             let payload = SlicePayload::new(parent, vec![1, 2, 3, 4, 5]);
             let slice = Slice::from_parts(header, payload.clone());
             assert_eq!(slice.payload_bytes(), payload.to_bytes());

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -56,6 +56,34 @@ impl Slice {
         }
     }
 
+    /// Returns the [`SliceHeader`] describing this slice.
+    pub(crate) fn header(&self) -> SliceHeader {
+        SliceHeader {
+            slot: self.slot,
+            slice_index: self.slice_index,
+            is_last: self.is_last,
+        }
+    }
+
+    /// Serializes this slice's payload (its `parent` and `data`) into bytes.
+    ///
+    /// Produces exactly the same bytes as [`SlicePayload::to_bytes`] for the
+    /// equivalent payload, but reads straight from the slice's fields so no
+    /// owned [`SlicePayload`] (and hence no copy of `data`) has to be
+    /// materialized first. Used by shredders, which only need the serialized
+    /// payload and never the owned [`Slice`].
+    pub(crate) fn payload_bytes(&self) -> Vec<u8> {
+        // A wincode struct is the concatenation of its fields with no framing,
+        // so serializing `parent` then `data` matches `SlicePayload`'s layout.
+        // Guarded by the `payload_bytes_matches_slice_payload` test below.
+        let mut buf = Vec::new();
+        wincode::serialize_into(&mut buf, &self.parent)
+            .expect("serializing slice parent should not fail");
+        wincode::serialize_into(&mut buf, &self.data)
+            .expect("serializing slice data should not fail");
+        buf
+    }
+
     /// Deconstructs a [`Slice`] into its components: [`SliceHeader`] and [`SlicePayload`].
     pub(crate) fn deconstruct(self) -> (SliceHeader, SlicePayload) {
         let Slice {
@@ -241,6 +269,23 @@ mod tests {
         let payload = SlicePayload::new(None, vec![1, 2, 3, 4]);
         let bytes = payload.to_bytes();
         assert_eq!(SlicePayload::try_from(bytes.as_slice()).unwrap(), payload);
+    }
+
+    #[test]
+    fn payload_bytes_matches_slice_payload() {
+        // `Slice::payload_bytes` must be byte-identical to serializing the
+        // equivalent `SlicePayload`, for both `parent` variants.
+        let header = SliceHeader {
+            slot: Slot::new(7),
+            slice_index: SliceIndex::first(),
+            is_last: true,
+        };
+        let genesis = crate::crypto::merkle::GENESIS_BLOCK_HASH;
+        for parent in [None, Some((Slot::new(6), genesis))] {
+            let payload = SlicePayload::new(parent, vec![1, 2, 3, 4, 5]);
+            let slice = Slice::from_parts(header, payload.clone());
+            assert_eq!(slice.payload_bytes(), payload.to_bytes());
+        }
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated shred generation to borrow slice inputs across consensus, networking, and dissemination paths, avoiding unnecessary moves/clones and reducing overhead.
  * Updated the public shredding API so `shred` now takes `&Slice` (instead of consuming it), with behavior preserved.
  * Added slice helpers for consistent header/payload serialization, including a unit test confirming payload bytes match expected output.
* **Tests**
  * Adjusted and extended test coverage to use the new borrowed shred inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->