### PR TITLE
refactor: drop `async_trait` from network traits

### DIFF
--- a/src/all2all.rs
+++ b/src/all2all.rs
@@ -35,14 +35,11 @@
 mod robust;
 mod trivial;
 
-use async_trait::async_trait;
-
 pub use self::robust::RobustAll2All;
 pub use self::trivial::TrivialAll2All;
 use crate::consensus::ConsensusMessage;
 
 /// Abstraction for a direct all-to-all network communication protocol.
-#[async_trait]
 pub trait All2All {
     /// Broadcasts the given message to all known nodes.
     ///
@@ -53,7 +50,8 @@ pub trait All2All {
     /// # Errors
     ///
     /// Implementors should return an [`std::io::Error`] iff the underlying network fails.
-    async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()>;
+    fn broadcast(&self, msg: &ConsensusMessage)
+    -> impl Future<Output = std::io::Result<()>> + Send;
 
     /// Receives a message from any of the other nodes.
     ///
@@ -63,5 +61,5 @@ pub trait All2All {
     /// # Errors
     ///
     /// Implementors should return an [`std::io::Error`] iff the underlying network fails.
-    async fn receive(&self) -> std::io::Result<ConsensusMessage>;
+    fn receive(&self) -> impl Future<Output = std::io::Result<ConsensusMessage>> + Send;
 }

--- a/src/all2all/robust.rs
+++ b/src/all2all/robust.rs
@@ -8,12 +8,10 @@
 
 use std::iter::repeat_n;
 
-use async_trait::async_trait;
-
 use super::All2All;
 use crate::ValidatorInfo;
 use crate::consensus::ConsensusMessage;
-use crate::network::{ConsensusNetwork, Network};
+use crate::network::{ConsensusNetwork, Network, higher_ranked};
 
 /// Instance of the robust all-to-all broadcast protocol.
 // TODO: actually make more robust (retransmits, ...)
@@ -37,7 +35,6 @@ impl<N: Network> RobustAll2All<N> {
     pub fn handle_retransmits(&self) {}
 }
 
-#[async_trait]
 impl<N: Network> All2All for RobustAll2All<N>
 where
     N: ConsensusNetwork,
@@ -47,7 +44,9 @@ where
         let addrs = self
             .validators
             .iter()
-            .flat_map(|v| repeat_n(v.all2all_address, 1000));
+            .flat_map(higher_ranked(|v: &ValidatorInfo| {
+                repeat_n(v.all2all_address, 1000)
+            }));
         self.network.send_to_many(msg, addrs).await
     }
 

--- a/src/all2all/robust.rs
+++ b/src/all2all/robust.rs
@@ -7,16 +7,17 @@
 //! The message may be retransmitted multiple times.
 
 use std::iter::repeat_n;
+use std::net::SocketAddr;
 
 use super::All2All;
 use crate::ValidatorInfo;
 use crate::consensus::ConsensusMessage;
-use crate::network::{ConsensusNetwork, Network, higher_ranked};
+use crate::network::{ConsensusNetwork, Network};
 
 /// Instance of the robust all-to-all broadcast protocol.
 // TODO: actually make more robust (retransmits, ...)
 pub struct RobustAll2All<N: Network> {
-    validators: Vec<ValidatorInfo>,
+    addrs: Vec<SocketAddr>,
     network: N,
 }
 
@@ -26,10 +27,8 @@ impl<N: Network> RobustAll2All<N> {
     /// Messages will be broadcast to all `validators` over the provided `network`.
     /// Potential retransmits will be handled automatically, also over the `network`.
     pub fn new(validators: Vec<ValidatorInfo>, network: N) -> Self {
-        Self {
-            validators,
-            network,
-        }
+        let addrs = validators.iter().map(|v| v.all2all_address).collect();
+        Self { addrs, network }
     }
 
     pub fn handle_retransmits(&self) {}
@@ -42,11 +41,10 @@ where
     async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()> {
         // HACK: stupidly expensive retransmits
         let addrs = self
-            .validators
+            .addrs
             .iter()
-            .flat_map(higher_ranked(|v: &ValidatorInfo| {
-                repeat_n(v.all2all_address, 1000)
-            }));
+            .copied()
+            .flat_map(|addr| repeat_n(addr, 1000));
         self.network.send_to_many(msg, addrs).await
     }
 

--- a/src/all2all/trivial.rs
+++ b/src/all2all/trivial.rs
@@ -7,12 +7,10 @@
 //! After that, the message is forgotten. The protocol is completely stateless.
 //! If the underlying [`Network`] is not reliable, the message might thus be lost.
 
-use async_trait::async_trait;
-
 use super::All2All;
 use crate::ValidatorInfo;
 use crate::consensus::ConsensusMessage;
-use crate::network::{ConsensusNetwork, Network};
+use crate::network::{ConsensusNetwork, Network, higher_ranked};
 
 /// Instance of the trivial all-to-all broadcast protocol.
 pub struct TrivialAll2All<N: Network> {
@@ -33,15 +31,16 @@ impl<N: Network> TrivialAll2All<N> {
     }
 }
 
-#[async_trait]
 impl<N: Network> All2All for TrivialAll2All<N>
 where
     N: ConsensusNetwork,
 {
     async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()> {
-        self.network
-            .send_to_many(msg, self.validators.iter().map(|v| v.all2all_address))
-            .await?;
+        let addrs = self
+            .validators
+            .iter()
+            .map(higher_ranked(|v: &ValidatorInfo| v.all2all_address));
+        self.network.send_to_many(msg, addrs).await?;
         Ok(())
     }
 

--- a/src/all2all/trivial.rs
+++ b/src/all2all/trivial.rs
@@ -7,14 +7,16 @@
 //! After that, the message is forgotten. The protocol is completely stateless.
 //! If the underlying [`Network`] is not reliable, the message might thus be lost.
 
+use std::net::SocketAddr;
+
 use super::All2All;
 use crate::ValidatorInfo;
 use crate::consensus::ConsensusMessage;
-use crate::network::{ConsensusNetwork, Network, higher_ranked};
+use crate::network::{ConsensusNetwork, Network};
 
 /// Instance of the trivial all-to-all broadcast protocol.
 pub struct TrivialAll2All<N: Network> {
-    validators: Vec<ValidatorInfo>,
+    addrs: Vec<SocketAddr>,
     network: N,
 }
 
@@ -23,11 +25,9 @@ impl<N: Network> TrivialAll2All<N> {
     ///
     /// Messages will be broadcast to all `validators` over the provided `network`.
     /// For each, [`ValidatorInfo::all2all_address`] will serve as recipient.
-    pub const fn new(validators: Vec<ValidatorInfo>, network: N) -> Self {
-        Self {
-            validators,
-            network,
-        }
+    pub fn new(validators: Vec<ValidatorInfo>, network: N) -> Self {
+        let addrs = validators.iter().map(|v| v.all2all_address).collect();
+        Self { addrs, network }
     }
 }
 
@@ -36,10 +36,7 @@ where
     N: ConsensusNetwork,
 {
     async fn broadcast(&self, msg: &ConsensusMessage) -> std::io::Result<()> {
-        let addrs = self
-            .validators
-            .iter()
-            .map(higher_ranked(|v: &ValidatorInfo| v.all2all_address));
+        let addrs = self.addrs.iter().copied();
         self.network.send_to_many(msg, addrs).await?;
         Ok(())
     }

--- a/src/disseminator.rs
+++ b/src/disseminator.rs
@@ -14,23 +14,20 @@ pub mod rotor;
 pub mod trivial;
 pub mod turbine;
 
-use async_trait::async_trait;
-
 pub use self::rotor::Rotor;
 pub use self::trivial::TrivialDisseminator;
 pub use self::turbine::Turbine;
 use crate::shredder::Shred;
 
 /// Abstraction of a block dissemination protocol.
-#[async_trait]
 #[cfg_attr(test, mockall::automock)]
 pub trait Disseminator {
     /// Sends the given shred to the network as the original source.
-    async fn send(&self, shred: &Shred) -> std::io::Result<()>;
+    fn send(&self, shred: &Shred) -> impl Future<Output = std::io::Result<()>> + Send;
 
     /// Performs any necessary forwarding of the given shred.
-    async fn forward(&self, shred: &Shred) -> std::io::Result<()>;
+    fn forward(&self, shred: &Shred) -> impl Future<Output = std::io::Result<()>> + Send;
 
     /// Receives the next shred from the network.
-    async fn receive(&self) -> std::io::Result<Shred>;
+    fn receive(&self) -> impl Future<Output = std::io::Result<Shred>> + Send;
 }

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -26,9 +26,9 @@ pub use self::sampling_strategy::{
 };
 use super::Disseminator;
 use crate::consensus::ValidatorEpochInfo;
-use crate::network::{Network, ShredNetwork, higher_ranked};
+use crate::network::{Network, ShredNetwork};
 use crate::shredder::{Shred, TOTAL_SHREDS};
-use crate::{Slot, ValidatorIndex, ValidatorInfo};
+use crate::{Slot, ValidatorIndex};
 
 /// Maximum number of per-slice relay committees cached.
 ///
@@ -128,14 +128,15 @@ where
         }
 
         // otherwise, broadcast
-        let to = self
-            .epoch_info
-            .epoch_info()
-            .validators()
-            .iter()
-            .filter_map(higher_ranked(move |v: &ValidatorInfo| {
-                (v.id != leader && v.id != relay).then_some(v.disseminator_address)
-            }));
+        // NOTE: iterates indices so the closure's argument carries no lifetime;
+        // with a `&ValidatorInfo` argument, the closure is inferred with a fixed
+        // lifetime and proving the (unboxed) `send_to_many` future [`Send`] fails
+        // (<https://github.com/rust-lang/rust/issues/102211>).
+        let validators = self.epoch_info.epoch_info().validators();
+        let to = (0..validators.len()).filter_map(move |i| {
+            let v = &validators[i];
+            (v.id != leader && v.id != relay).then_some(v.disseminator_address)
+        });
         self.network.send_to_many(shred, to).await?;
         Ok(())
     }

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -115,28 +115,24 @@ where
     /// Does nothing if we are not the dedicated relay for this shred.
     #[hotpath::measure]
     async fn broadcast_if_relay(&self, shred: &Shred) -> std::io::Result<()> {
-        let leader = self
-            .epoch_info
-            .epoch_info()
-            .leader(shred.payload().header.slot)
-            .id;
-
         // do nothing if we are not the relay
         let relay = self.sample_relay(shred);
         if self.epoch_info.own_id() != relay {
             return Ok(());
         }
 
+        // exclude the leader
+        let leader = self
+            .epoch_info
+            .epoch_info()
+            .leader(shred.payload().header.slot)
+            .id;
+
         // otherwise, broadcast
-        // NOTE: iterates indices so the closure's argument carries no lifetime;
-        // with a `&ValidatorInfo` argument, the closure is inferred with a fixed
-        // lifetime and proving the (unboxed) `send_to_many` future [`Send`] fails
-        // (<https://github.com/rust-lang/rust/issues/102211>).
         let validators = self.epoch_info.epoch_info().validators();
-        let to = (0..validators.len()).filter_map(move |i| {
-            let v = &validators[i];
-            (v.id != leader && v.id != relay).then_some(v.disseminator_address)
-        });
+        let to = (0..validators.len())
+            .filter(move |i| i != &relay.as_usize() && i != &leader.as_usize())
+            .map(move |i| validators[i].disseminator_address);
         self.network.send_to_many(shred, to).await?;
         Ok(())
     }

--- a/src/disseminator/rotor.rs
+++ b/src/disseminator/rotor.rs
@@ -16,7 +16,6 @@ pub mod sampling_strategy;
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use quick_cache::sync::Cache;
 use rand::prelude::*;
 
@@ -27,9 +26,9 @@ pub use self::sampling_strategy::{
 };
 use super::Disseminator;
 use crate::consensus::ValidatorEpochInfo;
-use crate::network::{Network, ShredNetwork};
+use crate::network::{Network, ShredNetwork, higher_ranked};
 use crate::shredder::{Shred, TOTAL_SHREDS};
-use crate::{Slot, ValidatorIndex};
+use crate::{Slot, ValidatorIndex, ValidatorInfo};
 
 /// Maximum number of per-slice relay committees cached.
 ///
@@ -134,8 +133,9 @@ where
             .epoch_info()
             .validators()
             .iter()
-            .filter(|v| v.id != leader && v.id != relay)
-            .map(|v| v.disseminator_address);
+            .filter_map(higher_ranked(move |v: &ValidatorInfo| {
+                (v.id != leader && v.id != relay).then_some(v.disseminator_address)
+            }));
         self.network.send_to_many(shred, to).await?;
         Ok(())
     }
@@ -178,7 +178,6 @@ where
     }
 }
 
