### PR TITLE
refactor: de-async Pool/Blockstore, extract sync VotorState

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -512,7 +512,7 @@ where
                 // Add under the lock, then forward the buffered events off the lock.
                 let outbox = {
                     let mut pool = self.pool.write().await;
-                    match pool.add_vote(vote).await {
+                    match pool.add_vote(vote) {
                         Ok(()) => {}
                         Err(AddVoteError::Slashable(offence)) => {
                             warn!("slashable offence detected: {offence}");
@@ -533,7 +533,7 @@ where
                 };
                 let outbox = {
                     let mut pool = self.pool.write().await;
-                    match pool.add_cert(cert).await {
+                    match pool.add_cert(cert) {
                         Ok(()) => {}
                         Err(err) => trace!("ignoring invalid cert: {err}"),
                     }
@@ -574,7 +574,7 @@ where
         // *after* releasing the write lock (see `EventForwarder`).
         let (res, events) = {
             let mut blockstore = self.blockstore.write().await;
-            let res = blockstore.add_shred_from_dissemination(validated).await;
+            let res = blockstore.add_shred_from_dissemination(validated);
             (res, blockstore.take_events())
         };
         self.event_forwarder.forward_blockstore_events(events).await;
@@ -583,7 +583,7 @@ where
             let block_id = (slot, block_info.hash);
             let outbox = {
                 let mut pool = self.pool.write().await;
-                pool.add_block(block_id, block_info.parent).await;
+                pool.add_block(block_id, block_info.parent);
                 pool.take_outbox()
             };
             self.event_forwarder.forward_pool_outbox(outbox).await;

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -371,7 +371,7 @@ where
         // buffered events to Votor after releasing the write lock.
         let (block_info, events) = {
             let mut blockstore = self.blockstore.write().await;
-            let block_info = blockstore.add_own_slice(payload, shreds).await;
+            let block_info = blockstore.add_own_slice(payload, shreds);
             (block_info, blockstore.take_events())
         };
         self.event_forwarder.forward_blockstore_events(events).await;
@@ -391,7 +391,7 @@ where
                 let block_id = (slot, block_info.hash.clone());
                 let outbox = {
                     let mut pool = self.pool.write().await;
-                    pool.add_block(block_id, block_info.parent).await;
+                    pool.add_block(block_id, block_info.parent);
                     pool.take_outbox()
                 };
                 self.event_forwarder.forward_pool_outbox(outbox).await;
@@ -733,10 +733,7 @@ mod tests {
         blockstore
             .expect_add_own_slice()
             .times(1)
-            .returning(move |_slice, _shreds| {
-                let bi = bi.clone();
-                Box::pin(async move { Some(bi) })
-            });
+            .returning(move |_slice, _shreds| Some(bi.clone()));
         blockstore.expect_take_events().returning(Vec::new);
 
         let mut pool = MockPool::new();
@@ -745,7 +742,6 @@ mod tests {
             .returning(move |ret_block_id, ret_parent_block_id| {
                 assert_eq!(ret_block_id, (slot, bi.hash.clone()));
                 assert_eq!(bi.parent, ret_parent_block_id);
-                Box::pin(async {})
             });
         pool.expect_take_outbox().returning(PoolOutbox::default);
 
@@ -784,8 +780,11 @@ mod tests {
             parent: new_parent.clone(),
         };
 
-        let (first_slice_finished_tx, first_slice_finished_rx) = oneshot::channel();
-        let (start_second_slice_tx, start_second_slice_rx) = oneshot::channel();
+        // NOTE: the blockstore is now sync, so the rendezvous blocks on std
+        // channels inside the mock (briefly blocking the runtime thread) and a
+        // plain OS thread plays the coordinator that reacts in between.
+        let (first_slice_finished_tx, first_slice_finished_rx) = std::sync::mpsc::channel();
+        let (start_second_slice_tx, start_second_slice_rx) = std::sync::mpsc::channel();
 
         let mut seq = Sequence::new();
         let mut blockstore = MockBlockstore::new();
@@ -797,11 +796,9 @@ mod tests {
             .times(1)
             .in_sequence(&mut seq)
             .return_once(move |_slice, _shreds| {
-                Box::pin(async move {
-                    first_slice_finished_tx.send(()).unwrap();
-                    let () = start_second_slice_rx.await.unwrap();
-                    None
-                })
+                first_slice_finished_tx.send(()).unwrap();
+                let () = start_second_slice_rx.recv().unwrap();
+                None
             });
 
         // second (last) slice: block is constructed with the new parent
@@ -810,10 +807,7 @@ mod tests {
             .expect_add_own_slice()
             .times(1)
             .in_sequence(&mut seq)
-            .returning(move |_slice, _shreds| {
-                let nbi = nbi.clone();
-                Box::pin(async move { Some(nbi) })
-            });
+            .returning(move |_slice, _shreds| Some(nbi.clone()));
         blockstore.expect_take_events().returning(Vec::new);
 
         let mut pool = MockPool::new();
@@ -822,7 +816,6 @@ mod tests {
             .returning(move |ret_block_id, ret_parent_block_id| {
                 assert_eq!(ret_block_id, (slot, nbi.hash.clone()));
                 assert_eq!(nbi.parent, ret_parent_block_id);
-                Box::pin(async {})
             });
         pool.expect_take_outbox().returning(PoolOutbox::default);
 
@@ -841,8 +834,8 @@ mod tests {
         let (parent_ready_tx, parent_ready_rx) = oneshot::channel();
 
         let np = new_parent.clone();
-        tokio::spawn(async move {
-            let () = first_slice_finished_rx.await.unwrap();
+        std::thread::spawn(move || {
+            let () = first_slice_finished_rx.recv().unwrap();
             parent_ready_tx.send(np).unwrap();
             start_second_slice_tx.send(()).unwrap();
         });

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -8,7 +8,6 @@ mod slot_block_data;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use log::debug;
 use tokio::sync::RwLock;
 
@@ -63,24 +62,28 @@ impl From<&Block> for BlockInfo {
 /// Interface for the blockstore.
 ///
 /// This is only used for mocking of [`BlockstoreImpl`].
-#[async_trait]
+///
+/// All methods are synchronous: the blockstore is a pure state machine that
+/// performs no I/O and buffers its side-effects as [`BlockstoreEvent`]s, so no
+/// method ever needs to await (and none may, as callers invoke them under a
+/// write lock).
 #[cfg_attr(test, mockall::automock)]
 pub trait Blockstore {
-    async fn add_shred_from_dissemination(
+    fn add_shred_from_dissemination(
         &mut self,
         shred: ValidatedShred,
     ) -> Result<Option<BlockInfo>, AddShredError>;
-    async fn add_shred_from_repair(
+    fn add_shred_from_repair(
         &mut self,
         hash: BlockHash,
         shred: ValidatedShred,
     ) -> Result<Option<BlockInfo>, AddShredError>;
-    async fn add_own_slice(
+    fn add_own_slice(
         &mut self,
         payload: SlicePayload,
         shreds: Box<[ValidatedShred; TOTAL_SHREDS]>,
     ) -> Option<BlockInfo>;
-    async fn flag_leader_misbehavior(&mut self, slot: Slot);
+    fn flag_leader_misbehavior(&mut self, slot: Slot);
     /// Drains and returns the [`BlockstoreEvent`]s buffered since the last call.
     ///
     /// The caller must forward these to Votor *after* releasing the blockstore
@@ -260,7 +263,6 @@ impl BlockstoreImpl {
     }
 }
 
-#[async_trait]
 impl Blockstore for BlockstoreImpl {
     /// Stores a new shred in the blockstore.
     ///
@@ -275,7 +277,7 @@ impl Blockstore for BlockstoreImpl {
     /// Returns the block's [`BlockInfo`] on reconstruction, `None` otherwise.
     #[hotpath::measure]
     #[fastrace::trace(short_name = true)]
-    async fn add_shred_from_dissemination(
+    fn add_shred_from_dissemination(
         &mut self,
         shred: ValidatedShred,
     ) -> Result<Option<BlockInfo>, AddShredError> {
@@ -291,7 +293,7 @@ impl Blockstore for BlockstoreImpl {
             Ok(Some(event)) => Ok(self.emit(event)),
             Ok(None) => Ok(None),
             Err(err @ (AddShredError::Equivocation | AddShredError::InvalidShred)) => {
-                self.flag_leader_misbehavior(slot).await;
+                self.flag_leader_misbehavior(slot);
                 Err(err)
             }
             Err(e) => Err(e),
@@ -311,7 +313,7 @@ impl Blockstore for BlockstoreImpl {
     /// Returns the block's [`BlockInfo`] on reconstruction, `None` otherwise.
     #[hotpath::measure]
     #[fastrace::trace(short_name = true)]
-    async fn add_shred_from_repair(
+    fn add_shred_from_repair(
         &mut self,
         hash: BlockHash,
         shred: ValidatedShred,
@@ -329,7 +331,7 @@ impl Blockstore for BlockstoreImpl {
             result,
             Err(AddShredError::Equivocation | AddShredError::InvalidShred)
         ) {
-            self.flag_leader_misbehavior(slot).await;
+            self.flag_leader_misbehavior(slot);
         }
         match result? {
             Some(event) => Ok(self.emit(event)),
@@ -346,7 +348,7 @@ impl Blockstore for BlockstoreImpl {
     /// Returns the block's [`BlockInfo`] on reconstruction, `None` otherwise.
     #[hotpath::measure]
     #[fastrace::trace(short_name = true)]
-    async fn add_own_slice(
+    fn add_own_slice(
         &mut self,
         payload: SlicePayload,
         shreds: Box<[ValidatedShred; TOTAL_SHREDS]>,
@@ -365,7 +367,7 @@ impl Blockstore for BlockstoreImpl {
     /// Flags the leader as misbehaving for `slot`, notifying Votor exactly once.
     ///
     /// Emits [`BlockstoreEvent::InvalidBlock`] the first time the slot is flagged.
-    async fn flag_leader_misbehavior(&mut self, slot: Slot) {
+    fn flag_leader_misbehavior(&mut self, slot: Slot) {
         if self.slot_data_mut(slot).mark_leader_misbehaved() {
             self.emit(BlockstoreEvent::InvalidBlock(slot));
         }
@@ -487,11 +489,11 @@ mod tests {
         TestContext { sk, blockstore }
     }
 
-    async fn add_shred_ignore_duplicate(
+    fn add_shred_ignore_duplicate(
         blockstore: &mut BlockstoreImpl,
         shred: ValidatedShred,
     ) -> Result<Option<BlockInfo>, AddShredError> {
-        match blockstore.add_shred_from_dissemination(shred).await {
+        match blockstore.add_shred_from_dissemination(shred) {
             Ok(output) => Ok(output),
             Err(AddShredError::Duplicate) => Ok(None),
             Err(e) => Err(e),
@@ -512,12 +514,12 @@ mod tests {
     ///
     /// Reconstruction records `FirstShred` + `Block` events in the blockstore's
     /// outbox, to be drained via [`Blockstore::take_events`].
-    async fn store_full_block(blockstore: &mut BlockstoreImpl, sk: &SecretKey) -> BlockInfo {
+    fn store_full_block(blockstore: &mut BlockstoreImpl, sk: &SecretKey) -> BlockInfo {
         let slot = Slot::genesis().next();
         let (block_hash, _, shreds) = create_random_shredded_block(slot, 1, sk);
         let mut reconstructed = None;
         for shred in shreds.into_iter().flatten() {
-            if let Some(info) = add_shred_ignore_duplicate(blockstore, shred).await.unwrap() {
+            if let Some(info) = add_shred_ignore_duplicate(blockstore, shred).unwrap() {
                 reconstructed = Some(info);
             }
         }
@@ -529,10 +531,10 @@ mod tests {
     /// Reconstructing a block must record its `FirstShred` and `Block` events in the
     /// outbox (rather than sending them under the lock), so the caller can forward
     /// them to Votor losslessly after releasing the write lock.
-    #[tokio::test]
-    async fn reconstruction_events_are_recorded() {
+    #[test]
+    fn reconstruction_events_are_recorded() {
         let mut ctx = setup();
-        let info = store_full_block(&mut ctx.blockstore, &ctx.sk).await;
+        let info = store_full_block(&mut ctx.blockstore, &ctx.sk);
 
         let events = ctx.blockstore.take_events();
         assert!(
@@ -552,8 +554,8 @@ mod tests {
         assert!(ctx.blockstore.take_events().is_empty());
     }
 
-    #[tokio::test]
-    async fn store_one_slice_block() -> Result<()> {
+    #[test]
+    fn store_one_slice_block() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.slot_data(slot).is_none());
@@ -565,7 +567,7 @@ mod tests {
         let slice_hash = shreds[0][0].slice_root();
         for shred in &shreds[0] {
             // store shred
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred.clone()).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred.clone())?;
 
             // check shred is stored
             let Some(stored_shred) = ctx.blockstore.get_disseminated_shred(
@@ -591,8 +593,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn store_two_slice_block() -> Result<()> {
+    #[test]
+    fn store_two_slice_block() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.slot_data(slot).is_none());
@@ -602,21 +604,21 @@ mod tests {
 
         // first slice is not enough
         for shred in slices[0].clone() {
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_none());
 
         // after second slice we should have the block
         for shred in slices[1].clone() {
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_some());
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn store_block_from_repair() -> Result<()> {
+    #[test]
+    fn store_block_from_repair() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.slot_data(slot).is_none());
@@ -627,8 +629,7 @@ mod tests {
         // first slice is not enough
         for shred in slices[0].clone().into_iter().take(DATA_SHREDS) {
             ctx.blockstore
-                .add_shred_from_repair(block_hash.clone(), shred)
-                .await?;
+                .add_shred_from_repair(block_hash.clone(), shred)?;
         }
         assert!(
             ctx.blockstore
@@ -639,16 +640,15 @@ mod tests {
         // after second slice we should have the block
         for shred in slices[1].clone().into_iter().take(DATA_SHREDS) {
             ctx.blockstore
-                .add_shred_from_repair(block_hash.clone(), shred)
-                .await?;
+                .add_shred_from_repair(block_hash.clone(), shred)?;
         }
         assert!(ctx.blockstore.get_block(&(slot, block_hash)).is_some());
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn out_of_order_shreds() -> Result<()> {
+    #[test]
+    fn out_of_order_shreds() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_none());
@@ -658,15 +658,15 @@ mod tests {
 
         // insert shreds in reverse order
         for shred in slices[0].clone().into_iter().rev() {
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_some());
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn just_enough_shreds() -> Result<()> {
+    #[test]
+    fn just_enough_shreds() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_none());
@@ -677,7 +677,7 @@ mod tests {
 
         // insert just enough shreds to reconstruct slice 0 (from beginning)
         for shred in slices[0].clone().into_iter().take(DATA_SHREDS) {
-            ctx.blockstore.add_shred_from_dissemination(shred).await?;
+            ctx.blockstore.add_shred_from_dissemination(shred)?;
         }
         assert_eq!(ctx.blockstore.stored_slices_for_slot(slot), 1);
 
@@ -687,7 +687,7 @@ mod tests {
             .into_iter()
             .skip(TOTAL_SHREDS - DATA_SHREDS)
         {
-            ctx.blockstore.add_shred_from_dissemination(shred).await?;
+            ctx.blockstore.add_shred_from_dissemination(shred)?;
         }
         assert_eq!(ctx.blockstore.stored_slices_for_slot(slot), 2);
 
@@ -698,7 +698,7 @@ mod tests {
             .skip((TOTAL_SHREDS - DATA_SHREDS) / 2)
             .take(DATA_SHREDS)
         {
-            ctx.blockstore.add_shred_from_dissemination(shred).await?;
+            ctx.blockstore.add_shred_from_dissemination(shred)?;
         }
         assert_eq!(ctx.blockstore.stored_slices_for_slot(slot), 3);
 
@@ -709,7 +709,7 @@ mod tests {
             .enumerate()
             .filter(|(i, _)| *i < DATA_SHREDS / 2 || *i >= TOTAL_SHREDS - DATA_SHREDS / 2)
         {
-            ctx.blockstore.add_shred_from_dissemination(shred).await?;
+            ctx.blockstore.add_shred_from_dissemination(shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_some());
 
@@ -719,8 +719,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn out_of_order_slices() -> Result<()> {
+    #[test]
+    fn out_of_order_slices() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_none());
@@ -730,7 +730,7 @@ mod tests {
 
         // second slice alone is not enough
         for shred in slices[0].clone() {
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_none());
 
@@ -739,7 +739,7 @@ mod tests {
 
         // after also also inserting first slice we should have the block
         for shred in slices[1].clone() {
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_some());
 
@@ -752,8 +752,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn duplicate_shreds() -> Result<()> {
+    #[test]
+    fn duplicate_shreds() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         let (_hash, _tree, slices) = create_random_shredded_block(slot, 1, &ctx.sk);
@@ -761,15 +761,13 @@ mod tests {
         // inserting single shred should not throw errors
         let res = ctx
             .blockstore
-            .add_shred_from_dissemination(slices[0][0].clone())
-            .await;
+            .add_shred_from_dissemination(slices[0][0].clone());
         assert!(res.is_ok());
 
         // inserting same shred again should give duplicate error
         let res = ctx
             .blockstore
-            .add_shred_from_dissemination(slices[0][0].clone())
-            .await;
+            .add_shred_from_dissemination(slices[0][0].clone());
         assert_eq!(res, Err(AddShredError::Duplicate));
 
         // should only store one copy
@@ -787,8 +785,8 @@ mod tests {
             .count()
     }
 
-    #[tokio::test]
-    async fn dissemination_equivocation() -> Result<()> {
+    #[test]
+    fn dissemination_equivocation() -> Result<()> {
         let sk = SecretKey::new(&mut rand::rng());
         let mut blockstore = BlockstoreImpl::new();
         let slot = Slot::genesis().next();
@@ -796,26 +794,22 @@ mod tests {
         // disseminate two distinct blocks for the same slot
         let (_h0, _t0, slices0) = create_random_shredded_block(slot, 1, &sk);
         let (_h1, _t1, slices1) = create_random_shredded_block(slot, 1, &sk);
-        blockstore
-            .add_shred_from_dissemination(slices0[0][0].clone())
-            .await?;
-        let res = blockstore
-            .add_shred_from_dissemination(slices1[0][0].clone())
-            .await;
+        blockstore.add_shred_from_dissemination(slices0[0][0].clone())?;
+        let res = blockstore.add_shred_from_dissemination(slices1[0][0].clone());
 
         // equivocation detected, Votor should be notified
         assert_eq!(res, Err(AddShredError::Equivocation));
         assert_eq!(count_invalid_block_events(&mut blockstore, slot), 1);
 
         // idempotent: later misbehavior does not re-notify
-        blockstore.flag_leader_misbehavior(slot).await;
+        blockstore.flag_leader_misbehavior(slot);
         assert_eq!(count_invalid_block_events(&mut blockstore, slot), 0);
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn repair_conflicting_block_not_flagged_as_equivocation() -> Result<()> {
+    #[test]
+    fn repair_conflicting_block_not_flagged_as_equivocation() -> Result<()> {
         let sk = SecretKey::new(&mut rand::rng());
         let mut blockstore = BlockstoreImpl::new();
         let slot = Slot::genesis().next();
@@ -823,12 +817,8 @@ mod tests {
         // see different blocks from dissemination and repair
         let (_h0, _t0, slices0) = create_random_shredded_block(slot, 1, &sk);
         let (hash, _t1, slices1) = create_random_shredded_block(slot, 1, &sk);
-        blockstore
-            .add_shred_from_dissemination(slices0[0][0].clone())
-            .await?;
-        let res = blockstore
-            .add_shred_from_repair(hash, slices1[0][0].clone())
-            .await;
+        blockstore.add_shred_from_dissemination(slices0[0][0].clone())?;
+        let res = blockstore.add_shred_from_repair(hash, slices1[0][0].clone());
 
         // TODO: Detect equivocation across the dissemination and repair spots.
         assert_eq!(res, Ok(None));
@@ -837,8 +827,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn pruning() -> Result<()> {
+    #[test]
+    fn pruning() -> Result<()> {
         let mut ctx = setup();
         let block0_slot = Slot::genesis().next();
         let block1_slot = block0_slot.next();
@@ -856,7 +846,7 @@ mod tests {
         shreds.extend(block1.2.into_iter().flatten());
         shreds.extend(block2.2.into_iter().flatten());
         for shred in shreds {
-            add_shred_ignore_duplicate(blockstore, shred).await?;
+            add_shred_ignore_duplicate(blockstore, shred)?;
         }
         assert!(blockstore.disseminated_block_hash(block0_slot).is_some());
         assert!(blockstore.disseminated_block_hash(block1_slot).is_some());
@@ -894,17 +884,17 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn add_own_slice_matches_dissemination_single_slice() -> Result<()> {
-        check_own_slice_matches_dissemination(1).await
+    #[test]
+    fn add_own_slice_matches_dissemination_single_slice() -> Result<()> {
+        check_own_slice_matches_dissemination(1)
     }
 
-    #[tokio::test]
-    async fn add_own_slice_matches_dissemination_multi_slice() -> Result<()> {
-        check_own_slice_matches_dissemination(3).await
+    #[test]
+    fn add_own_slice_matches_dissemination_multi_slice() -> Result<()> {
+        check_own_slice_matches_dissemination(3)
     }
 
-    async fn check_own_slice_matches_dissemination(num_slices: usize) -> Result<()> {
+    fn check_own_slice_matches_dissemination(num_slices: usize) -> Result<()> {
         let sk = SecretKey::new(&mut rand::rng());
         let slot = Slot::genesis().next();
         let slices = create_random_block(slot, num_slices);
@@ -914,7 +904,7 @@ mod tests {
         for slice in &slices {
             let shreds = RegularShredder::default().shred(slice, &sk).unwrap();
             for shred in shreds {
-                add_shred_ignore_duplicate(&mut dissem, shred).await?;
+                add_shred_ignore_duplicate(&mut dissem, shred)?;
             }
         }
         let expected_hash = dissem.disseminated_block_hash(slot).unwrap().clone();
@@ -925,7 +915,7 @@ mod tests {
         for slice in slices {
             let is_last = slice.is_last;
             let (payload, shreds) = shred_as_leader(slice, &sk);
-            let block_info = own.add_own_slice(payload, Box::new(shreds)).await;
+            let block_info = own.add_own_slice(payload, Box::new(shreds));
             // only the last slice completes the block
             assert_eq!(block_info.is_some(), is_last);
             if let Some(info) = block_info {

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -15,7 +15,6 @@ use std::collections::BTreeMap;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use either::Either;
 use log::{debug, info, trace, warn};
 use thiserror::Error;
@@ -174,12 +173,15 @@ pub enum SlashableOffence {
 /// Interface for the Pool.
 ///
 /// This is only used for mocking of [`PoolImpl`].
-#[async_trait]
+///
+/// All methods are synchronous: the pool is a pure state machine that performs
+/// no I/O and buffers its side-effects in a [`PoolOutbox`], so no method ever
+/// needs to await (and none may, as callers invoke them under a write lock).
 #[cfg_attr(test, mockall::automock)]
 pub trait Pool {
-    async fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError>;
-    async fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError>;
-    async fn add_block(&mut self, block_id: BlockId, parent_id: BlockId);
+    fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError>;
+    fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError>;
+    fn add_block(&mut self, block_id: BlockId, parent_id: BlockId);
     /// Builds the standstill-recovery bundle to re-broadcast; see [`PoolImpl::recover_from_standstill`].
     fn recover_from_standstill(&self) -> PoolOutbox;
     /// Drains and returns the side-effects buffered since the last call.
@@ -241,7 +243,7 @@ impl PoolImpl {
     /// - slot is not too old or too far in the future
     /// - signature is valid
     /// - certificate is not a duplicate
-    async fn add_valid_cert(&mut self, cert: Cert) {
+    fn add_valid_cert(&mut self, cert: Cert) {
         let slot = cert.slot();
 
         // actually add certificate
@@ -263,7 +265,7 @@ impl PoolImpl {
                 );
                 if matches!(cert, Cert::Notar(_)) {
                     let finalization_event = self.finality_tracker.mark_notarized(block_id.clone());
-                    self.handle_finalization(finalization_event).await;
+                    self.handle_finalization(finalization_event);
                 }
 
                 // potentially notify child waiting for safe-to-notar
@@ -295,12 +297,12 @@ impl PoolImpl {
                 info!("fast finalized slot {slot}");
                 let hash = ff_cert.block_hash().clone();
                 let finalization_event = self.finality_tracker.mark_fast_finalized((slot, hash));
-                self.handle_finalization(finalization_event).await;
+                self.handle_finalization(finalization_event);
             }
             Cert::Final(_) => {
                 info!("slow finalized slot {slot}");
                 let finalization_event = self.finality_tracker.mark_finalized(slot);
-                self.handle_finalization(finalization_event).await;
+                self.handle_finalization(finalization_event);
             }
         }
 
@@ -453,7 +455,7 @@ impl PoolImpl {
             .is_some_and(|state| state.certificates.skip.is_some())
     }
 
-    async fn handle_finalization(&mut self, event: FinalizationEvent) {
+    fn handle_finalization(&mut self, event: FinalizationEvent) {
         let new_parents_ready = self.parent_ready_tracker.handle_finalization(event);
         self.send_parent_ready_events(new_parents_ready);
         self.prune();
@@ -484,11 +486,10 @@ impl PoolImpl {
     }
 }
 
-#[async_trait]
 impl Pool for PoolImpl {
     /// Adds a new certificate to the pool.
     #[hotpath::measure]
-    async fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError> {
+    fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError> {
         // ignore old and far-in-the-future certificates
         let slot = cert.slot();
         // TODO: set bounds exactly correctly
@@ -515,13 +516,13 @@ impl Pool for PoolImpl {
             return Err(AddCertError::Duplicate);
         }
 
-        self.add_valid_cert(cert).await;
+        self.add_valid_cert(cert);
         Ok(())
     }
 
     /// Adds a new vote to the pool.
     #[hotpath::measure]
-    async fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError> {
+    fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError> {
         // ignore old and far-in-the-future votes
         let slot = vote.slot();
         // TODO: set bounds exactly correctly
@@ -560,7 +561,7 @@ impl Pool for PoolImpl {
 
         // handle any resulting events
         for cert in new_certs {
-            self.add_valid_cert(cert).await;
+            self.add_valid_cert(cert);
         }
         for event in votor_events {
             self.enqueue_votor_event(event);
@@ -575,7 +576,7 @@ impl Pool for PoolImpl {
     ///
     /// This should be called once for every valid block (e.g. directly by blockstore).
     /// Ensures that the parent information is available for safe-to-notar checks.
-    async fn add_block(&mut self, block_id: BlockId, parent_id: BlockId) {
+    fn add_block(&mut self, block_id: BlockId, parent_id: BlockId) {
         assert!(block_id.0 > parent_id.0);
         let (slot, block_hash) = &block_id;
         let (parent_slot, parent_hash) = &parent_id;
@@ -768,27 +769,27 @@ mod tests {
         }
 
         /// Verifies `vote` into a [`ValidatedVote`] and adds it to the pool.
-        async fn add_vote(&mut self, vote: Vote) -> Result<(), AddVoteError> {
+        fn add_vote(&mut self, vote: Vote) -> Result<(), AddVoteError> {
             // NOTE: signature-rejection is covered by the [`ValidatedVote`] tests
             let vote = ValidatedVote::try_new(vote, self.epoch_info.epoch_info())
                 .expect("test vote should pass verification");
-            let res = self.pool.add_vote(vote).await;
+            let res = self.pool.add_vote(vote);
             self.forward_outbox();
             res
         }
 
         /// Verifies `cert` into a [`ValidatedCert`] and adds it to the pool.
-        async fn add_cert(&mut self, cert: Cert) -> Result<(), AddCertError> {
+        fn add_cert(&mut self, cert: Cert) -> Result<(), AddCertError> {
             // NOTE: certificate rejection is covered by the [`ValidatedCert`] tests
             let cert = ValidatedCert::try_new(cert, self.epoch_info.epoch_info())
                 .expect("test cert should pass verification");
-            let res = self.pool.add_cert(cert).await;
+            let res = self.pool.add_cert(cert);
             self.forward_outbox();
             res
         }
 
         /// Adds a notarization [`Vote`] for `hash` in `slot` from each of `validators` to the pool.
-        async fn add_notar_votes(
+        fn add_notar_votes(
             &mut self,
             slot: Slot,
             hash: &BlockHash,
@@ -796,12 +797,12 @@ mod tests {
         ) {
             for v in validators.map(|v| ValidatorIndex::new(v as u64)) {
                 let vote = Vote::new_notar(slot, hash.clone(), &self.sks[v.as_usize()], v);
-                assert_eq!(self.add_vote(vote).await, Ok(()));
+                assert_eq!(self.add_vote(vote), Ok(()));
             }
         }
 
         /// Adds a notar-fallback [`Vote`] for `hash` in `slot` from each of `validators` to the pool.
-        async fn add_notar_fallback_votes(
+        fn add_notar_fallback_votes(
             &mut self,
             slot: Slot,
             hash: &BlockHash,
@@ -809,23 +810,23 @@ mod tests {
         ) {
             for v in validators.map(|v| ValidatorIndex::new(v as u64)) {
                 let vote = Vote::new_notar_fallback(slot, hash.clone(), &self.sks[v.as_usize()], v);
-                assert_eq!(self.add_vote(vote).await, Ok(()));
+                assert_eq!(self.add_vote(vote), Ok(()));
             }
         }
 
         /// Adds a skip [`Vote`] for `slot` from each of `validators` to the pool.
-        async fn add_skip_votes(&mut self, slot: Slot, validators: std::ops::Range<usize>) {
+        fn add_skip_votes(&mut self, slot: Slot, validators: std::ops::Range<usize>) {
             for v in validators.map(|v| ValidatorIndex::new(v as u64)) {
                 let vote = Vote::new_skip(slot, &self.sks[v.as_usize()], v);
-                assert_eq!(self.add_vote(vote).await, Ok(()));
+                assert_eq!(self.add_vote(vote), Ok(()));
             }
         }
 
         /// Adds a finalization [`Vote`] for `slot` from each of `validators` to the pool.
-        async fn add_final_votes(&mut self, slot: Slot, validators: std::ops::Range<usize>) {
+        fn add_final_votes(&mut self, slot: Slot, validators: std::ops::Range<usize>) {
             for v in validators.map(|v| ValidatorIndex::new(v as u64)) {
                 let vote = Vote::new_final(slot, &self.sks[v.as_usize()], v);
-                assert_eq!(self.add_vote(vote).await, Ok(()));
+                assert_eq!(self.add_vote(vote), Ok(()));
             }
         }
 
@@ -854,9 +855,9 @@ mod tests {
         }
 
         /// Fast-finalizes the given block by submitting a unanimous fast-final cert.
-        async fn fast_finalize(&mut self, slot: Slot, hash: &BlockHash) {
+        fn fast_finalize(&mut self, slot: Slot, hash: &BlockHash) {
             let cert = self.fast_final_cert(slot, hash, 11);
-            assert_eq!(self.add_cert(Cert::FastFinal(cert)).await, Ok(()));
+            assert_eq!(self.add_cert(Cert::FastFinal(cert)), Ok(()));
         }
 
         /// Drains all pending votor events and reports whether `SafeToNotar(slot, hash)` was emitted.
@@ -877,8 +878,8 @@ mod tests {
     /// Notarizing a block must record a `CertCreated` event in the pool's outbox
     /// (rather than sending it under the lock), so the caller can forward it to
     /// Votor losslessly after releasing the write lock.
-    #[tokio::test]
-    async fn cert_created_event_is_recorded() {
+    #[test]
+    fn cert_created_event_is_recorded() {
         let mut ctx = setup();
 
         // Notarize genesis directly on the pool, bypassing the test helpers so the
@@ -887,7 +888,7 @@ mod tests {
             let vote = Vote::new_notar(Slot::new(0), GENESIS_BLOCK_HASH, &ctx.sks[v.as_usize()], v);
             let vote = ValidatedVote::try_new(vote, ctx.epoch_info.epoch_info())
                 .expect("test vote should pass verification");
-            ctx.pool.add_vote(vote).await.unwrap();
+            ctx.pool.add_vote(vote).unwrap();
         }
         assert!(ctx.pool.has_notar_cert(Slot::new(0)));
 
@@ -903,114 +904,108 @@ mod tests {
         assert!(ctx.pool.take_outbox().is_empty());
     }
 
-    #[tokio::test]
-    async fn notarize_block() {
+    #[test]
+    fn notarize_block() {
         let mut ctx = setup();
 
         // all nodes notarize block in slot 0
         assert!(!ctx.pool.has_notar_cert(Slot::new(0)));
-        ctx.add_notar_votes(Slot::new(0), &GENESIS_BLOCK_HASH, 0..11)
-            .await;
+        ctx.add_notar_votes(Slot::new(0), &GENESIS_BLOCK_HASH, 0..11);
         assert!(ctx.pool.has_notar_cert(Slot::new(0)));
 
         // just enough nodes notarize block in slot 1
         assert!(!ctx.pool.has_notar_cert(Slot::new(1)));
-        ctx.add_notar_votes(Slot::new(1), &GENESIS_BLOCK_HASH, 0..7)
-            .await;
+        ctx.add_notar_votes(Slot::new(1), &GENESIS_BLOCK_HASH, 0..7);
         assert!(ctx.pool.has_notar_cert(Slot::new(1)));
 
         // just NOT enough nodes notarize block in slot 2
         assert!(!ctx.pool.has_notar_cert(Slot::new(2)));
-        ctx.add_notar_votes(Slot::new(2), &GENESIS_BLOCK_HASH, 0..6)
-            .await;
+        ctx.add_notar_votes(Slot::new(2), &GENESIS_BLOCK_HASH, 0..6);
         assert!(!ctx.pool.has_notar_cert(Slot::new(2)));
     }
 
-    #[tokio::test]
-    async fn skip_block() {
+    #[test]
+    fn skip_block() {
         let mut ctx = setup();
 
         // all nodes vote skip on slot 0
         assert!(!ctx.pool.has_skip_cert(Slot::new(0)));
-        ctx.add_skip_votes(Slot::new(0), 0..11).await;
+        ctx.add_skip_votes(Slot::new(0), 0..11);
         assert!(ctx.pool.has_skip_cert(Slot::new(0)));
 
         // just enough nodes vote skip on slot 1
         assert!(!ctx.pool.has_skip_cert(Slot::new(1)));
-        ctx.add_skip_votes(Slot::new(1), 0..7).await;
+        ctx.add_skip_votes(Slot::new(1), 0..7);
         assert!(ctx.pool.has_skip_cert(Slot::new(1)));
 
         // just NOT enough nodes notarize block in slot 2
         assert!(!ctx.pool.has_skip_cert(Slot::new(2)));
-        ctx.add_skip_votes(Slot::new(2), 0..6).await;
+        ctx.add_skip_votes(Slot::new(2), 0..6);
         assert!(!ctx.pool.has_skip_cert(Slot::new(2)));
     }
 
-    #[tokio::test]
-    async fn finalize_block() {
+    #[test]
+    fn finalize_block() {
         let mut ctx = setup();
 
         // just enough nodes vote notar, this is NOT enough on its own to finalize
         let slot1 = Slot::genesis().next();
         let hash1: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot1, &hash1, 0..7).await;
+        ctx.add_notar_votes(slot1, &hash1, 0..7);
         assert!(!ctx.pool.has_final_cert(slot1));
         assert_eq!(ctx.pool.finalized_slot(), Slot::genesis());
 
         // just enough nodes vote final, NOW slot 1 should be finalized
-        ctx.add_final_votes(slot1, 0..7).await;
+        ctx.add_final_votes(slot1, 0..7);
         assert!(ctx.pool.has_final_cert(slot1));
         assert_eq!(ctx.pool.finalized_slot(), slot1);
 
         // just enough nodes vote final, this is NOT enough on its own to finalize
         let slot2 = slot1.next();
-        ctx.add_final_votes(slot2, 0..7).await;
+        ctx.add_final_votes(slot2, 0..7);
         assert!(ctx.pool.has_final_cert(slot2));
         assert_eq!(ctx.pool.finalized_slot(), slot1);
 
         // just enough nodes vote notar, NOW slot 2 should be finalized
         let hash2: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot2, &hash2, 0..7).await;
+        ctx.add_notar_votes(slot2, &hash2, 0..7);
         assert!(ctx.pool.has_final_cert(slot2));
         assert_eq!(ctx.pool.finalized_slot(), slot2);
 
         // just NOT enough nodes vote notar + final on slot 3
         let slot3 = slot2.next();
         let hash3: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot3, &hash3, 0..6).await;
-        ctx.add_final_votes(slot3, 0..6).await;
+        ctx.add_notar_votes(slot3, &hash3, 0..6);
+        ctx.add_final_votes(slot3, 0..6);
         assert!(!ctx.pool.has_final_cert(slot3));
         assert_eq!(ctx.pool.finalized_slot(), slot2);
     }
 
-    #[tokio::test]
-    async fn fast_finalize_block() {
+    #[test]
+    fn fast_finalize_block() {
         let mut ctx = setup();
 
         // all nodes vote notarize on slot 0
         assert!(!ctx.pool.has_final_cert(Slot::new(0)));
-        ctx.add_notar_votes(Slot::new(0), &GENESIS_BLOCK_HASH, 0..11)
-            .await;
+        ctx.add_notar_votes(Slot::new(0), &GENESIS_BLOCK_HASH, 0..11);
         assert!(ctx.pool.has_final_cert(Slot::new(0)));
         assert_eq!(ctx.pool.finalized_slot(), Slot::new(0));
 
         // just enough nodes to fast finalize slot 1
         assert!(!ctx.pool.has_final_cert(Slot::new(1)));
-        ctx.add_notar_votes(Slot::new(1), &GENESIS_BLOCK_HASH, 0..9)
-            .await;
+        ctx.add_notar_votes(Slot::new(1), &GENESIS_BLOCK_HASH, 0..9);
         assert!(ctx.pool.has_final_cert(Slot::new(1)));
         assert_eq!(ctx.pool.finalized_slot(), Slot::new(1));
 
         // just NOT enough nodes to fast finalize slot 2
         assert!(!ctx.pool.has_final_cert(Slot::new(2)));
-        ctx.add_notar_votes(Slot::new(2), &GENESIS_BLOCK_HASH, 0..8)
-            .await;
+        ctx.add_notar_votes(Slot::new(2), &GENESIS_BLOCK_HASH, 0..8);
         assert!(!ctx.pool.has_final_cert(Slot::new(2)));
         assert_eq!(ctx.pool.finalized_slot(), Slot::new(1));
     }
 
-    #[tokio::test]
-    async fn simple_branch_certified() {
+    #[test]
+    fn simple_branch_certified() {
         let mut ctx = setup();
 
         let window = Slot::genesis().slots_in_window().collect::<Vec<_>>();
@@ -1020,7 +1015,7 @@ mod tests {
             .collect();
         for slot in window.iter().skip(1) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(*slot, hash, 0..7).await;
+            ctx.add_notar_votes(*slot, hash, 0..7);
         }
         let slot = *window.last().unwrap();
         let next = slot.next();
@@ -1030,8 +1025,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn branch_certified_notar_fallback() {
+    #[test]
+    fn branch_certified_notar_fallback() {
         let mut ctx = setup();
 
         // receive mixed notar & notar-fallback votes
@@ -1046,8 +1041,8 @@ mod tests {
                 !ctx.pool
                     .is_parent_ready(slot.next(), &(*slot, hash.clone()))
             );
-            ctx.add_notar_votes(*slot, hash, 0..4).await;
-            ctx.add_notar_fallback_votes(*slot, hash, 4..7).await;
+            ctx.add_notar_votes(*slot, hash, 0..4);
+            ctx.add_notar_fallback_votes(*slot, hash, 4..7);
         }
         let slot = *window.last().unwrap();
         let next = slot.next();
@@ -1055,8 +1050,8 @@ mod tests {
         assert!(ctx.pool.is_parent_ready(next, &(slot, hash)));
     }
 
-    #[tokio::test]
-    async fn branch_certified_out_of_order() {
+    #[test]
+    fn branch_certified_out_of_order() {
         let mut ctx = setup();
 
         // first see skip votes for later slots
@@ -1065,7 +1060,7 @@ mod tests {
         window.remove(0);
         window.remove(0);
         for slot in window.iter() {
-            ctx.add_skip_votes(*slot, 0..7).await;
+            ctx.add_skip_votes(*slot, 0..7);
         }
 
         let next = window.last().unwrap().next();
@@ -1075,7 +1070,7 @@ mod tests {
         // then see notarization votes for slot 1
         let slot1 = Slot::new(1);
         let hash1: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot1, &hash1, 0..7).await;
+        ctx.add_notar_votes(slot1, &hash1, 0..7);
 
         // branch can only be certified once we saw votes other slots in window
         assert!(ctx.pool.is_parent_ready(next, &(slot1, hash1)));
@@ -1083,15 +1078,15 @@ mod tests {
         assert_eq!(ctx.pool.parents_ready(next).len(), 1);
     }
 
-    #[tokio::test]
-    async fn branch_certified_late_cert() {
+    #[test]
+    fn branch_certified_late_cert() {
         let mut ctx = setup();
 
         // first see skip votes for later slots
         let window = Slot::genesis().slots_in_window().collect::<Vec<_>>();
         assert!(window.len() > 2);
         for slot in window.iter().skip(2) {
-            ctx.add_skip_votes(*slot, 0..7).await;
+            ctx.add_skip_votes(*slot, 0..7);
         }
 
         // no blocks are valid parents yet
@@ -1102,14 +1097,14 @@ mod tests {
         let slot1 = Slot::new(1);
         let hash1: BlockHash = Hash::random_for_test().into();
         let cert = ctx.notar_cert(slot1, &hash1, 7);
-        ctx.add_cert(Cert::Notar(cert)).await.unwrap();
+        ctx.add_cert(Cert::Notar(cert)).unwrap();
 
         // branch can only be certified once we saw votes for parent
         assert!(ctx.pool.is_parent_ready(next, &(slot1, hash1)));
     }
 
-    #[tokio::test]
-    async fn regular_handover() {
+    #[test]
+    fn regular_handover() {
         let mut ctx = setup();
 
         let hashes: Vec<BlockHash> = (0..SLOTS_PER_WINDOW)
@@ -1119,7 +1114,7 @@ mod tests {
         // notarize all slots of first window
         for slot in (1..SLOTS_PER_WINDOW).map(Slot::new) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 0..7).await;
+            ctx.add_notar_votes(slot, hash, 0..7);
         }
 
         assert!(ctx.pool.is_parent_ready(
@@ -1131,8 +1126,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn one_skip_handover() {
+    #[test]
+    fn one_skip_handover() {
         let mut ctx = setup();
 
         let hashes: Vec<BlockHash> = (0..SLOTS_PER_WINDOW)
@@ -1142,12 +1137,11 @@ mod tests {
         // notarize all slots but last one
         for slot in (1..SLOTS_PER_WINDOW - 1).map(Slot::new) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 0..7).await;
+            ctx.add_notar_votes(slot, hash, 0..7);
         }
 
         // skip last slot
-        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 1), 0..7)
-            .await;
+        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 1), 0..7);
 
         assert!(ctx.pool.is_parent_ready(
             Slot::new(SLOTS_PER_WINDOW),
@@ -1158,8 +1152,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn two_skip_handover() {
+    #[test]
+    fn two_skip_handover() {
         let mut ctx = setup();
 
         let hashes: Vec<BlockHash> = (0..SLOTS_PER_WINDOW)
@@ -1169,14 +1163,12 @@ mod tests {
         // notarize all slots but last two
         for slot in (1..SLOTS_PER_WINDOW - 2).map(Slot::new) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 0..7).await;
+            ctx.add_notar_votes(slot, hash, 0..7);
         }
 
         // skip last 2 slots
-        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 2), 0..7)
-            .await;
-        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 1), 0..7)
-            .await;
+        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 2), 0..7);
+        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 1), 0..7);
 
         assert!(ctx.pool.is_parent_ready(
             Slot::new(SLOTS_PER_WINDOW),
@@ -1187,8 +1179,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn skip_window_handover() {
+    #[test]
+    fn skip_window_handover() {
         let mut ctx = setup();
 
         let hashes: Vec<BlockHash> = (0..SLOTS_PER_WINDOW)
@@ -1198,12 +1190,12 @@ mod tests {
         // notarize all slots in first window
         for slot in (1..SLOTS_PER_WINDOW).map(Slot::new) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 0..7).await;
+            ctx.add_notar_votes(slot, hash, 0..7);
         }
 
         // skip all slots in second window
         for slot in (SLOTS_PER_WINDOW..2 * SLOTS_PER_WINDOW).map(Slot::new) {
-            ctx.add_skip_votes(slot, 0..7).await;
+            ctx.add_skip_votes(slot, 0..7);
         }
 
         assert!(ctx.pool.is_parent_ready(
@@ -1215,8 +1207,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn pruning() {
+    #[test]
+    fn pruning() {
         let mut ctx = setup();
 
         let hashes: Vec<BlockHash> = (0..3 * SLOTS_PER_WINDOW + 10)
@@ -1227,7 +1219,7 @@ mod tests {
         for slot in (1..3 * SLOTS_PER_WINDOW).map(Slot::new) {
             let hash: &BlockHash = &hashes[slot.inner() as usize];
             assert!(!ctx.pool.has_final_cert(slot));
-            ctx.add_notar_votes(slot, hash, 0..11).await;
+            ctx.add_notar_votes(slot, hash, 0..11);
             assert!(ctx.pool.has_final_cert(slot));
         }
         let last_slot = Slot::new(3 * SLOTS_PER_WINDOW - 1);
@@ -1243,7 +1235,7 @@ mod tests {
         // NOT enough nodes vote to fast finalize next 10 slots
         for slot in last_slot.future_slots().take(10) {
             let hash: &BlockHash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 0..8).await;
+            ctx.add_notar_votes(slot, hash, 0..8);
             assert!(!ctx.pool.has_final_cert(slot));
         }
         assert_eq!(ctx.pool.finalized_slot(), last_slot);
@@ -1257,7 +1249,7 @@ mod tests {
         // add one more vote each to finalize next 10 slots
         for slot in last_slot.future_slots().take(10) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 8..9).await;
+            ctx.add_notar_votes(slot, hash, 8..9);
             assert!(ctx.pool.has_final_cert(slot));
         }
         assert_eq!(ctx.pool.finalized_slot().inner(), last_slot.inner() + 10);
@@ -1271,8 +1263,8 @@ mod tests {
         assert!(ctx.pool.slot_states.contains_key(&new_last_slot));
     }
 
-    #[tokio::test]
-    async fn duplicate_votes() {
+    #[test]
+    fn duplicate_votes() {
         let mut ctx = setup();
         let slot = Slot::new(0);
 
@@ -1283,26 +1275,26 @@ mod tests {
             &ctx.sks[0],
             ValidatorIndex::new(0),
         );
-        assert_eq!(ctx.add_vote(vote1.clone()).await, Ok(()));
+        assert_eq!(ctx.add_vote(vote1.clone()), Ok(()));
 
         // insert a skip vote from validator 1
         let vote2 = Vote::new_skip(slot, &ctx.sks[1], ValidatorIndex::new(1));
-        assert_eq!(ctx.add_vote(vote2.clone()).await, Ok(()));
+        assert_eq!(ctx.add_vote(vote2.clone()), Ok(()));
 
         // inserting same votes again should fail
-        assert_eq!(ctx.add_vote(vote1).await, Err(AddVoteError::Duplicate));
-        assert_eq!(ctx.add_vote(vote2).await, Err(AddVoteError::Duplicate));
+        assert_eq!(ctx.add_vote(vote1), Err(AddVoteError::Duplicate));
+        assert_eq!(ctx.add_vote(vote2), Err(AddVoteError::Duplicate));
     }
 
-    #[tokio::test]
-    async fn duplicate_certs() {
+    #[test]
+    fn duplicate_certs() {
         let mut ctx = setup();
 
         // insert a notar cert for first slot
         let first_slot = Slot::genesis().next();
         let hash: BlockHash = Hash::random_for_test().into();
         let notar_cert = ctx.notar_cert(first_slot, &hash, 11);
-        assert_eq!(ctx.add_cert(Cert::Notar(notar_cert.clone())).await, Ok(()));
+        assert_eq!(ctx.add_cert(Cert::Notar(notar_cert.clone())), Ok(()));
 
         // insert a skip cert for slot 1
         let second_slot = first_slot.next();
@@ -1310,28 +1302,27 @@ mod tests {
             .map(|v| SkipVote::new(second_slot, &ctx.sks[v as usize], ValidatorIndex::new(v)))
             .collect();
         let skip_cert = SkipCert::try_new(&skip_votes, &[], ctx.validators()).unwrap();
-        assert_eq!(ctx.add_cert(Cert::Skip(skip_cert.clone())).await, Ok(()));
+        assert_eq!(ctx.add_cert(Cert::Skip(skip_cert.clone())), Ok(()));
 
         // inserting same certs again should fail
         assert_eq!(
-            ctx.add_cert(Cert::Notar(notar_cert)).await,
+            ctx.add_cert(Cert::Notar(notar_cert)),
             Err(AddCertError::Duplicate)
         );
         assert_eq!(
-            ctx.add_cert(Cert::Skip(skip_cert)).await,
+            ctx.add_cert(Cert::Skip(skip_cert)),
             Err(AddCertError::Duplicate)
         );
     }
 
-    #[tokio::test]
-    async fn out_of_bounds_votes() {
+    #[test]
+    fn out_of_bounds_votes() {
         let mut ctx = setup();
 
         // fast-finalize a contiguous run of slots so the pruning watermark advances
         let slot = Slot::new(3 * SLOTS_PER_WINDOW - 1);
         for s in 1..=slot.inner() {
-            ctx.add_notar_votes(Slot::new(s), &GENESIS_BLOCK_HASH, 0..11)
-                .await;
+            ctx.add_notar_votes(Slot::new(s), &GENESIS_BLOCK_HASH, 0..11);
         }
         assert_eq!(ctx.pool.finalized_slot(), slot);
         assert_eq!(ctx.pool.first_unpruned_slot(), slot);
@@ -1344,7 +1335,7 @@ mod tests {
                     &ctx.sks[v as usize],
                     ValidatorIndex::new(v),
                 );
-                assert_eq!(ctx.add_vote(vote).await, Err(AddVoteError::SlotOutOfBounds));
+                assert_eq!(ctx.add_vote(vote), Err(AddVoteError::SlotOutOfBounds));
             }
         }
 
@@ -1352,18 +1343,18 @@ mod tests {
         let slot = Slot::new(5 * SLOTS_PER_EPOCH);
         for v in 0..11 {
             let vote = Vote::new_final(slot, &ctx.sks[v as usize], ValidatorIndex::new(v));
-            assert_eq!(ctx.add_vote(vote).await, Err(AddVoteError::SlotOutOfBounds));
+            assert_eq!(ctx.add_vote(vote), Err(AddVoteError::SlotOutOfBounds));
         }
     }
 
-    #[tokio::test]
-    async fn out_of_bounds_certs() {
+    #[test]
+    fn out_of_bounds_certs() {
         let mut ctx = setup();
 
         // fast-finalize a contiguous run of slots so the pruning watermark advances
         let slot = Slot::new(3 * SLOTS_PER_WINDOW - 1);
         for s in 1..=slot.inner() {
-            ctx.fast_finalize(Slot::new(s), &GENESIS_BLOCK_HASH).await;
+            ctx.fast_finalize(Slot::new(s), &GENESIS_BLOCK_HASH);
         }
         assert_eq!(ctx.pool.first_unpruned_slot(), slot);
 
@@ -1380,7 +1371,7 @@ mod tests {
                 .collect();
             let skip_cert = SkipCert::try_new(&skip_votes, &[], ctx.validators()).unwrap();
             assert_eq!(
-                ctx.add_cert(Cert::Skip(skip_cert.clone())).await,
+                ctx.add_cert(Cert::Skip(skip_cert.clone())),
                 Err(AddCertError::SlotOutOfBounds)
             );
         }
@@ -1392,13 +1383,13 @@ mod tests {
             .collect();
         let skip_cert = SkipCert::try_new(&skip_votes, &[], ctx.validators()).unwrap();
         assert_eq!(
-            ctx.add_cert(Cert::Skip(skip_cert.clone())).await,
+            ctx.add_cert(Cert::Skip(skip_cert)),
             Err(AddCertError::SlotOutOfBounds)
         );
     }
 
-    #[tokio::test]
-    async fn slow_finalize_closing_gap_no_double_parent_ready() {
+    #[test]
+    fn slow_finalize_closing_gap_no_double_parent_ready() {
         let mut ctx = setup();
         let next_start = Slot::windows().nth(1).unwrap();
         let gap_slot = next_start.prev();
@@ -1406,25 +1397,25 @@ mod tests {
 
         // fast-finalize every slot below `gap_slot`
         for s in 1..gap_slot.inner() {
-            ctx.fast_finalize(Slot::new(s), &GENESIS_BLOCK_HASH).await;
+            ctx.fast_finalize(Slot::new(s), &GENESIS_BLOCK_HASH);
         }
         // this moves the watermark just below it
         assert_eq!(ctx.pool.first_unpruned_slot(), watermark_slot);
 
         // `gap_slot` gets a final cert but no notarization yet
         let gap_hash: BlockHash = Hash::random_for_test().into();
-        ctx.add_final_votes(gap_slot, 0..7).await;
+        ctx.add_final_votes(gap_slot, 0..7);
         assert!(ctx.pool.has_final_cert(gap_slot));
         assert_eq!(ctx.pool.first_unpruned_slot(), watermark_slot);
 
         // fast-finalize `next_start`, introducing a gap
-        ctx.fast_finalize(next_start, &GENESIS_BLOCK_HASH).await;
+        ctx.fast_finalize(next_start, &GENESIS_BLOCK_HASH);
         assert_eq!(ctx.pool.finalized_slot(), next_start);
         // cannot prune past the gap
         assert_eq!(ctx.pool.first_unpruned_slot(), watermark_slot);
 
         // `gap_slot`'s notarization closes the gap
-        ctx.add_notar_votes(gap_slot, &gap_hash, 0..7).await;
+        ctx.add_notar_votes(gap_slot, &gap_hash, 0..7);
         // jumping the watermark across both slots
         assert_eq!(ctx.pool.first_unpruned_slot(), next_start);
 
@@ -1460,16 +1451,16 @@ mod tests {
         // all nodes vote for first slot (it's fast finalized)
         let slot1 = Slot::genesis().next();
         let hash1: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot1, &hash1, 0..11).await;
+        ctx.add_notar_votes(slot1, &hash1, 0..11);
 
         // we also vote for next slot, see only final votes (it's missing notar)
         let slot2 = slot1.next();
-        ctx.add_final_votes(slot2, 0..7).await;
+        ctx.add_final_votes(slot2, 0..7);
 
         // we also vote for next slot, see no other votes
         let slot3 = slot2.next();
         let hash3: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot3, &hash3, 0..1).await;
+        ctx.add_notar_votes(slot3, &hash3, 0..1);
 
         // initiate standstill
         let outbox = ctx.pool.recover_from_standstill();
@@ -1523,7 +1514,7 @@ mod tests {
         let block0 = random_block_id(slot1.prev());
         let block1 = random_block_id(slot1);
         let block2 = random_block_id(slot1.next());
-        ctx.add_notar_votes(block2.0, &block2.1, 0..11).await;
+        ctx.add_notar_votes(block2.0, &block2.1, 0..11);
 
         // should construct 3 certs (notar-fallback + notar + fast-final)
         for _ in 0..3 {
@@ -1538,8 +1529,8 @@ mod tests {
         );
 
         // add its ancestors
-        ctx.pool.add_block(block2.clone(), block1.clone()).await;
-        ctx.pool.add_block(block1.clone(), block0.clone()).await;
+        ctx.pool.add_block(block2.clone(), block1.clone());
+        ctx.pool.add_block(block1.clone(), block0.clone());
         ctx.forward_outbox();
 
         // should emit ParentReady as a result
@@ -1555,8 +1546,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn safe_to_notar_notar_cert_only() {
+    #[test]
+    fn safe_to_notar_notar_cert_only() {
         let mut ctx = setup();
 
         let slot1 = Slot::genesis().next();
@@ -1566,16 +1557,14 @@ mod tests {
 
         // parent (slot1) is notarized only via a received notar cert
         let cert = ctx.notar_cert(slot1, &hash1, 7);
-        ctx.add_cert(Cert::Notar(cert)).await.unwrap();
+        ctx.add_cert(Cert::Notar(cert)).unwrap();
 
         // register the child block
-        ctx.pool
-            .add_block((slot2, hash2.clone()), (slot1, hash1.clone()))
-            .await;
+        ctx.pool.add_block((slot2, hash2.clone()), (slot1, hash1));
 
         // we skip slot2, but 40% of others notarize the child
-        ctx.add_skip_votes(slot2, 0..1).await;
-        ctx.add_notar_votes(slot2, &hash2, 1..6).await;
+        ctx.add_skip_votes(slot2, 0..1);
+        ctx.add_notar_votes(slot2, &hash2, 1..6);
 
         // child should now be safe-to-notar
         assert!(
@@ -1584,8 +1573,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn safe_to_notar_fast_final_cert_only() {
+    #[test]
+    fn safe_to_notar_fast_final_cert_only() {
         let mut ctx = setup();
 
         let slot1 = Slot::genesis().next();
@@ -1595,16 +1584,14 @@ mod tests {
 
         // parent (slot1) is fast-finalized only via a received cert
         let cert = ctx.fast_final_cert(slot1, &hash1, 9);
-        ctx.add_cert(Cert::FastFinal(cert)).await.unwrap();
+        ctx.add_cert(Cert::FastFinal(cert)).unwrap();
 
         // register the child block
-        ctx.pool
-            .add_block((slot2, hash2.clone()), (slot1, hash1.clone()))
-            .await;
+        ctx.pool.add_block((slot2, hash2.clone()), (slot1, hash1));
 
         // we skip slot2, but 40% of others notarize the child
-        ctx.add_skip_votes(slot2, 0..1).await;
-        ctx.add_notar_votes(slot2, &hash2, 1..6).await;
+        ctx.add_skip_votes(slot2, 0..1);
+        ctx.add_notar_votes(slot2, &hash2, 1..6);
 
         // child should now be safe-to-notar
         assert!(

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -3,20 +3,25 @@
 
 //! Main voting logic for the consensus protocol.
 //!
-//! Besides [`super::Pool`], [`Votor`] is the other main internal component Alpenglow.
+//! Besides [`super::Pool`], [`VotorState`] is the other main internal component of Alpenglow.
 //! It handles the main voting decisions for the consensus protocol.
-//! As input it receives events from [`super::Pool`] (on a [`PoolEvent`] channel),
-//! from [`super::Blockstore`] (on a [`BlockstoreEvent`] channel),
-//! and its own internal timeout events.
-//! Votor keeps its own internal state for each slot based on previous events and votes.
+//! As input it receives events from [`super::Pool`] and [`super::Blockstore`],
+//! as well as its own internal timeout events.
+//! It keeps its own internal state for each slot based on previous events and votes.
 //!
-//! Votor has access to an instance of [`All2All`] for broadcasting votes.
+//! [`VotorState`] is a pure, synchronous state machine: it performs no I/O,
+//! tracks timeouts as deadlines instead of sleeping, and queues the votes it
+//! decides to cast in an internal outbox. The [`Votor`] task wraps it, feeding
+//! it events from its channels and firing due timeouts, and broadcasts the
+//! queued votes over an [`All2All`] instance.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use std::sync::Arc;
+use std::time::Instant;
 
 use log::{debug, trace, warn};
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::Receiver;
 
 use super::blockstore::{BlockInfo, BlockstoreEvent};
 use super::pool::PoolEvent;
@@ -26,33 +31,19 @@ use crate::crypto::aggsig::SecretKey;
 use crate::crypto::merkle::{BlockHash, GENESIS_BLOCK_HASH};
 use crate::{All2All, BlockId, Slot, ValidatorIndex};
 
-/// Votor implements the decision process of which votes to cast.
+/// Votor task: drives the `VotorState` state machine.
 ///
-/// It keeps some state for each slot and checks the conditions for voting.
+/// Feeds `VotorState` the events received from [`super::Pool`] and
+/// [`super::Blockstore`] as well as its due timeouts, then broadcasts the
+/// votes and certificates it queued via [`All2All`].
 pub struct Votor<A: All2All> {
-    /// Per-slot voting state, keyed by slot.
-    slots: BTreeMap<Slot, SlotState>,
-    /// Highest slot for which we have seen a (slow) final or fast-final cert.
-    ///
-    /// This is *not* equivalent to e.g. [`super::Pool::finalized_slot`],
-    /// because we may have seen a (slow) final cert without a matching notar.
-    /// We only use it to decide when our own vote for a slot no longer matters,
-    /// at which point the per-slot state for earlier leader windows is pruned.
-    highest_final_cert_slot: Slot,
-
-    /// Own validator index.
-    validator_index: ValidatorIndex,
-    /// Secret key used to sign votes.
-    voting_key: SecretKey,
+    /// The actual voting state machine.
+    state: VotorState,
 
     /// Channel for receiving events from Pool.
     pool_receiver: Receiver<PoolEvent>,
     /// Channel for receiving events from Blockstore.
     blockstore_receiver: Receiver<BlockstoreEvent>,
-    /// Channel for receiving internal timeout events.
-    timeout_receiver: Receiver<VotorTimeout>,
-    /// Sender side of the timeout channel. Used for scheduling timeouts.
-    timeout_sender: Sender<VotorTimeout>,
     /// [`All2All`] instance used to broadcast votes.
     all2all: Arc<A>,
 }
@@ -71,8 +62,146 @@ impl<A: All2All> Votor<A> {
         blockstore_receiver: Receiver<BlockstoreEvent>,
         all2all: Arc<A>,
     ) -> Self {
-        let (timeout_sender, timeout_receiver) = tokio::sync::mpsc::channel(256);
+        Self {
+            state: VotorState::new(validator_index, voting_key, Instant::now()),
+            pool_receiver,
+            blockstore_receiver,
+            all2all,
+        }
+    }
 
+    /// Handles the voting (leader and non-leader) side of consensus protocol.
+    ///
+    /// Checks consensus conditions and broadcasts new votes.
+    /// Returns once either input channel is closed (node shutdown).
+    #[fastrace::trace]
+    pub async fn voting_loop(&mut self) {
+        loop {
+            tokio::select! {
+                event = self.pool_receiver.recv() => match event {
+                    Some(event) => self.handle_pool_event(event).await,
+                    None => break,
+                },
+                event = self.blockstore_receiver.recv() => match event {
+                    Some(event) => self.handle_blockstore_event(event).await,
+                    None => break,
+                },
+                () = sleep_until_next(self.state.next_timeout()) => {
+                    self.handle_due_timeouts().await;
+                }
+            }
+        }
+    }
+
+    /// Feeds a pool event to the state machine and broadcasts resulting votes.
+    async fn handle_pool_event(&mut self, event: PoolEvent) {
+        self.state.handle_pool_event(event, Instant::now());
+        self.flush_broadcasts().await;
+    }
+
+    /// Feeds a blockstore event to the state machine and broadcasts resulting votes.
+    async fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
+        self.state.handle_blockstore_event(event);
+        self.flush_broadcasts().await;
+    }
+
+    /// Feeds a timeout event to the state machine and broadcasts resulting votes.
+    #[cfg(test)]
+    async fn handle_timeout_event(&mut self, event: VotorTimeout) {
+        self.state.handle_timeout_event(event);
+        self.flush_broadcasts().await;
+    }
+
+    /// Fires all due timeouts on the state machine and broadcasts resulting votes.
+    async fn handle_due_timeouts(&mut self) {
+        self.state.handle_due_timeouts(Instant::now());
+        self.flush_broadcasts().await;
+    }
+
+    /// Broadcasts all queued consensus messages on a best-effort basis.
+    ///
+    /// A failure of the underlying [`All2All`] network is logged and otherwise
+    /// ignored: it must not bring down the voting loop, which has to keep running
+    /// to preserve liveness.
+    ///
+    /// The message is genuinely lost — [`VotorState`] commits the state transition
+    /// the vote represents (`voted`, `retired`) when it enqueues the message, well
+    /// before this runs, and nothing re-sends it. That is deliberate rather than an
+    /// oversight. [`All2All`] rides on UDP, where a successful send only means the
+    /// datagram reached the kernel, so votes are dropped in flight as a matter of
+    /// course; a vote lost to a local send error is no different, protocol-wise,
+    /// from one lost on the wire, and the protocol already covers that case with
+    /// timeouts, skip votes and standstill recovery. Retrying here would buy back
+    /// only the sliver of losses that surface as an errno, at the cost of
+    /// reordering this node's own votes against each other.
+    ///
+    /// NOTE: a *persistent* failure (e.g. a misconfigured firewall or a full
+    /// partition) means this node stops contributing to consensus while only
+    /// logging. Once there is a metrics system, this should also bump a failure
+    /// counter so persistent failures become alertable.
+    ///
+    /// NOTE: this node's own votes reach its own [`super::Pool`] only by coming
+    /// back over [`All2All`] — Votor has no direct path to Pool — so a failure here
+    /// also means [`super::Pool::recover_from_standstill`] cannot replay the vote:
+    /// it re-broadcasts what Pool holds, and Pool never saw it. Removing that
+    /// dependency means delivering own votes to Pool directly, not retrying sends.
+    async fn flush_broadcasts(&mut self) {
+        for msg in self.state.take_broadcasts() {
+            if let Err(err) = self.all2all.broadcast(&msg).await {
+                warn!("failed to broadcast consensus message: {err}");
+            }
+        }
+    }
+}
+
+/// Sleeps until the given `deadline`, or forever if there is none.
+async fn sleep_until_next(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline.into()).await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Votor's state machine: implements the decision process of which votes to cast.
+///
+/// It keeps some state for each slot and checks the conditions for voting.
+///
+/// This is a pure, synchronous state machine: it performs no I/O, tracks its
+/// timeouts as deadlines (see [`Self::next_timeout`]) rather than sleeping, and
+/// queues the votes and certificates it wants broadcast in an internal outbox,
+/// drained via [`Self::take_broadcasts`].
+pub(crate) struct VotorState {
+    /// Per-slot voting state, keyed by slot.
+    slots: BTreeMap<Slot, SlotState>,
+    /// Highest slot for which we have seen a (slow) final or fast-final cert.
+    ///
+    /// This is *not* equivalent to e.g. [`super::Pool::finalized_slot`],
+    /// because we may have seen a (slow) final cert without a matching notar.
+    /// We only use it to decide when our own vote for a slot no longer matters,
+    /// at which point the per-slot state for earlier leader windows is pruned.
+    highest_final_cert_slot: Slot,
+
+    /// Own validator index.
+    validator_index: ValidatorIndex,
+    /// Secret key used to sign votes.
+    voting_key: SecretKey,
+
+    /// Pending timeout deadlines, earliest first.
+    timeouts: BinaryHeap<Reverse<(Instant, VotorTimeout)>>,
+    /// Consensus messages queued for (best-effort) broadcast,
+    /// drained via [`Self::take_broadcasts`].
+    broadcasts: Vec<ConsensusMessage>,
+}
+
+impl VotorState {
+    /// Creates a new voting state machine with empty per-slot state.
+    ///
+    /// Timeouts for the genesis window are scheduled relative to `now`.
+    pub(crate) fn new(
+        validator_index: ValidatorIndex,
+        voting_key: SecretKey,
+        now: Instant,
+    ) -> Self {
         // pre-populate the dummy genesis block's state
         let genesis_state = SlotState {
             voted: true,
@@ -86,34 +215,16 @@ impl<A: All2All> Votor<A> {
         };
         let slots = [(Slot::genesis(), genesis_state)].into_iter().collect();
 
-        let votor = Self {
+        let mut state = Self {
             slots,
             highest_final_cert_slot: Slot::genesis(),
             validator_index,
             voting_key,
-            pool_receiver,
-            blockstore_receiver,
-            timeout_receiver,
-            timeout_sender,
-            all2all,
+            timeouts: BinaryHeap::new(),
+            broadcasts: Vec::new(),
         };
-        votor.set_timeouts(Slot::new(0));
-        votor
-    }
-
-    /// Handles the voting (leader and non-leader) side of consensus protocol.
-    ///
-    /// Checks consensus conditions and broadcasts new votes.
-    #[fastrace::trace]
-    pub async fn voting_loop(&mut self) {
-        loop {
-            tokio::select! {
-                Some(event) = self.pool_receiver.recv() => self.handle_pool_event(event).await,
-                Some(event) = self.blockstore_receiver.recv() => self.handle_blockstore_event(event).await,
-                Some(event) = self.timeout_receiver.recv() => self.handle_timeout_event(event).await,
-                else => break,
-            }
-        }
+        state.set_timeouts(Slot::new(0), now);
+        state
     }
 
     /// Returns `true` iff the given slot has been retired.
@@ -173,7 +284,7 @@ impl<A: All2All> Votor<A> {
         }
     }
 
-    async fn handle_pool_event(&mut self, event: PoolEvent) {
+    fn handle_pool_event(&mut self, event: PoolEvent, now: Instant) {
         let slot = event.slot();
         if self.should_ignore_pool_event(&event) {
             trace!("ignoring pool event for old or retired slot {slot}");
@@ -188,47 +299,47 @@ impl<A: All2All> Votor<A> {
                     parent_hash.short_hex()
                 );
                 self.state_mut(slot).parents_ready.insert(parent);
-                self.check_pending_blocks().await;
-                self.set_timeouts(slot);
+                self.check_pending_blocks();
+                self.set_timeouts(slot, now);
             }
             PoolEvent::SafeToNotar((slot, hash)) => {
                 debug!("voted notar-fallback in slot {slot}");
                 let vote =
                     Vote::new_notar_fallback(slot, hash, &self.voting_key, self.validator_index);
-                self.broadcast(vote).await;
-                self.try_skip_window(slot).await;
+                self.enqueue_broadcast(vote);
+                self.try_skip_window(slot);
             }
             PoolEvent::SafeToSkip(slot) => {
                 debug!("voted skip-fallback in slot {slot}");
                 let vote = Vote::new_skip_fallback(slot, &self.voting_key, self.validator_index);
-                self.broadcast(vote).await;
-                self.try_skip_window(slot).await;
+                self.enqueue_broadcast(vote);
+                self.try_skip_window(slot);
             }
-            PoolEvent::CertCreated(cert) => self.handle_cert_created(cert).await,
+            PoolEvent::CertCreated(cert) => self.handle_cert_created(cert, now),
             PoolEvent::Standstill(_, certs, votes) => {
                 for cert in certs {
-                    self.broadcast(cert).await;
+                    self.enqueue_broadcast(cert);
                 }
                 for vote in votes {
-                    self.broadcast(vote).await;
+                    self.enqueue_broadcast(vote);
                 }
             }
         }
     }
 
     /// Updates state based on a newly created certificate and re-broadcasts it.
-    async fn handle_cert_created(&mut self, cert: Cert) {
+    fn handle_cert_created(&mut self, cert: Cert, now: Instant) {
         match &cert {
             Cert::Notar(notar_cert) => {
                 let hash = notar_cert.block_hash();
                 // need to mark notarized BEFORE trying finalization
                 self.state_mut(cert.slot()).block_notarized = Some(hash.clone());
-                self.try_final(cert.slot(), hash).await;
+                self.try_final(cert.slot(), hash);
             }
             Cert::Final(_) | Cert::FastFinal(_) => {
                 // makes sure we eventually vote skip for these slots,
                 // even if we never issued a ParentReady for this window
-                self.set_timeouts(cert.slot().first_slot_in_window());
+                self.set_timeouts(cert.slot().first_slot_in_window(), now);
 
                 // Votor can already be pruned upon regular final cert,
                 // whereas Pool would only be pruned upon actual finalization,
@@ -239,43 +350,24 @@ impl<A: All2All> Votor<A> {
             Cert::Skip(_) | Cert::NotarFallback(_) => {}
         }
 
-        self.broadcast(cert).await;
+        self.enqueue_broadcast(cert);
     }
 
-    /// Broadcasts a consensus message to all other nodes, best-effort.
+    /// Queues a consensus message for broadcast by the driving task.
     ///
-    /// A failure of the underlying [`All2All`] network is logged and otherwise
-    /// ignored: it must not bring down the voting loop, which has to keep running
-    /// to preserve liveness.
-    ///
-    /// The message is genuinely lost — the callers commit the state transition the
-    /// vote represents (`voted`, `retired`) as soon as this returns, and nothing
-    /// re-sends it. That is deliberate rather than an oversight. [`All2All`] rides
-    /// on UDP, where a successful send only means the datagram reached the kernel,
-    /// so votes are dropped in flight as a matter of course; a vote lost to a local
-    /// send error is no different, protocol-wise, from one lost on the wire, and
-    /// the protocol already covers that case with timeouts, skip votes and
-    /// standstill recovery. Retrying here would buy back only the sliver of losses
-    /// that surface as an errno, at the cost of reordering this node's own votes
-    /// against each other.
-    ///
-    /// NOTE: a *persistent* failure (e.g. a misconfigured firewall or a full
-    /// partition) means this node stops contributing to consensus while only
-    /// logging. Once there is a metrics system, this should also bump a failure
-    /// counter so persistent failures become alertable.
-    ///
-    /// NOTE: this node's own votes reach its own [`super::Pool`] only by coming
-    /// back over [`All2All`] — Votor has no direct path to Pool — so a failure here
-    /// also means [`super::Pool::recover_from_standstill`] cannot replay the vote:
-    /// it re-broadcasts what Pool holds, and Pool never saw it. Removing that
-    /// dependency means delivering own votes to Pool directly, not retrying sends.
-    async fn broadcast(&self, msg: impl Into<ConsensusMessage>) {
-        if let Err(err) = self.all2all.broadcast(&msg.into()).await {
-            warn!("failed to broadcast consensus message: {err}");
-        }
+    /// Buffered rather than sent so this state machine stays free of I/O; the
+    /// [`Votor`] task drains the queue via [`Self::take_broadcasts`] and performs
+    /// the actual (best-effort) [`All2All`] broadcast.
+    fn enqueue_broadcast(&mut self, msg: impl Into<ConsensusMessage>) {
+        self.broadcasts.push(msg.into());
     }
 
-    async fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
+    /// Drains and returns the consensus messages queued for broadcast.
+    pub(crate) fn take_broadcasts(&mut self) -> Vec<ConsensusMessage> {
+        std::mem::take(&mut self.broadcasts)
+    }
+
+    fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
         let slot = event.slot();
         if slot <= self.highest_final_cert_slot || self.is_retired(slot) {
             trace!("ignoring blockstore event for old or retired slot {slot}");
@@ -288,7 +380,7 @@ impl<A: All2All> Votor<A> {
             }
             BlockstoreEvent::InvalidBlock(slot) => {
                 warn!("invalid block from leader for slot {slot}, skipping window");
-                self.try_skip_window(slot).await;
+                self.try_skip_window(slot);
             }
             BlockstoreEvent::Block { slot, block_info } => {
                 if self.has_voted(slot) {
@@ -296,8 +388,8 @@ impl<A: All2All> Votor<A> {
                     warn!("not voting for block {h} in slot {slot}, already voted");
                     return;
                 }
-                if self.try_notar(slot, block_info.clone()).await {
-                    self.check_pending_blocks().await;
+                if self.try_notar(slot, block_info.clone()) {
+                    self.check_pending_blocks();
                 } else {
                     self.state_mut(slot).pending_block = Some(block_info);
                 }
@@ -305,7 +397,7 @@ impl<A: All2All> Votor<A> {
         }
     }
 
-    async fn handle_timeout_event(&mut self, event: VotorTimeout) {
+    fn handle_timeout_event(&mut self, event: VotorTimeout) {
         let slot = event.slot();
         if slot <= self.highest_final_cert_slot || self.is_retired(slot) {
             trace!("ignoring timeout for old or retired slot {slot}");
@@ -316,50 +408,71 @@ impl<A: All2All> Votor<A> {
             VotorTimeout::Timeout(slot) => {
                 trace!("timeout for slot {slot}");
                 if !self.has_voted(slot) {
-                    self.try_skip_window(slot).await;
+                    self.try_skip_window(slot);
                 }
             }
             VotorTimeout::TimeoutCrashedLeader(slot) => {
                 trace!("timeout (crashed leader) for slot {slot}");
                 if !self.received_shred(slot) && !self.has_voted(slot) {
-                    self.try_skip_window(slot).await;
+                    self.try_skip_window(slot);
                 }
             }
         }
     }
 
-    /// Sets timeouts for the leader window starting at the given `slot`.
+    /// Fires all timeouts that are due at `now`.
+    pub(crate) fn handle_due_timeouts(&mut self, now: Instant) {
+        while let Some(Reverse((deadline, _))) = self.timeouts.peek() {
+            if *deadline > now {
+                break;
+            }
+            let Reverse((_, event)) = self.timeouts.pop().expect("peeked entry exists");
+            self.handle_timeout_event(event);
+        }
+    }
+
+    /// Returns the earliest pending timeout deadline, if any.
+    pub(crate) fn next_timeout(&self) -> Option<Instant> {
+        self.timeouts.peek().map(|Reverse((deadline, _))| *deadline)
+    }
+
+    /// Schedules timeouts for the leader window starting at the given `slot`.
+    ///
+    /// Deadlines are computed relative to `now`, mirroring the schedule the
+    /// leader is expected to keep: the crashed-leader timeout fires after
+    /// `DELTA_TIMEOUT + DELTA_FIRST_SLICE`, then one timeout per slot in the
+    /// window, `DELTA_BLOCK` apart. They fire via [`Self::handle_due_timeouts`].
     ///
     /// # Panics
     ///
     /// Panics if `slot` is not the first slot of a window.
-    fn set_timeouts(&self, slot: Slot) {
+    fn set_timeouts(&mut self, slot: Slot, now: Instant) {
         assert!(slot.is_start_of_window());
 
         trace!(
             "setting timeouts for slots {slot}-{}",
             slot.last_slot_in_window()
         );
-        let sender = self.timeout_sender.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(DELTA_TIMEOUT + DELTA_FIRST_SLICE).await;
-            // HACK: ignoring errors to prevent panic when shutting down votor
-            let _ = sender.send(VotorTimeout::TimeoutCrashedLeader(slot)).await;
-            for s in slot.slots_in_window() {
-                if s.is_start_of_window() {
-                    tokio::time::sleep(DELTA_BLOCK.saturating_sub(DELTA_FIRST_SLICE)).await;
-                } else {
-                    tokio::time::sleep(DELTA_BLOCK).await;
-                }
-                let _ = sender.send(VotorTimeout::Timeout(s)).await;
-            }
-        });
+        let mut deadline = now + DELTA_TIMEOUT + DELTA_FIRST_SLICE;
+        self.timeouts.push(Reverse((
+            deadline,
+            VotorTimeout::TimeoutCrashedLeader(slot),
+        )));
+        for s in slot.slots_in_window() {
+            deadline += if s.is_start_of_window() {
+                DELTA_BLOCK.saturating_sub(DELTA_FIRST_SLICE)
+            } else {
+                DELTA_BLOCK
+            };
+            self.timeouts
+                .push(Reverse((deadline, VotorTimeout::Timeout(s))));
+        }
     }
 
     /// Sends a notarization vote for the given block if the conditions are met.
     ///
     /// Returns `true` iff we decided to send a notarization vote for the block.
-    async fn try_notar(&mut self, slot: Slot, block_info: BlockInfo) -> bool {
+    fn try_notar(&mut self, slot: Slot, block_info: BlockInfo) -> bool {
         assert!(slot >= self.first_unpruned_slot());
         if self.has_voted(slot) {
             return false;
@@ -390,17 +503,17 @@ impl<A: All2All> Votor<A> {
         }
         debug!("voted notar for slot {slot}");
         let vote = Vote::new_notar(slot, hash.clone(), &self.voting_key, self.validator_index);
-        self.broadcast(vote).await;
+        self.enqueue_broadcast(vote);
         let state = self.state_mut(slot);
         state.voted = true;
         state.voted_notar = Some(hash.clone());
         state.pending_block = None;
-        self.try_final(slot, &hash).await;
+        self.try_final(slot, &hash);
         true
     }
 
     /// Sends a finalization vote for the given block if the conditions are met.
-    async fn try_final(&mut self, slot: Slot, hash: &BlockHash) {
+    fn try_final(&mut self, slot: Slot, hash: &BlockHash) {
         assert!(slot >= self.first_unpruned_slot());
         let state = self.slots.get(&slot);
         let notarized = state.and_then(|s| s.block_notarized.as_ref()) == Some(hash);
@@ -408,7 +521,7 @@ impl<A: All2All> Votor<A> {
         let not_bad = !state.is_some_and(|s| s.bad_window);
         if notarized && voted_notar && not_bad {
             let vote = Vote::new_final(slot, &self.voting_key, self.validator_index);
-            self.broadcast(vote).await;
+            self.enqueue_broadcast(vote);
             self.state_mut(slot).retired = true;
         }
     }
@@ -424,7 +537,7 @@ impl<A: All2All> Votor<A> {
     /// happen to arrive in, which is not guaranteed — they are forwarded off the
     /// write lock and can be reordered across tasks. Withholding a final vote is
     /// always safe: it can cost this slot the fast path, never liveness.
-    async fn try_skip_window(&mut self, slot: Slot) {
+    fn try_skip_window(&mut self, slot: Slot) {
         assert!(slot >= self.first_unpruned_slot());
         trace!("try skip window of slot {slot}");
         for s in slot.slots_in_window() {
@@ -435,13 +548,13 @@ impl<A: All2All> Votor<A> {
             }
             state.voted = true;
             let vote = Vote::new_skip(s, &self.voting_key, self.validator_index);
-            self.broadcast(vote).await;
+            self.enqueue_broadcast(vote);
             debug!("voted skip for slot {s}");
         }
     }
 
     /// Checks if we can vote on any of the pending blocks by now.
-    async fn check_pending_blocks(&mut self) {
+    fn check_pending_blocks(&mut self) {
         let slots = self
             .slots
             .iter()
@@ -450,7 +563,7 @@ impl<A: All2All> Votor<A> {
             .collect::<Vec<_>>();
         for slot in slots {
             if let Some(block_info) = self.slots.get(&slot).and_then(|s| s.pending_block.clone()) {
-                self.try_notar(slot, block_info).await;
+                self.try_notar(slot, block_info);
             }
         }
     }
@@ -464,8 +577,10 @@ impl<A: All2All> Votor<A> {
     }
 }
 
-/// Internal timeout events generated by [`Votor`] itself.
-#[derive(Debug)]
+/// Internal timeout events generated by [`VotorState`] itself.
+///
+/// Ordered so timeouts can serve as tie-breakers in the deadline heap.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum VotorTimeout {
     /// Regular timeout for the given slot has fired.
     Timeout(Slot),
@@ -707,14 +822,14 @@ mod tests {
         votor
             .handle_blockstore_event(BlockstoreEvent::Block { slot, block_info })
             .await;
-        assert_eq!(votor.slots[&slot].voted_notar.as_ref(), Some(&hash));
+        assert_eq!(votor.state.slots[&slot].voted_notar.as_ref(), Some(&hash));
 
         // only now does the leader's misbehavior surface
         votor
             .handle_blockstore_event(BlockstoreEvent::InvalidBlock(slot))
             .await;
         assert!(
-            votor.slots[&slot].bad_window,
+            votor.state.slots[&slot].bad_window,
             "an invalid block must taint the window even for an already-voted slot"
         );
 
@@ -728,7 +843,7 @@ mod tests {
         votor.handle_pool_event(PoolEvent::CertCreated(cert)).await;
 
         assert!(
-            !votor.slots[&slot].retired,
+            !votor.state.slots[&slot].retired,
             "cast a final vote for a slot whose leader we proved misbehaving"
         );
     }
@@ -915,7 +1030,7 @@ mod tests {
             let event = BlockstoreEvent::FirstShred(Slot::new(i));
             votor.handle_blockstore_event(event).await;
         }
-        assert!((0..=highest.inner()).all(|i| votor.slots.contains_key(&Slot::new(i))));
+        assert!((0..=highest.inner()).all(|i| votor.state.slots.contains_key(&Slot::new(i))));
 
         // finalizing a mid-window slot should drop only the slots before its window
         let Vote::Final(final_vote) =
@@ -926,19 +1041,19 @@ mod tests {
         let cert = Cert::Final(FinalCert::new(&[final_vote], ctx.epoch_info.validators()));
         let event = PoolEvent::CertCreated(cert);
         votor.handle_pool_event(event).await;
-        assert_eq!(votor.highest_final_cert_slot, finalized);
+        assert_eq!(votor.state.highest_final_cert_slot, finalized);
 
         // the whole finalized window is kept
-        assert!(votor.slots.keys().all(|s| *s >= window_start));
+        assert!(votor.state.slots.keys().all(|s| *s >= window_start));
         for slot in window_start.slots_in_window() {
             assert!(
-                votor.slots.contains_key(&slot),
+                votor.state.slots.contains_key(&slot),
                 "slot {slot} in finalized window should be retained",
             );
         }
 
         // earlier windows are dropped
-        assert!(!votor.slots.contains_key(&Slot::genesis()));
-        assert!(!votor.slots.contains_key(&window_start.prev()));
+        assert!(!votor.state.slots.contains_key(&Slot::genesis()));
+        assert!(!votor.state.slots.contains_key(&window_start.prev()));
     }
 }

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -477,9 +477,7 @@ where
                 // store shred, then forward buffered events off the write lock
                 let (res, events) = {
                     let mut blockstore = self.blockstore.write().await;
-                    let res = blockstore
-                        .add_shred_from_repair(block_hash.clone(), validated)
-                        .await;
+                    let res = blockstore.add_shred_from_repair(block_hash.clone(), validated);
                     (res, blockstore.take_events())
                 };
                 self.event_forwarder.forward_blockstore_events(events).await;
@@ -487,8 +485,7 @@ where
                     assert_eq!(&block_info.hash, block_hash);
                     let outbox = {
                         let mut pool = self.pool.write().await;
-                        pool.add_block((*slot, block_info.hash), block_info.parent)
-                            .await;
+                        pool.add_block((*slot, block_info.hash), block_info.parent);
                         pool.take_outbox()
                     };
                     self.apply_pool_outbox(outbox).await;
@@ -814,7 +811,7 @@ mod tests {
         let mut b = ctx.blockstore.write().await;
         for slice_shreds in shreds.clone() {
             for shred in slice_shreds {
-                let _ = b.add_shred_from_dissemination(shred).await;
+                let _ = b.add_shred_from_dissemination(shred);
             }
         }
         drop(b);


### PR DESCRIPTION
The Pool and Blockstore traits were only async because they used to send events on channels; since they now buffer side-effects in outboxes, drop the vestigial async so the compiler enforces that nothing awaits under their write locks.

Extract Votor's decision logic into VotorState, a pure synchronous state machine: timeouts become a deadline heap (next_timeout/handle_due_timeouts) instead of spawned sleeper tasks (removing the shutdown-send HACK), and votes are queued in a broadcast outbox. The Votor task is now a thin loop that feeds the state machine from its channels and deadline, and performs the best-effort All2All broadcasts.

Step 2 of the sans-IO consensus core migration.