### PR TITLE
ci: ignore unmaintained `ttf-parser` dependency RUSTSEC advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -836,26 +836,25 @@ dependencies = [
 
 [[package]]
 name = "fastrace"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2130caec636d7a1d23b173576674ced1af967228642ceaeb6a1b4705c282b00e"
+checksum = "74539685f6baa3c33251571272eac7939fc3b93dff97c30381d7a6267394e528"
 dependencies = [
  "fastant",
  "fastrace-macro",
  "parking_lot",
  "pin-project",
- "rand 0.9.4",
+ "rand 0.10.2",
  "rtrb",
  "serde",
 ]
 
 [[package]]
 name = "fastrace-macro"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b35f67e02527fca6515ff61f922360df781f477daf6a806fff16bd59525dee5"
+checksum = "390d4f754b751905fa9294716c4ead717ffb5fa733a0c2417358b7779fceaeed"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "alpenglow"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.90"
+rust-version = "1.91"
 authors = ["Quentin Kniep <quentin@anza.xyz>"]
 description = "Reference research implementation of the Alpenglow consensus protocol."
 license = "Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ all-features = true
 # (or `crate@version`) here, ideally with a reason.
 ignore = [
     # { id = "RUSTSEC-0000-0000", reason = "why this is acceptable" },
+    { id = "RUSTSEC-2026-0192", reason = "ttf-parser is unmaintained; only reachable via plotters' font backend (simulations plots), and both plotters font backends need it — revisit once ab_glyph/plotters migrate to skrifa" },
 ]
 
 [licenses]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Rust toolchain to version 1.91.
  * Updated security advisory configuration to account for a known advisory while the affected functionality is being addressed in a future update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->