-#[async_trait]
 impl<N, S: QuorumSamplingStrategy + Send + Sync + 'static> Disseminator for Rotor<N, S>
 where
     N: ShredNetwork,

--- a/src/disseminator/trivial.rs
+++ b/src/disseminator/trivial.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Anza Technology, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_trait::async_trait;
-
 use super::Disseminator;
 use crate::ValidatorInfo;
 use crate::network::{Network, ShredNetwork};
@@ -24,7 +22,6 @@ impl<N: Network> TrivialDisseminator<N> {
     }
 }
 
-#[async_trait]
 impl<N> Disseminator for TrivialDisseminator<N>
 where
     N: ShredNetwork,

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -12,14 +12,13 @@ mod weighted_shuffle;
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use quick_cache::sync::Cache;
 use rand::prelude::*;
 
 pub(crate) use self::weighted_shuffle::WeightedShuffle;
 use super::Disseminator;
 use crate::consensus::ValidatorEpochInfo;
-use crate::network::{Network, ShredNetwork};
+use crate::network::{Network, ShredNetwork, higher_ranked};
 use crate::shredder::Shred;
 use crate::{Slot, ValidatorIndex, ValidatorInfo};
 
@@ -103,12 +102,15 @@ where
     /// Returns an error if the send operation on the underlying network fails.
     pub async fn forward_shred(&self, shred: &Shred) -> std::io::Result<()> {
         let tree = self.get_tree(shred.payload().header.slot, shred.payload().index_in_slot());
-        let addrs = tree.get_children().iter().map(|child| {
-            self.epoch_info
-                .epoch_info()
-                .validator(*child)
-                .disseminator_address
-        });
+        let addrs = tree
+            .get_children()
+            .iter()
+            .map(higher_ranked(|child: &ValidatorIndex| {
+                self.epoch_info
+                    .epoch_info()
+                    .validator(*child)
+                    .disseminator_address
+            }));
         self.network.send_to_many(shred, addrs).await?;
         Ok(())
     }
