### PR TITLE
feat: add support for authentication to the `Network` trait

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -36,10 +36,10 @@ use wincode::{ReadResult, SchemaRead};
 
 pub use self::simulated::SimulatedNetwork;
 pub use self::udp::UdpNetwork;
-use crate::Transaction;
 use crate::consensus::ConsensusMessage;
 use crate::repair::{RepairRequest, RepairResponse};
 use crate::shredder::Shred;
+use crate::{Transaction, ValidatorIndex};
 
 /// Maximum payload size of a UDP packet.
 pub const MTU_BYTES: usize = 1500;
@@ -64,11 +64,37 @@ where
     wincode::config::deserialize_exact(bytes, NetworkMessageConfig::new())
 }
 
+/// Identity of the peer a message was received from.
+///
+/// Transports that cryptographically authenticate their peers (e.g. a future
+/// QUIC transport) resolve this to a concrete [`ValidatorIndex`] via
+/// [`validator`](PeerId::validator). Transports that cannot attribute traffic
+/// to an identity (UDP, simulated) report [`Unauthenticated`], for which
+/// [`validator`](PeerId::validator) is always `None`.
+pub trait PeerId: Clone + Send + Sync + 'static {
+    /// Returns the authenticated validator this peer proved itself to be, or
+    /// `None` if the transport does not authenticate its peers.
+    fn validator(&self) -> Option<ValidatorIndex> {
+        None
+    }
+}
+
+/// Peer identity reported by transports that do not authenticate their peers.
+///
+/// Its [`PeerId::validator`] is always `None`, so a message received over such
+/// a transport carries no attributable, spoof-proof origin.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Unauthenticated;
+
+impl PeerId for Unauthenticated {}
+
 /// Abstraction of a network interface for sending and receiving messages.
 #[async_trait]
 pub trait Network: Send + Sync {
     type Send;
     type Recv;
+    /// Identity of the peer a received message came from.
+    type Peer: PeerId;
 
     /// Sends the `message` to all the addresses in `addrs`.
     ///
@@ -88,7 +114,29 @@ pub trait Network: Send + Sync {
 
     // TODO: implement broadcast at `Network` level?
 
-    async fn receive(&self) -> std::io::Result<Self::Recv>;
+    /// Receives the next message together with the identity of the peer that
+    /// sent it.
+    ///
+    /// The peer is [`Unauthenticated`] for transports that do not authenticate
+    /// their peers. Callers that do not need the origin can use
+    /// [`receive`](Network::receive) instead.
+    async fn receive_from(&self) -> std::io::Result<(Self::Peer, Self::Recv)>;
+
+    /// Receives the next message, discarding the sender's identity.
+    ///
+    /// Convenience wrapper over [`receive_from`](Network::receive_from) for the
+    /// common case where the origin is not needed.
+    async fn receive(&self) -> std::io::Result<Self::Recv> {
+        let (_peer, msg) = self.receive_from().await?;
+        Ok(msg)
+    }
+
+    /// Refuses further traffic from `peer`.
+    ///
+    /// Lets the caller shun a peer that provably misbehaved (e.g. sent an
+    /// invalid signature). The default is a no-op for transports that cannot
+    /// attribute or block traffic by identity (UDP, simulated).
+    fn ban(&self, _peer: &Self::Peer) {}
 }
 
 /// A marker trait that constrains [`Network`] to send and receive [`Shred`]

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -36,7 +36,7 @@ use wincode::{SchemaRead, SchemaWrite};
 
 pub use self::core::SimulatedNetworkCore;
 use self::token_bucket::TokenBucket;
-use super::Network;
+use super::{Network, Unauthenticated};
 use crate::ValidatorIndex;
 use crate::network::{MTU_BYTES, NetworkMessageConfig};
 
@@ -76,6 +76,7 @@ where
     S: SchemaWrite<DefaultConfig, Src = S> + Send + Sync,
     R: for<'de> SchemaRead<'de, NetworkMessageConfig, Dst = R> + Send + Sync,
 {
+    type Peer = Unauthenticated;
     type Recv = R;
     type Send = S;
 
@@ -100,7 +101,7 @@ where
         self.send_serialized(bytes, addr).await
     }
 
-    async fn receive(&self) -> std::io::Result<R> {
+    async fn receive_from(&self) -> std::io::Result<(Unauthenticated, R)> {
         loop {
             let Some(buf) = self.receiver.lock().await.recv().await else {
                 return Err(std::io::Error::other("channel closed"));
@@ -112,7 +113,7 @@ where
                     continue;
                 }
             };
-            return Ok(msg);
+            return Ok((Unauthenticated, msg));
         }
     }
 }

--- a/src/network/udp.rs
+++ b/src/network/udp.rs
@@ -24,7 +24,7 @@ use tokio::net::UdpSocket;
 use wincode::config::DefaultConfig;
 use wincode::{SchemaRead, SchemaWrite};
 
-use super::{MTU_BYTES, NetworkMessageConfig};
+use super::{MTU_BYTES, NetworkMessageConfig, Unauthenticated};
 use crate::network::Network;
 use crate::serialize;
 
@@ -206,6 +206,7 @@ where
     S: SchemaWrite<DefaultConfig, Src = S> + Send + Sync,
     R: for<'de> SchemaRead<'de, NetworkMessageConfig, Dst = R> + Send + Sync,
 {
+    type Peer = Unauthenticated;
     type Recv = R;
     type Send = S;
 
@@ -271,13 +272,13 @@ where
     /// Both may find `recv_queue` empty and enter `recv_batch`,
     /// and once one drains the socket and stashes its surplus,
     /// the other can be left parked until the next datagram arrives.
-    async fn receive(&self) -> io::Result<R> {
+    async fn receive_from(&self) -> io::Result<(Unauthenticated, R)> {
         loop {
             // fast path: hand out a datagram drained by an earlier batch
             // the lock is released before the `await` below
             let queued = self.recv_queue.lock().pop_front();
             if let Some(msg) = queued {
-                return Ok(msg);
+                return Ok((Unauthenticated, msg));
             }
 
             // queue empty: pull a fresh batch from the socket
@@ -287,7 +288,7 @@ where
                 if !batch.is_empty() {
                     self.recv_queue.lock().append(&mut batch);
                 }
-                return Ok(first);
+                return Ok((Unauthenticated, first));
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peer identity support to network message reception.
  * Network messages can now include the originating peer and support peer banning.
  * Added compatibility for unauthenticated transports, including simulated and UDP networks.
* **Bug Fixes**
  * Malformed UDP datagrams continue to be safely discarded during reception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->