### PR TITLE
refactor: replace `const_assert` macro with `const` expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,6 @@ dependencies = [
  "sha2 0.11.0",
  "smallvec",
  "socket2",
- "static_assertions",
  "tempfile",
  "thiserror 2.0.18",
  "time",
@@ -2556,12 +2555,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ serde_json = { version = "1", optional = true }
 sha2 = "0.11"
 smallvec = "1"
 socket2 = "0.6"
-static_assertions = "1"
 thiserror = "2"
 time = { version = "0.3", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -15,19 +15,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,19 +35,20 @@ dependencies = [
  "either",
  "fastrace",
  "futures",
- "hex",
  "hex-literal",
  "hotpath",
+ "libc",
  "log",
  "logforth",
  "owo-colors",
+ "parking_lot",
  "quick_cache",
  "rand 0.10.1",
  "reed-solomon-simd",
  "serde",
  "sha2 0.11.0",
  "smallvec",
- "static_assertions",
+ "socket2",
  "thiserror",
  "time",
  "tokio",
@@ -705,12 +693,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "hex-literal"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,18 +700,18 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hotpath"
-version = "0.18.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2c28b1fa962e433f800ed1ea0bf53dc028d3745cf2acec6cfd28b65ac96afa"
+checksum = "1ff6b552a6afa29d9e33f8d555bee9093c142dd449501ae128e6494a303f03dc"
 dependencies = [
  "hotpath-macros",
 ]
 
 [[package]]
 name = "hotpath-macros"
-version = "0.18.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a585238d8daf746e27df0f24d1bbdcd2410e9febff63f9a0173f90d7e71c50f6"
+checksum = "4f15322569d3cfadf84c0de7ef72be435b8f4b4839ee4ace78a7eaca48a87ded"
 
 [[package]]
 name = "hybrid-array"
@@ -1122,13 +1104,13 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.22"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
+checksum = "403c1a912fec895cafb223201e368234842acb9220aaf08ab042ae89ba5f135c"
 dependencies = [
- "ahash",
  "equivalent",
- "hashbrown 0.16.1",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
  "parking_lot",
 ]
 
@@ -1401,12 +1383,6 @@ dependencies = [
  "base64ct",
  "der",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/src/bin/simulations/quorum_robustness.rs
+++ b/src/bin/simulations/quorum_robustness.rs
@@ -22,7 +22,6 @@ use log::debug;
 use parking_lot::RwLock;
 use rand::prelude::*;
 use rayon::prelude::*;
-use static_assertions::const_assert_eq;
 
 /// Parallelism level for rayon.
 const PARALLELISM: usize = 1000;
@@ -30,7 +29,7 @@ const PARALLELISM: usize = 1000;
 const WRITE_BATCH: usize = 1000;
 /// Maximum number of total iterations per attack scenario.
 const TOTAL_ITERATIONS: usize = 10_000_000;
-const_assert_eq!(TOTAL_ITERATIONS % (PARALLELISM * WRITE_BATCH), 0);
+const _: () = assert!(TOTAL_ITERATIONS.is_multiple_of(PARALLELISM * WRITE_BATCH));
 /// Simulations stop early if the number of failures is greater than this.
 const MAX_FAILURES: usize = 1;
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -36,7 +36,6 @@ use anyhow::Result;
 use fastrace::Span;
 use fastrace::future::FutureExt;
 use log::{trace, warn};
-use static_assertions::const_assert;
 use tokio::sync::{RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
 use wincode::{SchemaRead, SchemaWrite};
@@ -67,7 +66,7 @@ pub const DELTA: Duration = Duration::from_millis(250);
 const DELTA_BLOCK: Duration = Duration::from_millis(400);
 /// Time the leader has for producing and sending the first slice.
 const DELTA_FIRST_SLICE: Duration = Duration::from_millis(10);
-const_assert!(DELTA_FIRST_SLICE.as_nanos() <= DELTA_BLOCK.as_nanos());
+const _: () = assert!(DELTA_FIRST_SLICE.as_nanos() <= DELTA_BLOCK.as_nanos());
 /// Base timeout for when leader's first slice should arrive if they sent it immediately.
 const DELTA_TIMEOUT: Duration = DELTA.checked_mul(3).unwrap();
 /// Timeout for standstill detection mechanism.

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -10,7 +10,6 @@ use anyhow::Result;
 use either::Either;
 use fastrace::Span;
 use log::{debug, info, warn};
-use static_assertions::const_assert;
 use tokio::pin;
 use tokio::sync::oneshot;
 use tokio::time::sleep;
@@ -444,7 +443,7 @@ where
 
     // each slice should be able hold at least 1 transaction
     // +8 to encode number of txs, +8 to encode tx payload length
-    const_assert!(MAX_DATA_PER_SLICE >= MAX_TRANSACTION_SIZE + 8 + 8);
+    const _: () = assert!(MAX_DATA_PER_SLICE >= MAX_TRANSACTION_SIZE + 8 + 8);
 
     // reserve space for: parent info, and
     // 8 bytes for SlicePayload::data length

--- a/src/crypto/aggsig.rs
+++ b/src/crypto/aggsig.rs
@@ -37,7 +37,6 @@ use blst::min_sig::{
 use log::warn;
 use rand::prelude::*;
 use serde::{Deserialize, Deserializer, Serialize};
-use static_assertions::const_assert_eq;
 use wincode::config::Config;
 use wincode::{SchemaRead, SchemaWrite};
 
@@ -53,10 +52,7 @@ const DST: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_";
 /// This way signatures are twice as big as if we used compressed signatures.
 /// However, we save the time of uncompressing the signature before verifying.
 const UNCOMPRESSED_SIG_SIZE: usize = 96;
-const_assert_eq!(
-    UNCOMPRESSED_SIG_SIZE,
-    std::mem::size_of::<blst::blst_p1_affine>()
-);
+const _: () = assert!(UNCOMPRESSED_SIG_SIZE == std::mem::size_of::<blst::blst_p1_affine>());
 
 /// Maximum number of signers that can be aggregated into an aggregate signature.
 const MAX_SIGNERS: usize = 2048;

--- a/src/crypto/merkle.rs
+++ b/src/crypto/merkle.rs
@@ -20,7 +20,6 @@ use std::marker::PhantomData;
 use derive_more::{From, Into};
 use hex_literal::hex;
 use smallvec::SmallVec;
-use static_assertions::const_assert;
 use wincode::{SchemaRead, SchemaWrite};
 
 use super::Hash;
@@ -36,9 +35,9 @@ pub const MAX_MERKLE_TREE_HEIGHT: usize = 32;
 /// Maximum number of leaf nodes in the Merkle trees currently supported.
 pub const MAX_MERKLE_TREE_LEAVES: usize = 1 << MAX_MERKLE_TREE_HEIGHT;
 // need to be able to build Merkle tree for each slice
-const_assert!(TOTAL_SHREDS <= MAX_MERKLE_TREE_LEAVES);
+const _: () = assert!(TOTAL_SHREDS <= MAX_MERKLE_TREE_LEAVES);
 // need to be able to build double-Merkle tree for each block
-const_assert!(MAX_SLICES_PER_BLOCK <= MAX_MERKLE_TREE_LEAVES);
+const _: () = assert!(MAX_SLICES_PER_BLOCK <= MAX_MERKLE_TREE_LEAVES);
 
 const LEAF_LABEL: [u8; 32] = *b"ALPENGLOW-MERKLE-TREE  LEAF-NODE";
 const LEFT_LABEL: [u8; 32] = *b"ALPENGLOW-MERKLE-TREE  LEFT-NODE";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
-use static_assertions::const_assert_eq;
 use wincode::config::DefaultConfig;
 use wincode::{SchemaRead, SchemaWrite};
 
@@ -48,7 +47,7 @@ use crate::shredder::Shred;
 
 // NOTE: In many places we assume that `usize` is 64 bits wide.
 // So, for now, we only support 64-bit architectures.
-const_assert_eq!(std::mem::size_of::<usize>(), 8);
+const _: () = assert!(std::mem::size_of::<usize>() == 8);
 
 /// Serializes an in-memory value with [`wincode`].
 ///

--- a/src/shredder/reed_solomon.rs
+++ b/src/shredder/reed_solomon.rs
@@ -7,7 +7,6 @@
 //! It is mostly a wrapper around the [`reed_solomon_simd`] crate.
 
 use reed_solomon_simd::{ReedSolomonDecoder, ReedSolomonEncoder};
-use static_assertions::const_assert;
 use thiserror::Error;
 
 use super::{DATA_SHREDS, MAX_DATA_PER_SLICE, MAX_DATA_PER_SLICE_AFTER_PADDING, TOTAL_SHREDS};
@@ -58,7 +57,7 @@ impl ReedSolomonCoder {
     /// It is also initialized for up to [`MAX_DATA_PER_SHRED`] bytes per fragment.
     pub(super) fn new(num_coding: usize) -> ReedSolomonCoder {
         // max shreds supported by RS field
-        const_assert!(DATA_SHREDS + TOTAL_SHREDS <= 65536);
+        const _: () = assert!(DATA_SHREDS + TOTAL_SHREDS <= 65536);
 
         assert!(num_coding <= TOTAL_SHREDS);
 
@@ -234,7 +233,6 @@ impl ReedSolomonCoder {
 
 #[cfg(test)]
 mod tests {
-    use static_assertions::const_assert;
 
     use super::*;
     use crate::Slot;
@@ -268,7 +266,7 @@ mod tests {
 
     #[test]
     fn restore_various() {
-        const_assert!(MAX_DATA_PER_SLICE >= 2 * DATA_SHREDS);
+        const _: () = assert!(MAX_DATA_PER_SLICE >= 2 * DATA_SHREDS);
         let slice_bytes = MAX_DATA_PER_SLICE / 2;
         for offset in 0..DATA_SHREDS {
             let (header, payload) =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an unused dependency from the project.
  * Replaced several compile-time checks with built-in Rust assertions across core modules.
  * Kept all existing behavior and public interfaces unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->