@@ -131,7 +133,6 @@ where
     }
 }
 
-#[async_trait]
 impl<N> Disseminator for Turbine<N>
 where
     N: ShredNetwork,

--- a/src/disseminator/turbine.rs
+++ b/src/disseminator/turbine.rs
@@ -18,7 +18,7 @@ use rand::prelude::*;
 pub(crate) use self::weighted_shuffle::WeightedShuffle;
 use super::Disseminator;
 use crate::consensus::ValidatorEpochInfo;
-use crate::network::{Network, ShredNetwork, higher_ranked};
+use crate::network::{Network, ShredNetwork};
 use crate::shredder::Shred;
 use crate::{Slot, ValidatorIndex, ValidatorInfo};
 
@@ -102,15 +102,12 @@ where
     /// Returns an error if the send operation on the underlying network fails.
     pub async fn forward_shred(&self, shred: &Shred) -> std::io::Result<()> {
         let tree = self.get_tree(shred.payload().header.slot, shred.payload().index_in_slot());
-        let addrs = tree
-            .get_children()
-            .iter()
-            .map(higher_ranked(|child: &ValidatorIndex| {
-                self.epoch_info
-                    .epoch_info()
-                    .validator(*child)
-                    .disseminator_address
-            }));
+        let addrs = tree.get_children().iter().copied().map(|child| {
+            self.epoch_info
+                .epoch_info()
+                .validator(child)
+                .disseminator_address
+        });
         self.network.send_to_many(shred, addrs).await?;
         Ok(())
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -30,7 +30,6 @@ mod udp;
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use async_trait::async_trait;
 use wincode::config::Configuration;
 use wincode::{ReadResult, SchemaRead};
 
@@ -65,7 +64,6 @@ where
 }
 
 /// Abstraction of a network interface for sending and receiving messages.
