### PR TITLE
refactor: rename `empty` constructor on `SortedVecMap`/`SortedVecSet` to `new`

### DIFF
--- a/src/consensus/pool/slot_state.rs
+++ b/src/consensus/pool/slot_state.rs
@@ -48,13 +48,6 @@ pub(super) struct SlotState {
     pub(super) epoch_info: Arc<ValidatorEpochInfo>,
 }
 
-// PERF: `SlotVotes::new` eagerly allocates five N-length vectors per slot
-// (~700 B/validator), even for a slot that only ever sees a single vote. This
-// dominates per-slot memory and amplifies the far-future-slot allocation vector
-// in `Pool::add_vote` (one signed vote forces a full allocation). The durable fix
-// is sparse/lazy storage — buffer votes until a slot proves live, then promote to
-// this dense layout — which also subsumes the marginal "store only signatures"
-// win (dropping the redundant `slot`/`signer` saves only ~15%, sig dominates).
 pub(super) struct SlotVotes {
     /// Notarization votes for all validators (indexed by `ValidatorIndex`).
     pub(super) notar: Vec<Option<NotarVote>>,

--- a/src/consensus/pool/slot_state.rs
+++ b/src/consensus/pool/slot_state.rs
@@ -8,6 +8,7 @@
 //! - [`SlotVotedStake`] for all running stake totals in a single slot.
 //! - [`SlotCertificates`] for all certificates in a single slot.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use either::Either;
@@ -47,15 +48,18 @@ pub(super) struct SlotState {
     pub(super) epoch_info: Arc<ValidatorEpochInfo>,
 }
 
-// PERF: each stored vote duplicates `slot`/`signer` (both implied by context);
-// storing only signatures (+ block hash) and collapsing these five vectors into
-// one `Vec<ValidatorVotes>` would improve ingest-path locality. The per-vote
-// saving is modest (~15%, the 96-byte signature dominates), so profile first.
+// PERF: `SlotVotes::new` eagerly allocates five N-length vectors per slot
+// (~700 B/validator), even for a slot that only ever sees a single vote. This
+// dominates per-slot memory and amplifies the far-future-slot allocation vector
+// in `Pool::add_vote` (one signed vote forces a full allocation). The durable fix
+// is sparse/lazy storage — buffer votes until a slot proves live, then promote to
+// this dense layout — which also subsumes the marginal "store only signatures"
+// win (dropping the redundant `slot`/`signer` saves only ~15%, sig dominates).
 pub(super) struct SlotVotes {
     /// Notarization votes for all validators (indexed by `ValidatorIndex`).
     pub(super) notar: Vec<Option<NotarVote>>,
     /// Notar-fallback votes for all validators (indexed by `ValidatorIndex`).
-    pub(super) notar_fallback: Vec<SortedVecMap<BlockHash, NotarFallbackVote>>,
+    pub(super) notar_fallback: Vec<BTreeMap<BlockHash, NotarFallbackVote>>,
     /// Skip votes for all validators (indexed by `ValidatorIndex`).
     pub(super) skip: Vec<Option<SkipVote>>,
     /// Skip-fallback votes for all validators (indexed by `ValidatorIndex`).
@@ -658,7 +662,7 @@ impl SlotVotes {
     pub(super) fn new(num_validators: usize) -> Self {
         Self {
             notar: vec![None; num_validators],
-            notar_fallback: vec![SortedVecMap::new(); num_validators],
+            notar_fallback: vec![BTreeMap::new(); num_validators],
             skip: vec![None; num_validators],
             skip_fallback: vec![None; num_validators],
             finalize: vec![None; num_validators],

--- a/src/consensus/pool/slot_state.rs
+++ b/src/consensus/pool/slot_state.rs
@@ -8,7 +8,6 @@
 //! - [`SlotVotedStake`] for all running stake totals in a single slot.
 //! - [`SlotCertificates`] for all certificates in a single slot.
 
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use either::Either;
@@ -48,12 +47,15 @@ pub(super) struct SlotState {
     pub(super) epoch_info: Arc<ValidatorEpochInfo>,
 }
 
-// PERF: replace storing Votes (50% size overhead) with storing only signatures?
+// PERF: each stored vote duplicates `slot`/`signer` (both implied by context);
+// storing only signatures (+ block hash) and collapsing these five vectors into
+// one `Vec<ValidatorVotes>` would improve ingest-path locality. The per-vote
+// saving is modest (~15%, the 96-byte signature dominates), so profile first.
 pub(super) struct SlotVotes {
     /// Notarization votes for all validators (indexed by `ValidatorIndex`).
     pub(super) notar: Vec<Option<NotarVote>>,
     /// Notar-fallback votes for all validators (indexed by `ValidatorIndex`).
-    pub(super) notar_fallback: Vec<BTreeMap<BlockHash, NotarFallbackVote>>,
+    pub(super) notar_fallback: Vec<SortedVecMap<BlockHash, NotarFallbackVote>>,
     /// Skip votes for all validators (indexed by `ValidatorIndex`).
     pub(super) skip: Vec<Option<SkipVote>>,
     /// Skip-fallback votes for all validators (indexed by `ValidatorIndex`).
@@ -136,9 +138,9 @@ impl SlotState {
             votes: SlotVotes::new(epoch_info.epoch_info().validators().len()),
             voted_stakes: SlotVotedStake::default(),
             certificates: SlotCertificates::default(),
-            parents: SortedVecMap::empty(),
-            pending_safe_to_notar: SortedVecSet::empty(),
-            sent_safe_to_notar: SortedVecSet::empty(),
+            parents: SortedVecMap::new(),
+            pending_safe_to_notar: SortedVecSet::new(),
+            sent_safe_to_notar: SortedVecSet::new(),
             sent_safe_to_skip: false,
 
             slot,
@@ -656,7 +658,7 @@ impl SlotVotes {
     pub(super) fn new(num_validators: usize) -> Self {
         Self {
             notar: vec![None; num_validators],
-            notar_fallback: vec![BTreeMap::new(); num_validators],
+            notar_fallback: vec![SortedVecMap::new(); num_validators],
             skip: vec![None; num_validators],
             skip_fallback: vec![None; num_validators],
             finalize: vec![None; num_validators],

--- a/src/consensus/pool/sorted_vec.rs
+++ b/src/consensus/pool/sorted_vec.rs
@@ -28,35 +28,9 @@ impl<K: Ord, V> SortedVecMap<K, V> {
         Self::default()
     }
 
-    /// Returns whether the map contains no entries.
-    pub(super) fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
     /// Returns a reference to the value for `key`, if present.
     pub(super) fn get(&self, key: &K) -> Option<&V> {
         self.search(key).ok().map(|i| &self.0[i].1)
-    }
-
-    /// Returns whether `key` is present in the map.
-    pub(super) fn contains_key(&self, key: &K) -> bool {
-        self.search(key).is_ok()
-    }
-
-    /// Returns an iterator over the values in the map, in key order.
-    pub(super) fn values(&self) -> impl Iterator<Item = &V> {
-        self.0.iter().map(|(_, v)| v)
-    }
-
-    /// Inserts `value` for `key`, returning the previous value if one was present.
-    pub(super) fn insert(&mut self, key: K, value: V) -> Option<V> {
-        match self.search(&key) {
-            Ok(index) => Some(std::mem::replace(&mut self.0[index].1, value)),
-            Err(index) => {
-                self.0.insert(index, (key, value));
-                None
-            }
-        }
     }
 
     /// Returns a mutable reference to the value for `key`, if present.
@@ -161,23 +135,6 @@ mod tests {
 
         assert_eq!(map.get(&9), None);
         assert_eq!(map.get_mut(&9), None);
-    }
-
-    #[test]
-    fn map_insert_contains_is_empty() {
-        let mut map: SortedVecMap<u32, u32> = SortedVecMap::new();
-        assert!(map.is_empty());
-        assert!(!map.contains_key(&7));
-
-        // inserting a fresh key returns no previous value
-        assert_eq!(map.insert(7, 5), None);
-        assert!(!map.is_empty());
-        assert!(map.contains_key(&7));
-        assert_eq!(map.get(&7), Some(&5));
-
-        // inserting an existing key returns and overwrites the previous value
-        assert_eq!(map.insert(7, 8), Some(5));
-        assert_eq!(map.get(&7), Some(&8));
     }
 
     #[test]

--- a/src/consensus/pool/sorted_vec.rs
+++ b/src/consensus/pool/sorted_vec.rs
@@ -24,6 +24,7 @@ impl<K, V> Default for SortedVecMap<K, V> {
 
 impl<K: Ord, V> SortedVecMap<K, V> {
     /// Creates a new, empty map.
+    #[must_use]
     pub(super) fn new() -> Self {
         Self::default()
     }
@@ -76,6 +77,7 @@ impl<T> Default for SortedVecSet<T> {
 
 impl<T: Ord> SortedVecSet<T> {
     /// Creates a new, empty set.
+    #[must_use]
     pub(super) fn new() -> Self {
         Self::default()
     }

--- a/src/consensus/pool/sorted_vec.rs
+++ b/src/consensus/pool/sorted_vec.rs
@@ -23,14 +23,40 @@ impl<K, V> Default for SortedVecMap<K, V> {
 }
 
 impl<K: Ord, V> SortedVecMap<K, V> {
-    /// Creates an empty map.
-    pub(super) fn empty() -> Self {
+    /// Creates a new, empty map.
+    pub(super) fn new() -> Self {
         Self::default()
+    }
+
+    /// Returns whether the map contains no entries.
+    pub(super) fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     /// Returns a reference to the value for `key`, if present.
     pub(super) fn get(&self, key: &K) -> Option<&V> {
         self.search(key).ok().map(|i| &self.0[i].1)
+    }
+
+    /// Returns whether `key` is present in the map.
+    pub(super) fn contains_key(&self, key: &K) -> bool {
+        self.search(key).is_ok()
+    }
+
+    /// Returns an iterator over the values in the map, in key order.
+    pub(super) fn values(&self) -> impl Iterator<Item = &V> {
+        self.0.iter().map(|(_, v)| v)
+    }
+
+    /// Inserts `value` for `key`, returning the previous value if one was present.
+    pub(super) fn insert(&mut self, key: K, value: V) -> Option<V> {
+        match self.search(&key) {
+            Ok(index) => Some(std::mem::replace(&mut self.0[index].1, value)),
+            Err(index) => {
+                self.0.insert(index, (key, value));
+                None
+            }
+        }
     }
 
     /// Returns a mutable reference to the value for `key`, if present.
@@ -75,8 +101,8 @@ impl<T> Default for SortedVecSet<T> {
 }
 
 impl<T: Ord> SortedVecSet<T> {
-    /// Creates an empty set.
-    pub(super) fn empty() -> Self {
+    /// Creates a new, empty set.
+    pub(super) fn new() -> Self {
         Self::default()
     }
 
@@ -123,7 +149,7 @@ mod tests {
 
     #[test]
     fn map_get_or_insert_with() {
-        let mut map: SortedVecMap<u32, u64> = SortedVecMap::empty();
+        let mut map: SortedVecMap<u32, u64> = SortedVecMap::new();
 
         // inserts the default when absent
         *map.get_or_insert_with(&7, || 0) += 5;
@@ -138,8 +164,25 @@ mod tests {
     }
 
     #[test]
+    fn map_insert_contains_is_empty() {
+        let mut map: SortedVecMap<u32, u32> = SortedVecMap::new();
+        assert!(map.is_empty());
+        assert!(!map.contains_key(&7));
+
+        // inserting a fresh key returns no previous value
+        assert_eq!(map.insert(7, 5), None);
+        assert!(!map.is_empty());
+        assert!(map.contains_key(&7));
+        assert_eq!(map.get(&7), Some(&5));
+
+        // inserting an existing key returns and overwrites the previous value
+        assert_eq!(map.insert(7, 8), Some(5));
+        assert_eq!(map.get(&7), Some(&8));
+    }
+
+    #[test]
     fn map_stays_sorted_when_spilling() {
-        let mut map: SortedVecMap<u32, u32> = SortedVecMap::empty();
+        let mut map: SortedVecMap<u32, u32> = SortedVecMap::new();
         for k in [5, 1, 9, 3, 7, 0] {
             map.get_or_insert_with(&k, || k);
         }
@@ -152,7 +195,7 @@ mod tests {
 
     #[test]
     fn set_insert_contains_iter() {
-        let mut set: SortedVecSet<u32> = SortedVecSet::empty();
+        let mut set: SortedVecSet<u32> = SortedVecSet::new();
         assert!(set.insert(3));
         assert!(set.insert(1));
         assert!(set.insert(5));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized ordered map/set initialization to use the `new()` constructor for more consistent setup.
  * Updated consensus pool state initialization to use the updated ordered collection constructors.
* **Tests**
  * Adjusted existing tests to use the `new()` constructor while preserving the same insertion and lookup coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->