-#[async_trait]
 pub trait Network: Send + Sync {
     type Send;
     type Recv;
@@ -77,18 +75,22 @@ pub trait Network: Send + Sync {
     /// This means that the function is not atomic, if it fails, some messages may still have been sent.
     //
     // NOTE: Consider return a `Vec<Result<()>>` to indicate per address failures.
-    async fn send_to_many(
+    fn send_to_many(
         &self,
         message: &Self::Send,
         addrs: impl IntoIterator<Item = SocketAddr> + Send,
-    ) -> std::io::Result<()>;
+    ) -> impl Future<Output = std::io::Result<()>> + Send;
 
     /// Sends the `message` to `addr`.
-    async fn send(&self, message: &Self::Send, addr: SocketAddr) -> std::io::Result<()>;
+    fn send(
+        &self,
+        message: &Self::Send,
+        addr: SocketAddr,
+    ) -> impl Future<Output = std::io::Result<()>> + Send;
 
     // TODO: implement broadcast at `Network` level?
 
-    async fn receive(&self) -> std::io::Result<Self::Recv>;
+    fn receive(&self) -> impl Future<Output = std::io::Result<Self::Recv>> + Send;
 }
 
 /// A marker trait that constrains [`Network`] to send and receive [`Shred`]
@@ -112,6 +114,20 @@ impl<N> RepairRequesterNetwork for N where N: Network<Recv = RepairResponse, Sen
 /// receiving [`RepairRequest`] and sending [`RepairResponse`].
 pub trait RepairResponderNetwork: Network<Recv = RepairRequest, Send = RepairResponse> {}
 impl<N> RepairResponderNetwork for N where N: Network<Recv = RepairRequest, Send = RepairResponse> {}
+
+/// Identity function that forces a closure to be higher-ranked over its
+/// argument's lifetime.
+///
+/// Address-mapping closures passed to [`Network::send_to_many`] are otherwise
+/// inferred with a fixed lifetime, and proving the returned (unboxed) future
+/// [`Send`] then fails with "implementation of `FnOnce` is not general enough"
+/// (<https://github.com/rust-lang/rust/issues/102211>).
+pub(crate) fn higher_ranked<T: ?Sized, R, F>(f: F) -> F
+where
+    F: for<'a> FnMut(&'a T) -> R,
+{
+    f
+}
 
 /// Returns a [`SocketAddr`] bound to the localhost IPv4 and given port.
 ///

--- a/src/network.rs
+++ b/src/network.rs
@@ -129,20 +129,6 @@ impl<N> RepairRequesterNetwork for N where N: Network<Recv = RepairResponse, Sen
 pub trait RepairResponderNetwork: Network<Recv = RepairRequest, Send = RepairResponse> {}
 impl<N> RepairResponderNetwork for N where N: Network<Recv = RepairRequest, Send = RepairResponse> {}
 
-/// Identity function that forces a closure to be higher-ranked over its
-/// argument's lifetime.
-///
-/// Address-mapping closures passed to [`Network::send_to_many`] are otherwise
-/// inferred with a fixed lifetime, and proving the returned (unboxed) future
-/// [`Send`] then fails with "implementation of `FnOnce` is not general enough"
-/// (<https://github.com/rust-lang/rust/issues/102211>).
-pub(crate) fn higher_ranked<T: ?Sized, R, F>(f: F) -> F
-where
-    F: for<'a> FnMut(&'a T) -> R,
-{
-    f
-}
-
 /// Returns a [`SocketAddr`] bound to the localhost IPv4 and given port.
 ///
 /// NOTE: port 0 is generally reserved and used to get the OS to assign a port.

--- a/src/network.rs
+++ b/src/network.rs
@@ -78,7 +78,7 @@ pub trait Network: Send + Sync {
         &self,
         message: &Self::Send,
         addr: SocketAddr,
-    ) -> impl Future<Output = std::io::Result<()>> + Send;
+    ) -> impl Future<Output = io::Result<()>> + Send;
 
     /// Sends the `message` to all the addresses in `addrs`, best-effort.
     ///
@@ -94,7 +94,7 @@ pub trait Network: Send + Sync {
         &self,
         message: &Self::Send,
         addrs: impl IntoIterator<Item = SocketAddr> + Send,
-    ) -> impl Future<Output = std::io::Result<()>> + Send;
+    ) -> impl Future<Output = io::Result<()>> + Send;
 
     /// Receives a message from the network.
     ///
@@ -104,7 +104,7 @@ pub trait Network: Send + Sync {
     /// # Errors
     ///
     /// Returns an [`io::Error`] if the underlying network operation fails.
-    fn receive(&self) -> impl Future<Output = std::io::Result<Self::Recv>> + Send;
+    fn receive(&self) -> impl Future<Output = io::Result<Self::Recv>> + Send;
 }
 
 /// A marker trait that constrains [`Network`] to send and receive [`Shred`]

--- a/src/network/simulated.rs
+++ b/src/network/simulated.rs
@@ -27,7 +27,6 @@ use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use futures::future::join_all;
 use log::warn;
 use tokio::sync::{Mutex, RwLock, mpsc};
@@ -70,7 +69,6 @@ impl<S, R> SimulatedNetwork<S, R> {
     }
 }
 
-#[async_trait]
 impl<S, R> Network for SimulatedNetwork<S, R>
 where
     S: SchemaWrite<DefaultConfig, Src = S> + Send + Sync,

--- a/src/network/udp.rs
+++ b/src/network/udp.rs
@@ -16,7 +16,6 @@ use std::io;
 use std::marker::PhantomData;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
-use async_trait::async_trait;
 use log::warn;
 use parking_lot::Mutex;
 use socket2::SockRef;
@@ -200,7 +199,6 @@ where
     }
 }
 
-#[async_trait]
 impl<S, R> Network for UdpNetwork<S, R>
 where
     S: SchemaWrite<DefaultConfig, Src = S> + Send + Sync,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated networking, dissemination, and all-to-all broadcast trait APIs to return native Rust futures directly, removing reliance on the previous async-trait macro approach.
  - Precomputed broadcast/forward recipient addresses in all-to-all implementations to streamline destination selection.
  - Refined relay/forward target iterator construction (e.g., excluding relay/leader targets and iterating addresses efficiently) while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->