### PR TITLE
refactor: single sans-IO consensus core driven by one task

### DIFF
--- a/src/bin/performance_test.rs
+++ b/src/bin/performance_test.rs
@@ -166,25 +166,25 @@ async fn latency_test(num_nodes: usize, duration_secs: u64) {
     // start `num_nodes` nodes
     let nodes = create_test_nodes(num_nodes as u64).await;
     let mut node_cancel_tokens = Vec::new();
-    let mut pools = Vec::new();
+    let mut finalized_watches = Vec::new();
     for node in nodes {
-        pools.push(node.get_pool());
+        finalized_watches.push(node.finalized_slot());
         node_cancel_tokens.push(node.get_cancel_token());
         tokio::spawn(node.run());
     }
 
-    // spawn a thread checking pool for progress
+    // spawn a thread checking finalization progress
     let cancel_tokens = node_cancel_tokens.clone();
     let liveness_tester = tokio::spawn(async move {
-        let mut finalized = vec![Slot::new(0); pools.len()];
-        let mut times = vec![Instant::now(); pools.len()];
+        let mut finalized = vec![Slot::new(0); finalized_watches.len()];
+        let mut times = vec![Instant::now(); finalized_watches.len()];
         loop {
             tokio::time::sleep(Duration::from_millis(1)).await;
-            for (i, pool) in pools.iter().enumerate() {
+            for (i, watch) in finalized_watches.iter().enumerate() {
                 if cancel_tokens[i].is_cancelled() {
                     continue;
                 }
-                let new_finalized = pool.read().await.finalized_slot();
+                let new_finalized = *watch.borrow();
                 if new_finalized > finalized[i] {
                     info!(
                         "node {} finalized new block {} after {:.2} ms",

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -9,8 +9,10 @@
 //!
 //! Most important component data structures defined in this module are:
 //! - [`Blockstore`] holds individual shreds and reconstructed blocks for each slot.
-//! - [`Pool`] holds votes and certificates for each slot.
-//! - [`Votor`] handles the main voting logic.
+//! - [`PoolImpl`] holds votes and certificates for each slot.
+//! - `VotorState` handles the main voting logic.
+//! - `ConsensusCore` combines the latter two into one synchronous state
+//!   machine, driven by a single `Driver` task that performs all I/O.
 //!
 //! Some other data types for consensus are also defined here:
 //! - [`Cert`] represents a certificate of votes of a specific type.
@@ -20,6 +22,8 @@
 mod block_producer;
 mod blockstore;
 mod cert;
+pub(crate) mod core;
+mod driver;
 mod epoch_info;
 mod pool;
 mod validated_cert;
@@ -35,9 +39,9 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use fastrace::Span;
 use fastrace::future::FutureExt;
-use log::{debug, trace, warn};
+use log::{debug, trace};
 use static_assertions::const_assert;
-use tokio::sync::{RwLock, mpsc};
+use tokio::sync::{RwLock, mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use wincode::{SchemaRead, SchemaWrite};
 
@@ -45,21 +49,22 @@ pub use self::blockstore::{
     AddShredError, BlockInfo, Blockstore, BlockstoreEvent, BlockstoreImpl, SharedBlockstore,
 };
 pub use self::cert::{Cert, CertError, NotarCert};
+use self::core::{ConsensusCore, Input};
+use self::driver::{Driver, ParentReadyMap};
 pub use self::epoch_info::{EpochInfo, ValidatorEpochInfo};
 #[cfg(feature = "test-utils")]
 pub use self::pool::bench_replay_votes;
-pub use self::pool::{AddVoteError, Pool, PoolEvent, PoolImpl, PoolOutbox, SharedPool};
+pub use self::pool::{AddVoteError, PoolEvent, PoolImpl, PoolOutbox};
 pub use self::validated_cert::{CertValidationError, ValidatedCert};
 pub use self::validated_vote::{ValidatedVote, VoteValidationError};
 pub use self::vote::{FinalVote, NotarFallbackVote, NotarVote, SkipFallbackVote, SkipVote, Vote};
-pub use self::votor::Votor;
 use crate::consensus::block_producer::BlockProducer;
 use crate::crypto::{aggsig, signature};
 use crate::network::{RepairRequesterNetwork, RepairResponderNetwork, TransactionNetwork};
 use crate::repair::{Repair, RepairRequestHandler};
 use crate::shredder::{Shred, ValidatedShred};
 use crate::types::Fraction;
-use crate::{All2All, BlockId, Disseminator, Slot, ValidatorInfo};
+use crate::{All2All, Disseminator, Slot, ValidatorInfo};
 
 /// Time bound assumed on network transmission delays during periods of synchrony.
 pub const DELTA: Duration = Duration::from_millis(250);
@@ -104,69 +109,6 @@ impl From<Cert> for ConsensusMessage {
     }
 }
 
-/// Forwards side-effects drained from the Blockstore and Pool outboxes to Votor
-/// and the repair loop *after* the producing task has released the write lock.
-///
-/// The Blockstore and Pool buffer their events instead of sending them while
-/// holding their write lock: a blocking send under the lock would let a slow or
-/// stalled Votor jam every other task contending for that lock, while a
-/// non-blocking send would have to drop the event (which for a reconstructed-block
-/// event silently costs this node its vote for that block, with no retry path).
-/// Each task that mutates the Blockstore/Pool drains the outbox (with
-/// [`Blockstore::take_events`] / [`Pool::take_outbox`]) and hands it here; the
-/// blocking send then back-pressures that (ingest) task instead of dropping the
-/// event or stalling the lock.
-///
-/// Cloneable so the message loop, the repair loop and the block producer can each
-/// forward the events they produce.
-#[derive(Clone)]
-pub(crate) struct EventForwarder {
-    /// Blockstore events destined for Votor.
-    blockstore_events: mpsc::Sender<BlockstoreEvent>,
-    /// Pool events destined for Votor.
-    pool_events: mpsc::Sender<PoolEvent>,
-    /// Repair requests destined for the repair loop.
-    repairs: mpsc::Sender<BlockId>,
-}
-
-impl EventForwarder {
-    /// Creates a forwarder over Votor's event channels and the repair channel.
-    pub(crate) fn new(
-        blockstore_events: mpsc::Sender<BlockstoreEvent>,
-        pool_events: mpsc::Sender<PoolEvent>,
-        repairs: mpsc::Sender<BlockId>,
-    ) -> Self {
-        Self {
-            blockstore_events,
-            pool_events,
-            repairs,
-        }
-    }
-
-    /// Forwards `items` to `sender` with blocking sends, stopping early if the
-    /// channel has closed (the consumer shut down). A closed channel is logged
-    /// (using `what` to name it) and the remaining items dropped, not panicked on.
-    async fn forward_all<T>(sender: &mpsc::Sender<T>, items: Vec<T>, what: &str) {
-        for item in items {
-            if sender.send(item).await.is_err() {
-                debug!("{what} channel closed, dropping remaining events");
-                return;
-            }
-        }
-    }
-
-    /// Forwards buffered blockstore events to Votor.
-    pub(crate) async fn forward_blockstore_events(&self, events: Vec<BlockstoreEvent>) {
-        Self::forward_all(&self.blockstore_events, events, "Votor blockstore-event").await;
-    }
-
-    /// Forwards a drained [`PoolOutbox`]: Votor events first, then repair requests.
-    pub(crate) async fn forward_pool_outbox(&self, outbox: PoolOutbox) {
-        Self::forward_all(&self.pool_events, outbox.votor_events, "Votor pool-event").await;
-        Self::forward_all(&self.repairs, outbox.repairs, "repair").await;
-    }
-}
-
 /// Alpenglow consensus protocol implementation.
 pub struct Alpenglow<A: All2All, D: Disseminator, T>
 where
@@ -177,8 +119,13 @@ where
 
     /// Blockstore for storing raw block data.
     blockstore: SharedBlockstore,
-    /// Pool of votes and certificates.
-    pool: SharedPool,
+    /// Inputs destined for the consensus core (driver task).
+    ///
+    /// A full channel back-pressures the ingest tasks; a closed one means the
+    /// driver shut down, at which point remaining messages are dropped.
+    inputs: mpsc::Sender<Input>,
+    /// Observes the highest finalized slot, published by the driver.
+    finalized: watch::Receiver<Slot>,
 
     /// Block production (i.e. leader side) component of the consensus protocol.
     block_producer: Arc<BlockProducer<D, T>>,
@@ -188,13 +135,10 @@ where
     /// Block dissemination network protocol for shreds.
     disseminator: Arc<D>,
 
-    /// Forwards blockstore outbox events to Votor off the write lock.
-    event_forwarder: EventForwarder,
-
     /// Indicates whether the node is shutting down.
     cancel_token: CancellationToken,
-    /// Votor task handle.
-    votor_handle: tokio::task::JoinHandle<()>,
+    /// Consensus driver task handle.
+    driver_handle: tokio::task::JoinHandle<()>,
 }
 
 /// Interprets a joined task result during shutdown.
@@ -239,21 +183,33 @@ where
         RP: RepairResponderNetwork + 'static,
     {
         let cancel_token = CancellationToken::new();
-        // Votor's event channels. The Blockstore/Pool buffer events into an outbox
-        // under their write lock and the producing task forwards them here *after*
-        // releasing the lock (see `EventForwarder`), so a full channel back-pressures
-        // the ingest task rather than jamming the lock or dropping the event. The
-        // buffer is sized to absorb ordinary bursts without back-pressuring.
-        let (blockstore_tx, blockstore_rx) = mpsc::channel(1024);
-        let (pool_tx, pool_rx) = mpsc::channel(1024);
+        // The consensus core's inbox. Ingest tasks (message loop, block
+        // producer, repair loop) push validated inputs here; a full channel
+        // back-pressures them. The buffer is sized to absorb ordinary bursts
+        // without back-pressuring.
+        let (input_tx, input_rx) = mpsc::channel(1024);
         let (repair_tx, repair_rx) = mpsc::channel(1024);
+        let (parent_ready_tx, parent_ready_rx) = watch::channel(ParentReadyMap::new());
+        let (finalized_tx, finalized_rx) = watch::channel(Slot::genesis());
         let all2all = Arc::new(all2all);
-
-        let event_forwarder = EventForwarder::new(blockstore_tx, pool_tx, repair_tx);
 
         let blockstore: SharedBlockstore = Arc::new(RwLock::new(BlockstoreImpl::new()));
 
-        let pool: SharedPool = Arc::new(RwLock::new(PoolImpl::new(epoch_info.clone())));
+        let core = ConsensusCore::new(epoch_info.clone(), voting_secret_key, Instant::now());
+        let driver = Driver::new(
+            core,
+            input_rx,
+            all2all.clone(),
+            repair_tx,
+            parent_ready_tx,
+            finalized_tx,
+            cancel_token.clone(),
+        );
+        let driver_handle = tokio::spawn(
+            driver
+                .run()
+                .in_span(Span::enter_with_local_parent("consensus driver")),
+        );
 
         let repair_request_handler = RepairRequestHandler::new(
             epoch_info.clone(),
@@ -265,27 +221,14 @@ where
 
         let mut repair = Repair::new(
             Arc::clone(&blockstore),
-            Arc::clone(&pool),
             repair_requester_network,
             epoch_info.clone(),
-            event_forwarder.clone(),
+            input_tx.clone(),
         );
 
         let _repair_handle = tokio::spawn(
             async move { repair.repair_loop(repair_rx).await }
                 .in_span(Span::enter_with_local_parent("repair loop")),
-        );
-
-        let mut votor = Votor::new(
-            epoch_info.own_id(),
-            voting_secret_key,
-            pool_rx,
-            blockstore_rx,
-            all2all.clone(),
-        );
-        let votor_handle = tokio::spawn(
-            async move { votor.voting_loop().await }
-                .in_span(Span::enter_with_local_parent("voting loop")),
         );
 
         let disseminator = Arc::new(disseminator);
@@ -296,8 +239,9 @@ where
             disseminator.clone(),
             txs_receiver,
             blockstore.clone(),
-            pool.clone(),
-            event_forwarder.clone(),
+            input_tx.clone(),
+            parent_ready_rx,
+            finalized_rx.clone(),
             cancel_token.clone(),
             DELTA_BLOCK,
             DELTA_FIRST_SLICE,
@@ -306,13 +250,13 @@ where
         Self {
             epoch_info,
             blockstore,
-            pool,
+            inputs: input_tx,
+            finalized: finalized_rx,
             block_producer,
             all2all,
             disseminator,
-            event_forwarder,
             cancel_token,
-            votor_handle,
+            driver_handle,
         }
     }
 
@@ -328,11 +272,6 @@ where
         let nn = node.clone();
         let msg_loop = tokio::spawn(async move { nn.message_loop().await }.in_span(msg_loop_span));
 
-        let standstill_loop_span = Span::enter_with_local_parent("standstill detection loop");
-        let nn = node.clone();
-        let standstill_loop =
-            tokio::spawn(async move { nn.standstill_loop().await }.in_span(standstill_loop_span));
-
         let block_production_span = Span::enter_with_local_parent("block production");
         let block_producer = Arc::clone(&node.block_producer);
         let prod_loop = tokio::spawn(
@@ -341,9 +280,8 @@ where
         );
 
         node.cancel_token.cancelled().await;
-        node.votor_handle.abort();
+        node.driver_handle.abort();
         msg_loop.abort();
-        standstill_loop.abort();
         prod_loop.abort();
 
         let (msg_res, prod_res) = tokio::join!(msg_loop, prod_loop);
@@ -358,8 +296,10 @@ where
             .validator(self.epoch_info.own_id())
     }
 
-    pub fn get_pool(&self) -> SharedPool {
-        Arc::clone(&self.pool)
+    /// Returns a watch receiver tracking the highest finalized slot.
+    #[must_use]
+    pub fn finalized_slot(&self) -> watch::Receiver<Slot> {
+        self.finalized.clone()
     }
 
     pub fn get_cancel_token(&self) -> CancellationToken {
@@ -368,7 +308,7 @@ where
 
     /// Handles incoming messages on all the different network interfaces.
     ///
-    /// [`All2All`]: Handles incoming votes and certificates. Adds them to the [`Pool`].
+    /// [`All2All`]: Handles incoming votes and certificates, feeding them to the consensus core.
     /// [`Disseminator`]: Handles incoming shreds. Adds them to the [`Blockstore`].
     async fn message_loop(self: &Arc<Self>) -> Result<()> {
         loop {
@@ -383,75 +323,36 @@ where
         }
     }
 
-    /// Handles standstill detection and triggers recovery.
+    /// Pushes an input into the consensus core's inbox.
     ///
-    /// Keeps track of when consensus progresses, i.e., [`Pool`] finalizes new blocks.
-    /// Triggers standstill recovery if no progress was detected for a long time.
-    async fn standstill_loop(self: &Arc<Self>) -> Result<()> {
-        let mut finalized_slot = Slot::new(0);
-        let mut last_progress = Instant::now();
-        loop {
-            let slot = self.pool.read().await.finalized_slot();
-            if slot > finalized_slot {
-                finalized_slot = slot;
-                last_progress = Instant::now();
-            } else if last_progress.elapsed() > DELTA_STANDSTILL {
-                let outbox = self.pool.read().await.recover_from_standstill();
-                self.event_forwarder.forward_pool_outbox(outbox).await;
-                last_progress = Instant::now();
-            }
-            tokio::time::sleep(DELTA_BLOCK).await;
+    /// A full inbox back-pressures the calling ingest task. A closed inbox
+    /// means the driver shut down; the input is dropped with a debug log
+    /// rather than treated as an error, since the node is going down anyway.
+    async fn send_input(&self, input: Input) {
+        if self.inputs.send(input).await.is_err() {
+            debug!("consensus core inbox closed, dropping input");
         }
     }
 
+    /// Validates an incoming consensus message and feeds it to the core.
+    ///
+    /// Signatures are verified here, in the (parallelizable) ingest task,
+    /// mirroring the `ValidatedShred` pattern on the shred path — the core
+    /// never performs crypto.
     #[fastrace::trace(short_name = true)]
     async fn handle_all2all_message(&self, msg: ConsensusMessage) {
         trace!("received all2all msg: {msg:?}");
 
-        // verify signatures BEFORE taking the pool lock,
-        // mirroring the `ValidatedShred` pattern on the shred path
         let epoch_info = self.epoch_info.epoch_info();
         match msg {
-            ConsensusMessage::Vote(v) => {
-                let vote = match ValidatedVote::try_new(v, epoch_info) {
-                    Ok(vote) => vote,
-                    Err(err) => {
-                        trace!("ignoring invalid vote: {err}");
-                        return;
-                    }
-                };
-                // Add under the lock, then forward the buffered events off the lock.
-                let outbox = {
-                    let mut pool = self.pool.write().await;
-                    match pool.add_vote(vote) {
-                        Ok(()) => {}
-                        Err(AddVoteError::Slashable(offence)) => {
-                            warn!("slashable offence detected: {offence}");
-                        }
-                        Err(err) => trace!("ignoring invalid vote: {err}"),
-                    }
-                    pool.take_outbox()
-                };
-                self.event_forwarder.forward_pool_outbox(outbox).await;
-            }
-            ConsensusMessage::Cert(c) => {
-                let cert = match ValidatedCert::try_new(c, epoch_info) {
-                    Ok(cert) => cert,
-                    Err(err) => {
-                        trace!("ignoring invalid cert: {err}");
-                        return;
-                    }
-                };
-                let outbox = {
-                    let mut pool = self.pool.write().await;
-                    match pool.add_cert(cert) {
-                        Ok(()) => {}
-                        Err(err) => trace!("ignoring invalid cert: {err}"),
-                    }
-                    pool.take_outbox()
-                };
-                self.event_forwarder.forward_pool_outbox(outbox).await;
-            }
+            ConsensusMessage::Vote(v) => match ValidatedVote::try_new(v, epoch_info) {
+                Ok(vote) => self.send_input(Input::Vote(vote)).await,
+                Err(err) => trace!("ignoring invalid vote: {err}"),
+            },
+            ConsensusMessage::Cert(c) => match ValidatedCert::try_new(c, epoch_info) {
+                Ok(cert) => self.send_input(Input::Cert(cert)).await,
+                Err(err) => trace!("ignoring invalid cert: {err}"),
+            },
         }
     }
 
@@ -481,87 +382,18 @@ where
             return Ok(());
         }
 
-        // Ingest into the blockstore, then forward the buffered events to Votor
-        // *after* releasing the write lock (see `EventForwarder`).
-        let (res, events) = {
+        // Ingest into the blockstore, then feed the buffered events to the
+        // consensus core *after* releasing the write lock. The core registers
+        // completed blocks with the pool itself, so no separate `add_block`
+        // call is needed here.
+        let events = {
             let mut blockstore = self.blockstore.write().await;
-            let res = blockstore.add_shred_from_dissemination(validated);
-            (res, blockstore.take_events())
+            let _ = blockstore.add_shred_from_dissemination(validated);
+            blockstore.take_events()
         };
-        self.event_forwarder.forward_blockstore_events(events).await;
-
-        if let Ok(Some(block_info)) = res {
-            let block_id = (slot, block_info.hash);
-            let outbox = {
-                let mut pool = self.pool.write().await;
-                pool.add_block(block_id, block_info.parent);
-                pool.take_outbox()
-            };
-            self.event_forwarder.forward_pool_outbox(outbox).await;
+        for event in events {
+            self.send_input(Input::BlockstoreEvent(event)).await;
         }
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::crypto::merkle::GENESIS_BLOCK_HASH;
-
-    /// A closed Votor / repair channel (a shutting-down node) must not panic the
-    /// forwarder: the send fails, is logged, and the remaining items are dropped.
-    #[tokio::test]
-    async fn forward_to_closed_channels_does_not_panic() {
-        let (bs_tx, bs_rx) = mpsc::channel(1);
-        let (pool_tx, pool_rx) = mpsc::channel(1);
-        let (repair_tx, repair_rx) = mpsc::channel(1);
-        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx);
-        // Votor and the repair loop have shut down.
-        drop(bs_rx);
-        drop(pool_rx);
-        drop(repair_rx);
-
-        forwarder
-            .forward_blockstore_events(vec![BlockstoreEvent::FirstShred(Slot::new(1))])
-            .await;
-        forwarder
-            .forward_pool_outbox(PoolOutbox {
-                votor_events: vec![PoolEvent::SafeToSkip(Slot::new(1))],
-                repairs: vec![(Slot::new(1), GENESIS_BLOCK_HASH)],
-            })
-            .await;
-    }
-
-    /// Forwarding delivers all buffered items, in order, to open channels.
-    #[tokio::test]
-    async fn forward_delivers_all_events_in_order() {
-        let (bs_tx, mut bs_rx) = mpsc::channel(8);
-        let (pool_tx, mut pool_rx) = mpsc::channel(8);
-        let (repair_tx, mut repair_rx) = mpsc::channel(8);
-        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx);
-
-        forwarder
-            .forward_blockstore_events(vec![
-                BlockstoreEvent::FirstShred(Slot::new(1)),
-                BlockstoreEvent::InvalidBlock(Slot::new(2)),
-            ])
-            .await;
-        assert!(
-            matches!(bs_rx.try_recv(), Ok(BlockstoreEvent::FirstShred(s)) if s == Slot::new(1))
-        );
-        assert!(
-            matches!(bs_rx.try_recv(), Ok(BlockstoreEvent::InvalidBlock(s)) if s == Slot::new(2))
-        );
-        assert!(bs_rx.try_recv().is_err());
-
-        let block = (Slot::new(3), GENESIS_BLOCK_HASH);
-        forwarder
-            .forward_pool_outbox(PoolOutbox {
-                votor_events: vec![PoolEvent::SafeToSkip(Slot::new(3))],
-                repairs: vec![block.clone()],
-            })
-            .await;
-        assert!(matches!(pool_rx.try_recv(), Ok(PoolEvent::SafeToSkip(s)) if s == Slot::new(3)));
-        assert_eq!(repair_rx.try_recv().unwrap(), block);
     }
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -173,6 +173,10 @@ where
         RP: RepairResponderNetwork + 'static,
     {
         let cancel_token = CancellationToken::new();
+        // Producers (blockstore/pool) send on these with a non-blocking `try_send`
+        // so they never hold a write lock waiting on Votor; the buffer must be deep
+        // enough to absorb bursts, since on overflow events are dropped (and only
+        // recovered later via standstill recovery). Keep these capacities generous.
         let (blockstore_tx, blockstore_rx) = mpsc::channel(1024);
         let (pool_tx, pool_rx) = mpsc::channel(1024);
         let (repair_tx, repair_rx) = mpsc::channel(1024);

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -35,7 +35,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use fastrace::Span;
 use fastrace::future::FutureExt;
-use log::{trace, warn};
+use log::{debug, trace, warn};
 use static_assertions::const_assert;
 use tokio::sync::{RwLock, mpsc};
 use tokio_util::sync::CancellationToken;
@@ -48,7 +48,7 @@ pub use self::cert::{Cert, CertError, NotarCert};
 pub use self::epoch_info::{EpochInfo, ValidatorEpochInfo};
 #[cfg(feature = "test-utils")]
 pub use self::pool::bench_replay_votes;
-pub use self::pool::{AddVoteError, Pool, PoolEvent, PoolImpl, SharedPool};
+pub use self::pool::{AddVoteError, Pool, PoolEvent, PoolImpl, PoolOutbox, SharedPool};
 pub use self::validated_cert::{CertValidationError, ValidatedCert};
 pub use self::validated_vote::{ValidatedVote, VoteValidationError};
 pub use self::vote::{FinalVote, NotarFallbackVote, NotarVote, SkipFallbackVote, SkipVote, Vote};
@@ -59,7 +59,7 @@ use crate::network::{RepairRequesterNetwork, RepairResponderNetwork, Transaction
 use crate::repair::{Repair, RepairRequestHandler};
 use crate::shredder::{Shred, ValidatedShred};
 use crate::types::Fraction;
-use crate::{All2All, Disseminator, Slot, ValidatorInfo};
+use crate::{All2All, BlockId, Disseminator, Slot, ValidatorInfo};
 
 /// Time bound assumed on network transmission delays during periods of synchrony.
 pub const DELTA: Duration = Duration::from_millis(250);
@@ -104,6 +104,79 @@ impl From<Cert> for ConsensusMessage {
     }
 }
 
+/// Forwards side-effects drained from the Blockstore and Pool outboxes to Votor
+/// and the repair loop *after* the producing task has released the write lock.
+///
+/// The Blockstore and Pool buffer their events instead of sending them while
+/// holding their write lock: a blocking send under the lock would let a slow or
+/// stalled Votor jam every other task contending for that lock, while a
+/// non-blocking send would have to drop the event (which for a reconstructed-block
+/// event silently costs this node its vote for that block, with no retry path).
+/// Each task that mutates the Blockstore/Pool drains the outbox (with
+/// [`Blockstore::take_events`] / [`Pool::take_outbox`]) and hands it here; the
+/// blocking send then back-pressures that (ingest) task instead of dropping the
+/// event or stalling the lock.
+///
+/// Cloneable so the message loop, the repair loop and the block producer can each
+/// forward the events they produce.
+#[derive(Clone)]
+pub(crate) struct EventForwarder {
+    /// Blockstore events destined for Votor.
+    blockstore_events: mpsc::Sender<BlockstoreEvent>,
+    /// Pool events destined for Votor.
+    pool_events: mpsc::Sender<PoolEvent>,
+    /// Repair requests destined for the repair loop.
+    repairs: mpsc::Sender<BlockId>,
+}
+
+impl EventForwarder {
+    /// Creates a forwarder over Votor's event channels and the repair channel.
+    pub(crate) fn new(
+        blockstore_events: mpsc::Sender<BlockstoreEvent>,
+        pool_events: mpsc::Sender<PoolEvent>,
+        repairs: mpsc::Sender<BlockId>,
+    ) -> Self {
+        Self {
+            blockstore_events,
+            pool_events,
+            repairs,
+        }
+    }
+
+    /// Forwards buffered blockstore events to Votor with a blocking send.
+    ///
+    /// A closed channel (Votor shutting down) is logged and the remaining events
+    /// dropped, rather than panicking.
+    pub(crate) async fn forward_blockstore_events(&self, events: Vec<BlockstoreEvent>) {
+        for event in events {
+            if self.blockstore_events.send(event).await.is_err() {
+                debug!("Votor event channel closed, dropping blockstore events");
+                break;
+            }
+        }
+    }
+
+    /// Forwards a drained [`PoolOutbox`] (Votor events, then repair requests) with
+    /// blocking sends.
+    ///
+    /// A closed channel (Votor or the repair loop shutting down) is logged and the
+    /// remaining items dropped, rather than panicking.
+    pub(crate) async fn forward_pool_outbox(&self, outbox: PoolOutbox) {
+        for event in outbox.votor_events {
+            if self.pool_events.send(event).await.is_err() {
+                debug!("Votor event channel closed, dropping pool events");
+                break;
+            }
+        }
+        for block in outbox.repairs {
+            if self.repairs.send(block).await.is_err() {
+                debug!("repair channel closed, dropping repair requests");
+                break;
+            }
+        }
+    }
+}
+
 /// Alpenglow consensus protocol implementation.
 pub struct Alpenglow<A: All2All, D: Disseminator, T>
 where
@@ -124,6 +197,9 @@ where
     all2all: Arc<A>,
     /// Block dissemination network protocol for shreds.
     disseminator: Arc<D>,
+
+    /// Forwards blockstore outbox events to Votor off the write lock.
+    event_forwarder: EventForwarder,
 
     /// Indicates whether the node is shutting down.
     cancel_token: CancellationToken,
@@ -173,23 +249,21 @@ where
         RP: RepairResponderNetwork + 'static,
     {
         let cancel_token = CancellationToken::new();
-        // Producers (blockstore/pool) send on these with a non-blocking `try_send`
-        // so they never hold a write lock waiting on Votor; the buffer must be deep
-        // enough to absorb bursts, since on overflow events are dropped (and only
-        // recovered later via standstill recovery). Keep these capacities generous.
+        // Votor's event channels. The Blockstore/Pool buffer events into an outbox
+        // under their write lock and the producing task forwards them here *after*
+        // releasing the lock (see `EventForwarder`), so a full channel back-pressures
+        // the ingest task rather than jamming the lock or dropping the event. The
+        // buffer is sized to absorb ordinary bursts without back-pressuring.
         let (blockstore_tx, blockstore_rx) = mpsc::channel(1024);
         let (pool_tx, pool_rx) = mpsc::channel(1024);
         let (repair_tx, repair_rx) = mpsc::channel(1024);
         let all2all = Arc::new(all2all);
 
-        let blockstore: SharedBlockstore =
-            Arc::new(RwLock::new(BlockstoreImpl::new(blockstore_tx)));
+        let event_forwarder = EventForwarder::new(blockstore_tx, pool_tx, repair_tx);
 
-        let pool: SharedPool = Arc::new(RwLock::new(PoolImpl::new(
-            epoch_info.clone(),
-            pool_tx,
-            repair_tx,
-        )));
+        let blockstore: SharedBlockstore = Arc::new(RwLock::new(BlockstoreImpl::new()));
+
+        let pool: SharedPool = Arc::new(RwLock::new(PoolImpl::new(epoch_info.clone())));
 
         let repair_request_handler = RepairRequestHandler::new(
             epoch_info.clone(),
@@ -204,6 +278,7 @@ where
             Arc::clone(&pool),
             repair_requester_network,
             epoch_info.clone(),
+            event_forwarder.clone(),
         );
 
         let _repair_handle = tokio::spawn(
@@ -232,6 +307,7 @@ where
             txs_receiver,
             blockstore.clone(),
             pool.clone(),
+            event_forwarder.clone(),
             cancel_token.clone(),
             DELTA_BLOCK,
             DELTA_FIRST_SLICE,
@@ -244,6 +320,7 @@ where
             block_producer,
             all2all,
             disseminator,
+            event_forwarder,
             cancel_token,
             votor_handle,
         }
@@ -329,7 +406,8 @@ where
                 finalized_slot = slot;
                 last_progress = Instant::now();
             } else if last_progress.elapsed() > DELTA_STANDSTILL {
-                self.pool.read().await.recover_from_standstill().await;
+                let outbox = self.pool.read().await.recover_from_standstill();
+                self.event_forwarder.forward_pool_outbox(outbox).await;
                 last_progress = Instant::now();
             }
             tokio::time::sleep(DELTA_BLOCK).await;
@@ -352,13 +430,19 @@ where
                         return;
                     }
                 };
-                match self.pool.write().await.add_vote(vote).await {
-                    Ok(()) => {}
-                    Err(AddVoteError::Slashable(offence)) => {
-                        warn!("slashable offence detected: {offence}");
+                // Add under the lock, then forward the buffered events off the lock.
+                let outbox = {
+                    let mut pool = self.pool.write().await;
+                    match pool.add_vote(vote).await {
+                        Ok(()) => {}
+                        Err(AddVoteError::Slashable(offence)) => {
+                            warn!("slashable offence detected: {offence}");
+                        }
+                        Err(err) => trace!("ignoring invalid vote: {err}"),
                     }
-                    Err(err) => trace!("ignoring invalid vote: {err}"),
-                }
+                    pool.take_outbox()
+                };
+                self.event_forwarder.forward_pool_outbox(outbox).await;
             }
             ConsensusMessage::Cert(c) => {
                 let cert = match ValidatedCert::try_new(c, epoch_info) {
@@ -368,10 +452,15 @@ where
                         return;
                     }
                 };
-                match self.pool.write().await.add_cert(cert).await {
-                    Ok(()) => {}
-                    Err(err) => trace!("ignoring invalid cert: {err}"),
-                }
+                let outbox = {
+                    let mut pool = self.pool.write().await;
+                    match pool.add_cert(cert).await {
+                        Ok(()) => {}
+                        Err(err) => trace!("ignoring invalid cert: {err}"),
+                    }
+                    pool.take_outbox()
+                };
+                self.event_forwarder.forward_pool_outbox(outbox).await;
             }
         }
     }
@@ -402,21 +491,87 @@ where
             return Ok(());
         }
 
-        // otherwise, ingest into blockstore
-        let res = self
-            .blockstore
-            .write()
-            .await
-            .add_shred_from_dissemination(validated)
-            .await;
+        // Ingest into the blockstore, then forward the buffered events to Votor
+        // *after* releasing the write lock (see `EventForwarder`).
+        let (res, events) = {
+            let mut blockstore = self.blockstore.write().await;
+            let res = blockstore.add_shred_from_dissemination(validated).await;
+            (res, blockstore.take_events())
+        };
+        self.event_forwarder.forward_blockstore_events(events).await;
+
         if let Ok(Some(block_info)) = res {
             let block_id = (slot, block_info.hash);
-            self.pool
-                .write()
-                .await
-                .add_block(block_id, block_info.parent)
-                .await;
+            let outbox = {
+                let mut pool = self.pool.write().await;
+                pool.add_block(block_id, block_info.parent).await;
+                pool.take_outbox()
+            };
+            self.event_forwarder.forward_pool_outbox(outbox).await;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::merkle::GENESIS_BLOCK_HASH;
+
+    /// A closed Votor / repair channel (a shutting-down node) must not panic the
+    /// forwarder: the send fails, is logged, and the remaining items are dropped.
+    #[tokio::test]
+    async fn forward_to_closed_channels_does_not_panic() {
+        let (bs_tx, bs_rx) = mpsc::channel(1);
+        let (pool_tx, pool_rx) = mpsc::channel(1);
+        let (repair_tx, repair_rx) = mpsc::channel(1);
+        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx);
+        // Votor and the repair loop have shut down.
+        drop(bs_rx);
+        drop(pool_rx);
+        drop(repair_rx);
+
+        forwarder
+            .forward_blockstore_events(vec![BlockstoreEvent::FirstShred(Slot::new(1))])
+            .await;
+        forwarder
+            .forward_pool_outbox(PoolOutbox {
+                votor_events: vec![PoolEvent::SafeToSkip(Slot::new(1))],
+                repairs: vec![(Slot::new(1), GENESIS_BLOCK_HASH)],
+            })
+            .await;
+    }
+
+    /// Forwarding delivers all buffered items, in order, to open channels.
+    #[tokio::test]
+    async fn forward_delivers_all_events_in_order() {
+        let (bs_tx, mut bs_rx) = mpsc::channel(8);
+        let (pool_tx, mut pool_rx) = mpsc::channel(8);
+        let (repair_tx, mut repair_rx) = mpsc::channel(8);
+        let forwarder = EventForwarder::new(bs_tx, pool_tx, repair_tx);
+
+        forwarder
+            .forward_blockstore_events(vec![
+                BlockstoreEvent::FirstShred(Slot::new(1)),
+                BlockstoreEvent::InvalidBlock(Slot::new(2)),
+            ])
+            .await;
+        assert!(
+            matches!(bs_rx.try_recv(), Ok(BlockstoreEvent::FirstShred(s)) if s == Slot::new(1))
+        );
+        assert!(
+            matches!(bs_rx.try_recv(), Ok(BlockstoreEvent::InvalidBlock(s)) if s == Slot::new(2))
+        );
+        assert!(bs_rx.try_recv().is_err());
+
+        let block = (Slot::new(3), GENESIS_BLOCK_HASH);
+        forwarder
+            .forward_pool_outbox(PoolOutbox {
+                votor_events: vec![PoolEvent::SafeToSkip(Slot::new(3))],
+                repairs: vec![block.clone()],
+            })
+            .await;
+        assert!(matches!(pool_rx.try_recv(), Ok(PoolEvent::SafeToSkip(s)) if s == Slot::new(3)));
+        assert_eq!(repair_rx.try_recv().unwrap(), block);
     }
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -423,7 +423,7 @@ where
                 // Add under the lock, then forward the buffered events off the lock.
                 let outbox = {
                     let mut pool = self.pool.write().await;
-                    match pool.add_vote(vote).await {
+                    match pool.add_vote(vote) {
                         Ok(()) => {}
                         Err(AddVoteError::Slashable(offence)) => {
                             warn!("slashable offence detected: {offence}");
@@ -444,7 +444,7 @@ where
                 };
                 let outbox = {
                     let mut pool = self.pool.write().await;
-                    match pool.add_cert(cert).await {
+                    match pool.add_cert(cert) {
                         Ok(()) => {}
                         Err(err) => trace!("ignoring invalid cert: {err}"),
                     }
@@ -485,7 +485,7 @@ where
         // *after* releasing the write lock (see `EventForwarder`).
         let (res, events) = {
             let mut blockstore = self.blockstore.write().await;
-            let res = blockstore.add_shred_from_dissemination(validated).await;
+            let res = blockstore.add_shred_from_dissemination(validated);
             (res, blockstore.take_events())
         };
         self.event_forwarder.forward_blockstore_events(events).await;
@@ -494,7 +494,7 @@ where
             let block_id = (slot, block_info.hash);
             let outbox = {
                 let mut pool = self.pool.write().await;
-                pool.add_block(block_id, block_info.parent).await;
+                pool.add_block(block_id, block_info.parent);
                 pool.take_outbox()
             };
             self.event_forwarder.forward_pool_outbox(outbox).await;

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -143,37 +143,27 @@ impl EventForwarder {
         }
     }
 
-    /// Forwards buffered blockstore events to Votor with a blocking send.
-    ///
-    /// A closed channel (Votor shutting down) is logged and the remaining events
-    /// dropped, rather than panicking.
-    pub(crate) async fn forward_blockstore_events(&self, events: Vec<BlockstoreEvent>) {
-        for event in events {
-            if self.blockstore_events.send(event).await.is_err() {
-                debug!("Votor event channel closed, dropping blockstore events");
-                break;
+    /// Forwards `items` to `sender` with blocking sends, stopping early if the
+    /// channel has closed (the consumer shut down). A closed channel is logged
+    /// (using `what` to name it) and the remaining items dropped, not panicked on.
+    async fn forward_all<T>(sender: &mpsc::Sender<T>, items: Vec<T>, what: &str) {
+        for item in items {
+            if sender.send(item).await.is_err() {
+                debug!("{what} channel closed, dropping remaining events");
+                return;
             }
         }
     }
 
-    /// Forwards a drained [`PoolOutbox`] (Votor events, then repair requests) with
-    /// blocking sends.
-    ///
-    /// A closed channel (Votor or the repair loop shutting down) is logged and the
-    /// remaining items dropped, rather than panicking.
+    /// Forwards buffered blockstore events to Votor.
+    pub(crate) async fn forward_blockstore_events(&self, events: Vec<BlockstoreEvent>) {
+        Self::forward_all(&self.blockstore_events, events, "Votor blockstore-event").await;
+    }
+
+    /// Forwards a drained [`PoolOutbox`]: Votor events first, then repair requests.
     pub(crate) async fn forward_pool_outbox(&self, outbox: PoolOutbox) {
-        for event in outbox.votor_events {
-            if self.pool_events.send(event).await.is_err() {
-                debug!("Votor event channel closed, dropping pool events");
-                break;
-            }
-        }
-        for block in outbox.repairs {
-            if self.repairs.send(block).await.is_err() {
-                debug!("repair channel closed, dropping repair requests");
-                break;
-            }
-        }
+        Self::forward_all(&self.pool_events, outbox.votor_events, "Votor pool-event").await;
+        Self::forward_all(&self.repairs, outbox.repairs, "repair").await;
     }
 }
 

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -372,7 +372,7 @@ where
         // buffered events to Votor after releasing the write lock.
         let (block_info, events) = {
             let mut blockstore = self.blockstore.write().await;
-            let block_info = blockstore.add_own_slice(payload, shreds).await;
+            let block_info = blockstore.add_own_slice(payload, shreds);
             (block_info, blockstore.take_events())
         };
         self.event_forwarder.forward_blockstore_events(events).await;
@@ -392,7 +392,7 @@ where
                 let block_id = (slot, block_info.hash.clone());
                 let outbox = {
                     let mut pool = self.pool.write().await;
-                    pool.add_block(block_id, block_info.parent).await;
+                    pool.add_block(block_id, block_info.parent);
                     pool.take_outbox()
                 };
                 self.event_forwarder.forward_pool_outbox(outbox).await;
@@ -733,10 +733,7 @@ mod tests {
         blockstore
             .expect_add_own_slice()
             .times(1)
-            .returning(move |_slice, _shreds| {
-                let bi = bi.clone();
-                Box::pin(async move { Some(bi) })
-            });
+            .returning(move |_slice, _shreds| Some(bi.clone()));
         blockstore.expect_take_events().returning(Vec::new);
 
         let mut pool = MockPool::new();
@@ -745,7 +742,6 @@ mod tests {
             .returning(move |ret_block_id, ret_parent_block_id| {
                 assert_eq!(ret_block_id, (slot, bi.hash.clone()));
                 assert_eq!(bi.parent, ret_parent_block_id);
-                Box::pin(async {})
             });
         pool.expect_take_outbox().returning(PoolOutbox::default);
 
@@ -784,8 +780,11 @@ mod tests {
             parent: new_parent.clone(),
         };
 
-        let (first_slice_finished_tx, first_slice_finished_rx) = oneshot::channel();
-        let (start_second_slice_tx, start_second_slice_rx) = oneshot::channel();
+        // NOTE: the blockstore is now sync, so the rendezvous blocks on std
+        // channels inside the mock (briefly blocking the runtime thread) and a
+        // plain OS thread plays the coordinator that reacts in between.
+        let (first_slice_finished_tx, first_slice_finished_rx) = std::sync::mpsc::channel();
+        let (start_second_slice_tx, start_second_slice_rx) = std::sync::mpsc::channel();
 
         let mut seq = Sequence::new();
         let mut blockstore = MockBlockstore::new();
@@ -797,11 +796,9 @@ mod tests {
             .times(1)
             .in_sequence(&mut seq)
             .return_once(move |_slice, _shreds| {
-                Box::pin(async move {
-                    first_slice_finished_tx.send(()).unwrap();
-                    let () = start_second_slice_rx.await.unwrap();
-                    None
-                })
+                first_slice_finished_tx.send(()).unwrap();
+                let () = start_second_slice_rx.recv().unwrap();
+                None
             });
 
         // second (last) slice: block is constructed with the new parent
@@ -810,10 +807,7 @@ mod tests {
             .expect_add_own_slice()
             .times(1)
             .in_sequence(&mut seq)
-            .returning(move |_slice, _shreds| {
-                let nbi = nbi.clone();
-                Box::pin(async move { Some(nbi) })
-            });
+            .returning(move |_slice, _shreds| Some(nbi.clone()));
         blockstore.expect_take_events().returning(Vec::new);
 
         let mut pool = MockPool::new();
@@ -822,7 +816,6 @@ mod tests {
             .returning(move |ret_block_id, ret_parent_block_id| {
                 assert_eq!(ret_block_id, (slot, nbi.hash.clone()));
                 assert_eq!(nbi.parent, ret_parent_block_id);
-                Box::pin(async {})
             });
         pool.expect_take_outbox().returning(PoolOutbox::default);
 
@@ -841,8 +834,8 @@ mod tests {
         let (parent_ready_tx, parent_ready_rx) = oneshot::channel();
 
         let np = new_parent.clone();
-        tokio::spawn(async move {
-            let () = first_slice_finished_rx.await.unwrap();
+        std::thread::spawn(move || {
+            let () = first_slice_finished_rx.recv().unwrap();
             parent_ready_tx.send(np).unwrap();
             start_second_slice_tx.send(()).unwrap();
         });

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -16,7 +16,7 @@ use tokio::sync::oneshot;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-use crate::consensus::{SharedBlockstore, SharedPool, ValidatorEpochInfo};
+use crate::consensus::{EventForwarder, SharedBlockstore, SharedPool, ValidatorEpochInfo};
 use crate::crypto::merkle::{BlockHash, GENESIS_BLOCK_HASH};
 use crate::crypto::signature;
 use crate::network::{Network, TransactionNetwork};
@@ -41,6 +41,8 @@ pub(super) struct BlockProducer<D: Disseminator, T: Network> {
     blockstore: SharedBlockstore,
     /// Pool of votes and certificates.
     pool: SharedPool,
+    /// Forwards blockstore outbox events to Votor off the write lock.
+    event_forwarder: EventForwarder,
 
     /// Block dissemination network protocol for shreds.
     disseminator: Arc<D>,
@@ -76,6 +78,7 @@ where
         txs_receiver: T,
         blockstore: SharedBlockstore,
         pool: SharedPool,
+        event_forwarder: EventForwarder,
         cancel_token: CancellationToken,
         delta_block: Duration,
         delta_first_slice: Duration,
@@ -86,6 +89,7 @@ where
             epoch_info,
             blockstore,
             pool,
+            event_forwarder,
             disseminator,
             txs_receiver,
             // block production is sequential, so a single shredder is enough
@@ -364,13 +368,14 @@ where
 
         // Fast path: we already have every shred and the decoded payload, so the
         // blockstore can skip RS-decode, Merkle verification and the per-shred
-        // lock churn. The completed block hands back (slot, hash).
-        let block_info = self
-            .blockstore
-            .write()
-            .await
-            .add_own_slice(payload, shreds)
-            .await;
+        // lock churn. The completed block hands back (slot, hash). Forward the
+        // buffered events to Votor after releasing the write lock.
+        let (block_info, events) = {
+            let mut blockstore = self.blockstore.write().await;
+            let block_info = blockstore.add_own_slice(payload, shreds).await;
+            (block_info, blockstore.take_events())
+        };
+        self.event_forwarder.forward_blockstore_events(events).await;
 
         if let Some(e) = first_err {
             warn!(
@@ -385,11 +390,12 @@ where
                 // followers can never reconstruct. Crash loudly instead.
                 assert!(is_last, "block completed before its last slice");
                 let block_id = (slot, block_info.hash.clone());
-                self.pool
-                    .write()
-                    .await
-                    .add_block(block_id, block_info.parent)
-                    .await;
+                let outbox = {
+                    let mut pool = self.pool.write().await;
+                    pool.add_block(block_id, block_info.parent).await;
+                    pool.take_outbox()
+                };
+                self.event_forwarder.forward_pool_outbox(outbox).await;
                 Ok(Some(block_info.hash))
             }
             None => {
@@ -567,7 +573,7 @@ mod tests {
     use super::*;
     use crate::consensus::blockstore::MockBlockstore;
     use crate::consensus::pool::MockPool;
-    use crate::consensus::{BlockInfo, ValidatorEpochInfo};
+    use crate::consensus::{BlockInfo, PoolOutbox, ValidatorEpochInfo};
     use crate::crypto::Hash;
     use crate::disseminator::MockDisseminator;
     use crate::network::{UdpNetwork, localhost_ip_sockaddr};
@@ -691,6 +697,10 @@ mod tests {
         let disseminator = Arc::new(disseminator);
         let txs_receiver = UdpNetwork::new_with_any_port();
         let cancel_token = CancellationToken::new();
+        let (bs_event_tx, _bs_event_rx) = tokio::sync::mpsc::channel(100);
+        let (pool_event_tx, _pool_event_rx) = tokio::sync::mpsc::channel(100);
+        let (repair_tx, _repair_rx) = tokio::sync::mpsc::channel(100);
+        let event_forwarder = EventForwarder::new(bs_event_tx, pool_event_tx, repair_tx);
 
         BlockProducer::new(
             secret_key,
@@ -699,6 +709,7 @@ mod tests {
             txs_receiver,
             blockstore,
             pool,
+            event_forwarder,
             cancel_token,
             delta_block,
             delta_first_slice,
@@ -726,6 +737,7 @@ mod tests {
                 let bi = bi.clone();
                 Box::pin(async move { Some(bi) })
             });
+        blockstore.expect_take_events().returning(Vec::new);
 
         let mut pool = MockPool::new();
         let bi = block_info.clone();
@@ -735,6 +747,7 @@ mod tests {
                 assert_eq!(bi.parent, ret_parent_block_id);
                 Box::pin(async {})
             });
+        pool.expect_take_outbox().returning(PoolOutbox::default);
 
         let mut disseminator = MockDisseminator::new();
         disseminator
@@ -801,6 +814,7 @@ mod tests {
                 let nbi = nbi.clone();
                 Box::pin(async move { Some(nbi) })
             });
+        blockstore.expect_take_events().returning(Vec::new);
 
         let mut pool = MockPool::new();
         let nbi = new_block_info.clone();
@@ -810,6 +824,7 @@ mod tests {
                 assert_eq!(nbi.parent, ret_parent_block_id);
                 Box::pin(async {})
             });
+        pool.expect_take_outbox().returning(PoolOutbox::default);
 
         let mut disseminator = MockDisseminator::new();
         disseminator

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -7,16 +7,17 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use either::Either;
 use fastrace::Span;
 use log::{debug, info, warn};
 use static_assertions::const_assert;
 use tokio::pin;
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-use crate::consensus::{EventForwarder, SharedBlockstore, SharedPool, ValidatorEpochInfo};
+use crate::consensus::core::Input;
+use crate::consensus::driver::ParentReadyMap;
+use crate::consensus::{SharedBlockstore, ValidatorEpochInfo};
 use crate::crypto::merkle::{BlockHash, GENESIS_BLOCK_HASH};
 use crate::crypto::signature;
 use crate::network::{Network, TransactionNetwork};
@@ -32,17 +33,19 @@ use crate::{BlockId, Disseminator, MAX_TRANSACTION_SIZE};
 /// Finished blocks are shredded and disseminated via a [`Disseminator`] instance.
 pub(super) struct BlockProducer<D: Disseminator, T: Network> {
     /// Own validator's secret key (used e.g. for block production).
-    /// This is not the same as the voting secret key, which is held by [`super::Votor`].
+    /// This is not the same as the voting secret key, which is held by the consensus core.
     secret_key: signature::SecretKey,
     /// Other validators' info.
     epoch_info: Arc<ValidatorEpochInfo>,
 
     /// Blockstore for storing raw block data.
     blockstore: SharedBlockstore,
-    /// Pool of votes and certificates.
-    pool: SharedPool,
-    /// Forwards blockstore outbox events to Votor off the write lock.
-    event_forwarder: EventForwarder,
+    /// Feeds drained blockstore events to the consensus core.
+    inputs: mpsc::Sender<Input>,
+    /// Observes the first ready parent per window, published by the driver.
+    parent_ready: watch::Receiver<ParentReadyMap>,
+    /// Observes the highest finalized slot, published by the driver.
+    finalized: watch::Receiver<Slot>,
 
     /// Block dissemination network protocol for shreds.
     disseminator: Arc<D>,
@@ -77,8 +80,9 @@ where
         disseminator: Arc<D>,
         txs_receiver: T,
         blockstore: SharedBlockstore,
-        pool: SharedPool,
-        event_forwarder: EventForwarder,
+        inputs: mpsc::Sender<Input>,
+        parent_ready: watch::Receiver<ParentReadyMap>,
+        finalized: watch::Receiver<Slot>,
         cancel_token: CancellationToken,
         delta_block: Duration,
         delta_first_slice: Duration,
@@ -88,8 +92,9 @@ where
             secret_key,
             epoch_info,
             blockstore,
-            pool,
-            event_forwarder,
+            inputs,
+            parent_ready,
+            finalized,
             disseminator,
             txs_receiver,
             // block production is sequential, so a single shredder is enough
@@ -124,7 +129,8 @@ where
 
             // wait for ParentReady or block in previous slot
             let slot_ready = wait_for_first_slot(
-                self.pool.clone(),
+                self.parent_ready.clone(),
+                self.finalized.clone(),
                 self.blockstore.clone(),
                 first_slot_in_window,
             )
@@ -368,14 +374,24 @@ where
 
         // Fast path: we already have every shred and the decoded payload, so the
         // blockstore can skip RS-decode, Merkle verification and the per-shred
-        // lock churn. The completed block hands back (slot, hash). Forward the
-        // buffered events to Votor after releasing the write lock.
+        // lock churn. The completed block hands back (slot, hash). Feed the
+        // buffered events to the consensus core after releasing the write lock;
+        // the core registers the completed block with the pool itself.
         let (block_info, events) = {
             let mut blockstore = self.blockstore.write().await;
             let block_info = blockstore.add_own_slice(payload, shreds);
             (block_info, blockstore.take_events())
         };
-        self.event_forwarder.forward_blockstore_events(events).await;
+        for event in events {
+            if self
+                .inputs
+                .send(Input::BlockstoreEvent(event))
+                .await
+                .is_err()
+            {
+                debug!("consensus core inbox closed, dropping input");
+            }
+        }
 
         if let Some(e) = first_err {
             warn!(
@@ -389,13 +405,6 @@ where
                 // and the only alternative is proposing a truncated block that
                 // followers can never reconstruct. Crash loudly instead.
                 assert!(is_last, "block completed before its last slice");
-                let block_id = (slot, block_info.hash.clone());
-                let outbox = {
-                    let mut pool = self.pool.write().await;
-                    pool.add_block(block_id, block_info.parent);
-                    pool.take_outbox()
-                };
-                self.event_forwarder.forward_pool_outbox(outbox).await;
                 Ok(Some(block_info.hash))
             }
             None => {
@@ -502,12 +511,13 @@ enum SlotReady {
 /// Waits for first slot in the given window to become ready for block production.
 ///
 /// Ready here can mean:
-/// - Pool emitted the `ParentReady` event for it, OR
+/// - the driver published a ready parent for it (Pool's `ParentReady`), OR
 /// - the blockstore has stored a block for the previous slot.
 ///
 /// See [`SlotReady`] for what is returned.
 async fn wait_for_first_slot(
-    pool: SharedPool,
+    mut parent_ready: watch::Receiver<ParentReadyMap>,
+    finalized: watch::Receiver<Slot>,
     blockstore: SharedBlockstore,
     first_slot_in_window: Slot,
 ) -> SlotReady {
@@ -516,25 +526,18 @@ async fn wait_for_first_slot(
         return SlotReady::Ready((Slot::genesis(), GENESIS_BLOCK_HASH));
     }
 
-    // if already have parent ready, return it, otherwise get a channel to await on
-    let mut rx = {
-        let mut guard = pool.write().await;
-        match guard.wait_for_parent_ready(first_slot_in_window) {
-            Either::Left(parent) => {
-                return SlotReady::Ready(parent);
-            }
-            Either::Right(rx) => rx,
-        }
-    };
-
     // Concurrently wait for:
-    // - `ParentReady` event,
+    // - a ready parent published by the driver,
     // - block reconstruction in blockstore, OR
     // - notification that a later slot was finalized.
+    let watch_for_oneshot = parent_ready.clone();
     tokio::select! {
-        res = &mut rx => {
-            let parent = res.expect("sender dropped channel");
-            SlotReady::Ready(parent)
+        res = parent_ready.wait_for(|map| map.contains_key(&first_slot_in_window)) => {
+            match res {
+                Ok(map) => SlotReady::Ready(map[&first_slot_in_window].clone()),
+                // the driver shut down; the node is going down anyway
+                Err(_) => SlotReady::Skip,
+            }
         }
 
         res = async {
@@ -547,7 +550,7 @@ async fn wait_for_first_slot(
                     {
                         return Some((last_slot_in_prev_window, hash.clone()));
                     }
-                    if pool.read().await.finalized_slot() >= first_slot_in_window {
+                    if *finalized.borrow() >= first_slot_in_window {
                         return None;
                     }
                     sleep(Duration::from_millis(1)).await;
@@ -557,28 +560,59 @@ async fn wait_for_first_slot(
         } => {
             match res {
                 None => SlotReady::Skip,
-                Some((slot, hash)) => SlotReady::ParentReadyNotSeen((slot, hash), rx),
+                Some((slot, hash)) => {
+                    let rx = parent_ready_oneshot(watch_for_oneshot, first_slot_in_window);
+                    SlotReady::ParentReadyNotSeen((slot, hash), rx)
+                }
             }
         }
     }
+}
+
+/// Bridges the parent-ready watch to a oneshot channel for the given `slot`.
+///
+/// The returned receiver resolves with the first ready parent for `slot`,
+/// mirroring the interface [`BlockProducer::produce_block_parent_not_ready`]
+/// selects on while producing optimistically. If the driver shuts down before
+/// a parent is ready, the sender is dropped.
+fn parent_ready_oneshot(
+    mut parent_ready: watch::Receiver<ParentReadyMap>,
+    slot: Slot,
+) -> oneshot::Receiver<BlockId> {
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(async move {
+        if let Ok(map) = parent_ready.wait_for(|map| map.contains_key(&slot)).await {
+            let _ = tx.send(map[&slot].clone());
+        }
+    });
+    rx
 }
 
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
-    use mockall::{Sequence, predicate};
+    use mockall::Sequence;
     use tokio::sync::RwLock;
 
     use super::*;
     use crate::consensus::blockstore::MockBlockstore;
-    use crate::consensus::pool::MockPool;
-    use crate::consensus::{BlockInfo, PoolOutbox, ValidatorEpochInfo};
+    use crate::consensus::{BlockInfo, ValidatorEpochInfo};
     use crate::crypto::Hash;
     use crate::disseminator::MockDisseminator;
     use crate::network::{UdpNetwork, localhost_ip_sockaddr};
     use crate::test_utils::{generate_validators, random_block_id};
     use crate::{Transaction, ValidatorIndex};
+
+    /// Fresh channels standing in for the driver's side of the wiring.
+    ///
+    /// Held (not read) for the duration of a test so the producer never
+    /// sees closed channels.
+    struct DriverStandIn {
+        _input_rx: mpsc::Receiver<Input>,
+        _parent_ready_tx: watch::Sender<ParentReadyMap>,
+        _finalized_tx: watch::Sender<Slot>,
+    }
 
     #[tokio::test]
     async fn produce_slice_empty_slices() {
@@ -631,28 +665,33 @@ mod tests {
 
     #[tokio::test]
     async fn wait_for_first_slot_genesis() {
-        let pool: SharedPool = Arc::new(RwLock::new(MockPool::new()));
         let blockstore: SharedBlockstore = Arc::new(RwLock::new(MockBlockstore::new()));
+        let (_parent_ready_tx, parent_ready_rx) = watch::channel(ParentReadyMap::new());
+        let (_finalized_tx, finalized_rx) = watch::channel(Slot::genesis());
 
-        let status = wait_for_first_slot(pool, blockstore, Slot::genesis()).await;
+        let status =
+            wait_for_first_slot(parent_ready_rx, finalized_rx, blockstore, Slot::genesis()).await;
         assert!(matches!(status, SlotReady::Ready(_)));
     }
 
     #[tokio::test]
     async fn wait_for_first_slot_parent_already_ready() {
-        let blockstore: SharedBlockstore = Arc::new(RwLock::new(MockBlockstore::new()));
+        // the concurrent blockstore poll may run before the ready parent wins
+        let mut mock_blockstore = MockBlockstore::new();
+        mock_blockstore
+            .expect_disseminated_block_hash()
+            .returning(|_| None);
+        let blockstore: SharedBlockstore = Arc::new(RwLock::new(mock_blockstore));
+        let (parent_ready_tx, parent_ready_rx) = watch::channel(ParentReadyMap::new());
+        let (_finalized_tx, finalized_rx) = watch::channel(Slot::genesis());
 
         let slot = Slot::windows().nth(10).unwrap();
         let parent = (slot.prev(), GENESIS_BLOCK_HASH);
+        parent_ready_tx.send_modify(|map| {
+            map.insert(slot, parent.clone());
+        });
 
-        let mut pool = MockPool::new();
-        let p = parent.clone();
-        pool.expect_wait_for_parent_ready()
-            .with(predicate::eq(slot))
-            .return_once(move |_slot| Either::Left(p));
-        let pool: SharedPool = Arc::new(RwLock::new(pool));
-
-        let status = wait_for_first_slot(pool, blockstore, slot).await;
+        let status = wait_for_first_slot(parent_ready_rx, finalized_rx, blockstore, slot).await;
         match status {
             SlotReady::Ready(p) => assert_eq!(p, parent),
             other => panic!("unexpected {other:?}"),
@@ -661,20 +700,28 @@ mod tests {
 
     #[tokio::test]
     async fn wait_for_first_slot_parent_ready_later() {
-        let blockstore: SharedBlockstore = Arc::new(RwLock::new(MockBlockstore::new()));
+        // the blockstore poll runs until the (delayed) parent becomes ready
+        let mut mock_blockstore = MockBlockstore::new();
+        mock_blockstore
+            .expect_disseminated_block_hash()
+            .returning(|_| None);
+        let blockstore: SharedBlockstore = Arc::new(RwLock::new(mock_blockstore));
+        let (parent_ready_tx, parent_ready_rx) = watch::channel(ParentReadyMap::new());
+        let (_finalized_tx, finalized_rx) = watch::channel(Slot::genesis());
 
         let slot = Slot::windows().nth(10).unwrap();
         let parent = (slot.prev(), GENESIS_BLOCK_HASH);
-        let (tx, rx) = oneshot::channel();
-        tx.send(parent.clone()).unwrap();
 
-        let mut pool = MockPool::new();
-        pool.expect_wait_for_parent_ready()
-            .with(predicate::eq(slot))
-            .return_once(move |_slot| Either::Right(rx));
-        let pool: SharedPool = Arc::new(RwLock::new(pool));
+        // parent becomes ready only while we are already waiting
+        let p = parent.clone();
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(50)).await;
+            parent_ready_tx.send_modify(|map| {
+                map.insert(slot, p);
+            });
+        });
 
-        let status = wait_for_first_slot(pool, blockstore, slot).await;
+        let status = wait_for_first_slot(parent_ready_rx, finalized_rx, blockstore, slot).await;
         match status {
             SlotReady::Ready(p) => assert_eq!(p, parent),
             other => panic!("unexpected {other:?}"),
@@ -684,36 +731,43 @@ mod tests {
     /// A bunch of boilerplate to initialize and return a [`BlockProducer`].
     fn setup(
         blockstore: MockBlockstore,
-        pool: MockPool,
         disseminator: MockDisseminator,
         delta_block: Duration,
         delta_first_slice: Duration,
-    ) -> BlockProducer<MockDisseminator, UdpNetwork<Transaction, Transaction>> {
+    ) -> (
+        BlockProducer<MockDisseminator, UdpNetwork<Transaction, Transaction>>,
+        DriverStandIn,
+    ) {
         let secret_key = signature::SecretKey::new(&mut rand::rng());
         let (_, epoch_info) = generate_validators(11);
         let epoch_info = Arc::new(ValidatorEpochInfo::new(ValidatorIndex::new(0), epoch_info));
         let blockstore: SharedBlockstore = Arc::new(RwLock::new(blockstore));
-        let pool: SharedPool = Arc::new(RwLock::new(pool));
         let disseminator = Arc::new(disseminator);
         let txs_receiver = UdpNetwork::new_with_any_port();
         let cancel_token = CancellationToken::new();
-        let (bs_event_tx, _bs_event_rx) = tokio::sync::mpsc::channel(100);
-        let (pool_event_tx, _pool_event_rx) = tokio::sync::mpsc::channel(100);
-        let (repair_tx, _repair_rx) = tokio::sync::mpsc::channel(100);
-        let event_forwarder = EventForwarder::new(bs_event_tx, pool_event_tx, repair_tx);
+        let (input_tx, input_rx) = mpsc::channel(100);
+        let (parent_ready_tx, parent_ready_rx) = watch::channel(ParentReadyMap::new());
+        let (finalized_tx, finalized_rx) = watch::channel(Slot::genesis());
 
-        BlockProducer::new(
+        let producer = BlockProducer::new(
             secret_key,
             epoch_info,
             disseminator,
             txs_receiver,
             blockstore,
-            pool,
-            event_forwarder,
+            input_tx,
+            parent_ready_rx,
+            finalized_rx,
             cancel_token,
             delta_block,
             delta_first_slice,
-        )
+        );
+        let stand_in = DriverStandIn {
+            _input_rx: input_rx,
+            _parent_ready_tx: parent_ready_tx,
+            _finalized_tx: finalized_tx,
+        };
+        (producer, stand_in)
     }
 
     #[tokio::test]
@@ -736,22 +790,12 @@ mod tests {
             .returning(move |_slice, _shreds| Some(bi.clone()));
         blockstore.expect_take_events().returning(Vec::new);
 
-        let mut pool = MockPool::new();
-        let bi = block_info.clone();
-        pool.expect_add_block()
-            .returning(move |ret_block_id, ret_parent_block_id| {
-                assert_eq!(ret_block_id, (slot, bi.hash.clone()));
-                assert_eq!(bi.parent, ret_parent_block_id);
-            });
-        pool.expect_take_outbox().returning(PoolOutbox::default);
-
         let mut disseminator = MockDisseminator::new();
         disseminator
             .expect_send()
             .returning(|_| Box::pin(async { Ok(()) }));
-        let block_producer = setup(
+        let (block_producer, _driver) = setup(
             blockstore,
-            pool,
             disseminator,
             Duration::from_micros(0),
             Duration::from_micros(0),
@@ -810,22 +854,12 @@ mod tests {
             .returning(move |_slice, _shreds| Some(nbi.clone()));
         blockstore.expect_take_events().returning(Vec::new);
 
-        let mut pool = MockPool::new();
-        let nbi = new_block_info.clone();
-        pool.expect_add_block()
-            .returning(move |ret_block_id, ret_parent_block_id| {
-                assert_eq!(ret_block_id, (slot, nbi.hash.clone()));
-                assert_eq!(nbi.parent, ret_parent_block_id);
-            });
-        pool.expect_take_outbox().returning(PoolOutbox::default);
-
         let mut disseminator = MockDisseminator::new();
         disseminator
             .expect_send()
             .returning(|_| Box::pin(async { Ok(()) }));
-        let block_producer = setup(
+        let (block_producer, _driver) = setup(
             blockstore,
-            pool,
             disseminator,
             Duration::from_micros(0),
             Duration::from_millis(0),

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -9,10 +9,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use log::{debug, warn};
+use log::debug;
 use tokio::sync::RwLock;
-use tokio::sync::mpsc::Sender;
-use tokio::sync::mpsc::error::TrySendError;
 
 pub use self::slot_block_data::AddShredError;
 use self::slot_block_data::SlotBlockData;
@@ -83,6 +81,12 @@ pub trait Blockstore {
         shreds: Box<[ValidatedShred; TOTAL_SHREDS]>,
     ) -> Option<BlockInfo>;
     async fn flag_leader_misbehavior(&mut self, slot: Slot);
+    /// Drains and returns the [`BlockstoreEvent`]s buffered since the last call.
+    ///
+    /// The caller must forward these to Votor *after* releasing the blockstore
+    /// lock, so that a slow Votor back-pressures the ingest task instead of
+    /// jamming the lock. See `BlockstoreImpl::emit` for the rationale.
+    fn take_events(&mut self) -> Vec<BlockstoreEvent>;
     #[expect(
         clippy::needless_lifetimes,
         reason = "explicit lifetime is required by mockall::automock"
@@ -114,23 +118,34 @@ pub struct BlockstoreImpl {
     block_data: BTreeMap<Slot, SlotBlockData>,
     /// Shredders used for reconstructing blocks.
     shredders: ShredderPool<RegularShredder>,
-    /// Event channel for sending notifications to Votor.
-    votor_channel: Sender<BlockstoreEvent>,
+    /// Buffer of events to be delivered to Votor, drained via [`Blockstore::take_events`].
+    ///
+    /// Events are buffered here (under whatever lock guards the blockstore) rather
+    /// than sent directly, so the caller can forward them to Votor *after* dropping
+    /// the write lock. See `BlockstoreImpl::emit` for the rationale.
+    events: Vec<BlockstoreEvent>,
+}
+
+impl Default for BlockstoreImpl {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl BlockstoreImpl {
     /// Initializes a new empty blockstore.
     ///
-    /// Blockstore will send the following [`BlockstoreEvent`]s to the provided `votor_channel`:
+    /// The blockstore records the following [`BlockstoreEvent`]s into its outbox, to
+    /// be drained by the caller via [`Blockstore::take_events`] and forwarded to Votor:
     /// - [`BlockstoreEvent::FirstShred`] when receiving the first shred for a slot
     ///   from the block dissemination protocol
     /// - [`BlockstoreEvent::Block`] for any reconstructed block
     /// - [`BlockstoreEvent::InvalidBlock`] if leader misbehavior is detected for a block
-    pub fn new(votor_channel: Sender<BlockstoreEvent>) -> Self {
+    pub fn new() -> Self {
         Self {
             block_data: BTreeMap::new(),
             shredders: ShredderPool::with_size(1),
-            votor_channel,
+            events: Vec::new(),
         }
     }
 
@@ -139,19 +154,19 @@ impl BlockstoreImpl {
         self.block_data = self.block_data.split_off(&slot);
     }
 
-    /// Forwards a [`BlockstoreEvent`] to Votor, returning the [`BlockInfo`] of a
+    /// Records a [`BlockstoreEvent`] in the outbox, returning the [`BlockInfo`] of a
     /// newly reconstructed block iff `event` is a [`BlockstoreEvent::Block`].
     ///
-    /// This uses a non-blocking [`Sender::try_send`] on purpose: the shred-ingest
-    /// path holds the blockstore write lock while adding a shred (see
-    /// [`super::Alpenglow::handle_disseminator_shred`]), so a blocking send would
-    /// let a slow or stalled Votor apply back-pressure that jams every other task
-    /// waiting on that lock. Instead, on overflow (channel full) or a closed
-    /// channel (Votor shutting down) we drop the event with a log message rather
-    /// than panicking. The block itself is still stored and handed to the Pool by
-    /// the caller, so a dropped event only costs this node its own vote for that
-    /// block under extreme back-pressure.
-    fn send_blockstore_event(&self, event: BlockstoreEvent) -> Option<BlockInfo> {
+    /// The event is buffered rather than sent on purpose: the shred-ingest path
+    /// holds the blockstore write lock while adding a shred (see
+    /// [`super::Alpenglow::handle_disseminator_shred`]), so a *blocking* send here
+    /// would let a slow or stalled Votor apply back-pressure that jams every other
+    /// task waiting on that lock. Instead the caller drains the outbox via
+    /// [`Blockstore::take_events`] and forwards it to Votor *after* dropping the
+    /// lock, where a blocking send is safe: it back-pressures the ingest task only,
+    /// never dropping the event. Losing a reconstructed-block event would otherwise
+    /// silently cost this node its vote for that block, with no retry path.
+    fn emit(&mut self, event: BlockstoreEvent) -> Option<BlockInfo> {
         let block_info = if let BlockstoreEvent::Block { slot, block_info } = &event {
             debug!(
                 "reconstructed block {} in slot {} with parent {} in slot {}",
@@ -164,15 +179,7 @@ impl BlockstoreImpl {
         } else {
             None
         };
-        match self.votor_channel.try_send(event) {
-            Ok(()) => {}
-            Err(TrySendError::Full(event)) => {
-                warn!("Votor event channel full, dropping blockstore event: {event:?}");
-            }
-            Err(TrySendError::Closed(event)) => {
-                debug!("Votor event channel closed, dropping blockstore event: {event:?}");
-            }
-        }
+        self.events.push(event);
         block_info
     }
 
@@ -276,7 +283,7 @@ impl Blockstore for BlockstoreImpl {
             .slot_data_mut(slot)
             .add_shred_from_dissemination(shred, &mut shredder)
         {
-            Ok(Some(event)) => Ok(self.send_blockstore_event(event)),
+            Ok(Some(event)) => Ok(self.emit(event)),
             Ok(None) => Ok(None),
             Err(err @ (AddShredError::Equivocation | AddShredError::InvalidShred)) => {
                 self.flag_leader_misbehavior(slot).await;
@@ -320,7 +327,7 @@ impl Blockstore for BlockstoreImpl {
             self.flag_leader_misbehavior(slot).await;
         }
         match result? {
-            Some(event) => Ok(self.send_blockstore_event(event)),
+            Some(event) => Ok(self.emit(event)),
             None => Ok(None),
         }
     }
@@ -342,12 +349,10 @@ impl Blockstore for BlockstoreImpl {
         let slot = shreds[0].payload().header.slot;
         let (first_shred, completed) = self.slot_data_mut(slot).add_own_slice(payload, *shreds);
         if first_shred {
-            self.send_blockstore_event(BlockstoreEvent::FirstShred(slot));
+            self.emit(BlockstoreEvent::FirstShred(slot));
         }
         match completed {
-            Some(block_info) => {
-                self.send_blockstore_event(BlockstoreEvent::Block { slot, block_info })
-            }
+            Some(block_info) => self.emit(BlockstoreEvent::Block { slot, block_info }),
             None => None,
         }
     }
@@ -357,8 +362,12 @@ impl Blockstore for BlockstoreImpl {
     /// Emits [`BlockstoreEvent::InvalidBlock`] the first time the slot is flagged.
     async fn flag_leader_misbehavior(&mut self, slot: Slot) {
         if self.slot_data_mut(slot).mark_leader_misbehaved() {
-            self.send_blockstore_event(BlockstoreEvent::InvalidBlock(slot));
+            self.emit(BlockstoreEvent::InvalidBlock(slot));
         }
+    }
+
+    fn take_events(&mut self) -> Vec<BlockstoreEvent> {
+        std::mem::take(&mut self.events)
     }
 
     /// Gives the disseminated block hash for a given `slot`, if any.
@@ -454,7 +463,6 @@ impl Blockstore for BlockstoreImpl {
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use tokio::sync::mpsc;
 
     use super::*;
     use crate::crypto::merkle::DoubleMerkleTree;
@@ -466,18 +474,12 @@ mod tests {
     struct TestContext {
         sk: SecretKey,
         blockstore: BlockstoreImpl,
-        _rx: mpsc::Receiver<BlockstoreEvent>,
     }
 
     fn setup() -> TestContext {
         let sk = SecretKey::new(&mut rand::rng());
-        let (tx, _rx) = mpsc::channel(1000);
-        let blockstore = BlockstoreImpl::new(tx);
-        TestContext {
-            sk,
-            blockstore,
-            _rx,
-        }
+        let blockstore = BlockstoreImpl::new();
+        TestContext { sk, blockstore }
     }
 
     async fn add_shred_ignore_duplicate(
@@ -503,8 +505,8 @@ mod tests {
     /// Feeds every shred of a fresh single-slice block into `blockstore` and
     /// returns the [`BlockInfo`] of the reconstructed block.
     ///
-    /// Reconstruction makes the blockstore emit `FirstShred` + `Block` events to
-    /// Votor via the (non-blocking) `send_blockstore_event`.
+    /// Reconstruction records `FirstShred` + `Block` events in the blockstore's
+    /// outbox, to be drained via [`Blockstore::take_events`].
     async fn store_full_block(blockstore: &mut BlockstoreImpl, sk: &SecretKey) -> BlockInfo {
         let slot = Slot::genesis().next();
         let (block_hash, _, shreds) = create_random_shredded_block(slot, 1, sk);
@@ -519,28 +521,30 @@ mod tests {
         info
     }
 
-    /// A full Votor channel must not panic or block the blockstore: the event is
-    /// dropped on overflow, yet the block is still reconstructed and returned.
+    /// Reconstructing a block must record its `FirstShred` and `Block` events in the
+    /// outbox (rather than sending them under the lock), so the caller can forward
+    /// them to Votor losslessly after releasing the write lock.
     #[tokio::test]
-    async fn block_event_dropped_when_channel_full() {
-        let sk = SecretKey::new(&mut rand::rng());
-        // Capacity 1, never drained: `FirstShred` fills it, `Block` overflows.
-        let (tx, _rx) = mpsc::channel(1);
-        let mut blockstore = BlockstoreImpl::new(tx);
+    async fn reconstruction_events_are_recorded() {
+        let mut ctx = setup();
+        let info = store_full_block(&mut ctx.blockstore, &ctx.sk).await;
 
-        store_full_block(&mut blockstore, &sk).await;
-    }
-
-    /// A closed Votor channel (Votor shutting down) must not panic the blockstore;
-    /// the event is dropped and the block is still reconstructed and returned.
-    #[tokio::test]
-    async fn block_event_dropped_when_channel_closed() {
-        let sk = SecretKey::new(&mut rand::rng());
-        let (tx, rx) = mpsc::channel(1000);
-        let mut blockstore = BlockstoreImpl::new(tx);
-        drop(rx);
-
-        store_full_block(&mut blockstore, &sk).await;
+        let events = ctx.blockstore.take_events();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, BlockstoreEvent::FirstShred(_))),
+            "expected a FirstShred event, got {events:?}"
+        );
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                BlockstoreEvent::Block { block_info, .. } if block_info.hash == info.hash
+            )),
+            "expected a Block event for the reconstructed block, got {events:?}"
+        );
+        // Draining leaves the outbox empty.
+        assert!(ctx.blockstore.take_events().is_empty());
     }
 
     #[tokio::test]
@@ -769,21 +773,19 @@ mod tests {
         Ok(())
     }
 
-    fn count_invalid_block_events(rx: &mut mpsc::Receiver<BlockstoreEvent>, slot: Slot) -> usize {
-        let mut count = 0;
-        while let Ok(event) = rx.try_recv() {
-            if matches!(event, BlockstoreEvent::InvalidBlock(s) if s == slot) {
-                count += 1;
-            }
-        }
-        count
+    /// Drains the blockstore outbox and counts `InvalidBlock` events for `slot`.
+    fn count_invalid_block_events(blockstore: &mut BlockstoreImpl, slot: Slot) -> usize {
+        blockstore
+            .take_events()
+            .iter()
+            .filter(|e| matches!(e, BlockstoreEvent::InvalidBlock(s) if *s == slot))
+            .count()
     }
 
     #[tokio::test]
     async fn dissemination_equivocation() -> Result<()> {
         let sk = SecretKey::new(&mut rand::rng());
-        let (tx, mut rx) = mpsc::channel(1000);
-        let mut blockstore = BlockstoreImpl::new(tx);
+        let mut blockstore = BlockstoreImpl::new();
         let slot = Slot::genesis().next();
 
         // disseminate two distinct blocks for the same slot
@@ -798,11 +800,11 @@ mod tests {
 
         // equivocation detected, Votor should be notified
         assert_eq!(res, Err(AddShredError::Equivocation));
-        assert_eq!(count_invalid_block_events(&mut rx, slot), 1);
+        assert_eq!(count_invalid_block_events(&mut blockstore, slot), 1);
 
         // idempotent: later misbehavior does not re-notify
         blockstore.flag_leader_misbehavior(slot).await;
-        assert_eq!(count_invalid_block_events(&mut rx, slot), 0);
+        assert_eq!(count_invalid_block_events(&mut blockstore, slot), 0);
 
         Ok(())
     }
@@ -810,8 +812,7 @@ mod tests {
     #[tokio::test]
     async fn repair_conflicting_block_not_flagged_as_equivocation() -> Result<()> {
         let sk = SecretKey::new(&mut rand::rng());
-        let (tx, mut rx) = mpsc::channel(1000);
-        let mut blockstore = BlockstoreImpl::new(tx);
+        let mut blockstore = BlockstoreImpl::new();
         let slot = Slot::genesis().next();
 
         // see different blocks from dissemination and repair
@@ -826,7 +827,7 @@ mod tests {
 
         // TODO: Detect equivocation across the dissemination and repair spots.
         assert_eq!(res, Ok(None));
-        assert_eq!(count_invalid_block_events(&mut rx, slot), 0);
+        assert_eq!(count_invalid_block_events(&mut blockstore, slot), 0);
 
         Ok(())
     }
@@ -904,8 +905,7 @@ mod tests {
         let slices = create_random_block(slot, num_slices);
 
         // reference: reconstruct the block via the dissemination path
-        let (dissem_tx, _dissem_rx) = mpsc::channel(1000);
-        let mut dissem = BlockstoreImpl::new(dissem_tx);
+        let mut dissem = BlockstoreImpl::new();
         for slice in &slices {
             let shreds = RegularShredder::default().shred(slice, &sk).unwrap();
             for shred in shreds {
@@ -915,8 +915,7 @@ mod tests {
         let expected_hash = dissem.disseminated_block_hash(slot).unwrap().clone();
 
         // fast path: feed the same slices through `add_own_slice`
-        let (own_tx, mut own_rx) = mpsc::channel(1000);
-        let mut own = BlockstoreImpl::new(own_tx);
+        let mut own = BlockstoreImpl::new();
         let mut completed = None;
         for slice in slices {
             let is_last = slice.is_last;
@@ -936,10 +935,10 @@ mod tests {
         assert_eq!(own.disseminated_block_hash(slot), Some(&expected_hash));
         assert!(own.get_block(&(slot, expected_hash.clone())).is_some());
 
-        // emits exactly one FirstShred and one Block event
+        // records exactly one FirstShred and one Block event in the outbox
         let mut first_shreds = 0;
         let mut blocks = 0;
-        while let Ok(event) = own_rx.try_recv() {
+        for event in own.take_events() {
             match event {
                 BlockstoreEvent::FirstShred(s) => {
                     assert_eq!(s, slot);

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -21,7 +21,7 @@ use crate::shredder::{
 use crate::types::{SliceIndex, SlicePayload};
 use crate::{Block, BlockId, Slot};
 
-/// Events emitted by [`BlockstoreImpl`] to [`super::votor::Votor`].
+/// Events emitted by [`BlockstoreImpl`] to the consensus core (`VotorState`).
 #[derive(Clone, Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum BlockstoreEvent {
@@ -158,7 +158,7 @@ impl BlockstoreImpl {
     /// newly reconstructed block iff `event` is a [`BlockstoreEvent::Block`].
     ///
     /// Events are buffered rather than sent so the caller can forward them off the
-    /// write lock (see [`super::EventForwarder`]). This matters most for the `Block`
+    /// consensus core off the write lock. This matters most for the `Block`
     /// event: dropping it would silently cost this node its vote for that block,
     /// with no retry path.
     fn emit(&mut self, event: BlockstoreEvent) -> Option<BlockInfo> {
@@ -517,7 +517,7 @@ mod tests {
 
     /// Reconstructing a block must record its `FirstShred` and `Block` events in the
     /// outbox (rather than sending them under the lock), so the caller can forward
-    /// them to Votor losslessly after releasing the write lock.
+    /// them to the consensus core losslessly after releasing the write lock.
     #[test]
     fn reconstruction_events_are_recorded() {
         let mut ctx = setup();

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -8,7 +8,6 @@ mod slot_block_data;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use log::debug;
 use tokio::sync::RwLock;
 
@@ -63,24 +62,28 @@ impl From<&Block> for BlockInfo {
 /// Interface for the blockstore.
 ///
 /// This is only used for mocking of [`BlockstoreImpl`].
-#[async_trait]
+///
+/// All methods are synchronous: the blockstore is a pure state machine that
+/// performs no I/O and buffers its side-effects as [`BlockstoreEvent`]s, so no
+/// method ever needs to await (and none may, as callers invoke them under a
+/// write lock).
 #[cfg_attr(test, mockall::automock)]
 pub trait Blockstore {
-    async fn add_shred_from_dissemination(
+    fn add_shred_from_dissemination(
         &mut self,
         shred: ValidatedShred,
     ) -> Result<Option<BlockInfo>, AddShredError>;
-    async fn add_shred_from_repair(
+    fn add_shred_from_repair(
         &mut self,
         hash: BlockHash,
         shred: ValidatedShred,
     ) -> Result<Option<BlockInfo>, AddShredError>;
-    async fn add_own_slice(
+    fn add_own_slice(
         &mut self,
         payload: SlicePayload,
         shreds: Box<[ValidatedShred; TOTAL_SHREDS]>,
     ) -> Option<BlockInfo>;
-    async fn flag_leader_misbehavior(&mut self, slot: Slot);
+    fn flag_leader_misbehavior(&mut self, slot: Slot);
     /// Drains and returns the [`BlockstoreEvent`]s buffered since the last call.
     ///
     /// The caller must forward these to Votor *after* releasing the blockstore
@@ -247,7 +250,6 @@ impl BlockstoreImpl {
     }
 }
 
-#[async_trait]
 impl Blockstore for BlockstoreImpl {
     /// Stores a new shred in the blockstore.
     ///
@@ -262,7 +264,7 @@ impl Blockstore for BlockstoreImpl {
     /// Returns the block's [`BlockInfo`] on reconstruction, `None` otherwise.
     #[hotpath::measure]
     #[fastrace::trace(short_name = true)]
-    async fn add_shred_from_dissemination(
+    fn add_shred_from_dissemination(
         &mut self,
         shred: ValidatedShred,
     ) -> Result<Option<BlockInfo>, AddShredError> {
@@ -278,7 +280,7 @@ impl Blockstore for BlockstoreImpl {
             Ok(Some(event)) => Ok(self.emit(event)),
             Ok(None) => Ok(None),
             Err(err @ (AddShredError::Equivocation | AddShredError::InvalidShred)) => {
-                self.flag_leader_misbehavior(slot).await;
+                self.flag_leader_misbehavior(slot);
                 Err(err)
             }
             Err(e) => Err(e),
@@ -298,7 +300,7 @@ impl Blockstore for BlockstoreImpl {
     /// Returns the block's [`BlockInfo`] on reconstruction, `None` otherwise.
     #[hotpath::measure]
     #[fastrace::trace(short_name = true)]
-    async fn add_shred_from_repair(
+    fn add_shred_from_repair(
         &mut self,
         hash: BlockHash,
         shred: ValidatedShred,
@@ -316,7 +318,7 @@ impl Blockstore for BlockstoreImpl {
             result,
             Err(AddShredError::Equivocation | AddShredError::InvalidShred)
         ) {
-            self.flag_leader_misbehavior(slot).await;
+            self.flag_leader_misbehavior(slot);
         }
         match result? {
             Some(event) => Ok(self.emit(event)),
@@ -333,7 +335,7 @@ impl Blockstore for BlockstoreImpl {
     /// Returns the block's [`BlockInfo`] on reconstruction, `None` otherwise.
     #[hotpath::measure]
     #[fastrace::trace(short_name = true)]
-    async fn add_own_slice(
+    fn add_own_slice(
         &mut self,
         payload: SlicePayload,
         shreds: Box<[ValidatedShred; TOTAL_SHREDS]>,
@@ -352,7 +354,7 @@ impl Blockstore for BlockstoreImpl {
     /// Flags the leader as misbehaving for `slot`, notifying Votor exactly once.
     ///
     /// Emits [`BlockstoreEvent::InvalidBlock`] the first time the slot is flagged.
-    async fn flag_leader_misbehavior(&mut self, slot: Slot) {
+    fn flag_leader_misbehavior(&mut self, slot: Slot) {
         if self.slot_data_mut(slot).mark_leader_misbehaved() {
             self.emit(BlockstoreEvent::InvalidBlock(slot));
         }
@@ -474,11 +476,11 @@ mod tests {
         TestContext { sk, blockstore }
     }
 
-    async fn add_shred_ignore_duplicate(
+    fn add_shred_ignore_duplicate(
         blockstore: &mut BlockstoreImpl,
         shred: ValidatedShred,
     ) -> Result<Option<BlockInfo>, AddShredError> {
-        match blockstore.add_shred_from_dissemination(shred).await {
+        match blockstore.add_shred_from_dissemination(shred) {
             Ok(output) => Ok(output),
             Err(AddShredError::Duplicate) => Ok(None),
             Err(e) => Err(e),
@@ -499,12 +501,12 @@ mod tests {
     ///
     /// Reconstruction records `FirstShred` + `Block` events in the blockstore's
     /// outbox, to be drained via [`Blockstore::take_events`].
-    async fn store_full_block(blockstore: &mut BlockstoreImpl, sk: &SecretKey) -> BlockInfo {
+    fn store_full_block(blockstore: &mut BlockstoreImpl, sk: &SecretKey) -> BlockInfo {
         let slot = Slot::genesis().next();
         let (block_hash, _, shreds) = create_random_shredded_block(slot, 1, sk);
         let mut reconstructed = None;
         for shred in shreds.into_iter().flatten() {
-            if let Some(info) = add_shred_ignore_duplicate(blockstore, shred).await.unwrap() {
+            if let Some(info) = add_shred_ignore_duplicate(blockstore, shred).unwrap() {
                 reconstructed = Some(info);
             }
         }
@@ -516,10 +518,10 @@ mod tests {
     /// Reconstructing a block must record its `FirstShred` and `Block` events in the
     /// outbox (rather than sending them under the lock), so the caller can forward
     /// them to Votor losslessly after releasing the write lock.
-    #[tokio::test]
-    async fn reconstruction_events_are_recorded() {
+    #[test]
+    fn reconstruction_events_are_recorded() {
         let mut ctx = setup();
-        let info = store_full_block(&mut ctx.blockstore, &ctx.sk).await;
+        let info = store_full_block(&mut ctx.blockstore, &ctx.sk);
 
         let events = ctx.blockstore.take_events();
         assert!(
@@ -539,8 +541,8 @@ mod tests {
         assert!(ctx.blockstore.take_events().is_empty());
     }
 
-    #[tokio::test]
-    async fn store_one_slice_block() -> Result<()> {
+    #[test]
+    fn store_one_slice_block() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.slot_data(slot).is_none());
@@ -552,7 +554,7 @@ mod tests {
         let slice_hash = shreds[0][0].slice_root();
         for shred in &shreds[0] {
             // store shred
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred.clone()).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred.clone())?;
 
             // check shred is stored
             let Some(stored_shred) = ctx.blockstore.get_disseminated_shred(
@@ -578,8 +580,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn store_two_slice_block() -> Result<()> {
+    #[test]
+    fn store_two_slice_block() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.slot_data(slot).is_none());
@@ -589,21 +591,21 @@ mod tests {
 
         // first slice is not enough
         for shred in slices[0].clone() {
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_none());
 
         // after second slice we should have the block
         for shred in slices[1].clone() {
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_some());
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn store_block_from_repair() -> Result<()> {
+    #[test]
+    fn store_block_from_repair() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.slot_data(slot).is_none());
@@ -614,8 +616,7 @@ mod tests {
         // first slice is not enough
         for shred in slices[0].clone().into_iter().take(DATA_SHREDS) {
             ctx.blockstore
-                .add_shred_from_repair(block_hash.clone(), shred)
-                .await?;
+                .add_shred_from_repair(block_hash.clone(), shred)?;
         }
         assert!(
             ctx.blockstore
@@ -626,16 +627,15 @@ mod tests {
         // after second slice we should have the block
         for shred in slices[1].clone().into_iter().take(DATA_SHREDS) {
             ctx.blockstore
-                .add_shred_from_repair(block_hash.clone(), shred)
-                .await?;
+                .add_shred_from_repair(block_hash.clone(), shred)?;
         }
         assert!(ctx.blockstore.get_block(&(slot, block_hash)).is_some());
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn out_of_order_shreds() -> Result<()> {
+    #[test]
+    fn out_of_order_shreds() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_none());
@@ -645,15 +645,15 @@ mod tests {
 
         // insert shreds in reverse order
         for shred in slices[0].clone().into_iter().rev() {
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_some());
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn just_enough_shreds() -> Result<()> {
+    #[test]
+    fn just_enough_shreds() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_none());
@@ -664,7 +664,7 @@ mod tests {
 
         // insert just enough shreds to reconstruct slice 0 (from beginning)
         for shred in slices[0].clone().into_iter().take(DATA_SHREDS) {
-            ctx.blockstore.add_shred_from_dissemination(shred).await?;
+            ctx.blockstore.add_shred_from_dissemination(shred)?;
         }
         assert_eq!(ctx.blockstore.stored_slices_for_slot(slot), 1);
 
@@ -674,7 +674,7 @@ mod tests {
             .into_iter()
             .skip(TOTAL_SHREDS - DATA_SHREDS)
         {
-            ctx.blockstore.add_shred_from_dissemination(shred).await?;
+            ctx.blockstore.add_shred_from_dissemination(shred)?;
         }
         assert_eq!(ctx.blockstore.stored_slices_for_slot(slot), 2);
 
@@ -685,7 +685,7 @@ mod tests {
             .skip((TOTAL_SHREDS - DATA_SHREDS) / 2)
             .take(DATA_SHREDS)
         {
-            ctx.blockstore.add_shred_from_dissemination(shred).await?;
+            ctx.blockstore.add_shred_from_dissemination(shred)?;
         }
         assert_eq!(ctx.blockstore.stored_slices_for_slot(slot), 3);
 
@@ -696,7 +696,7 @@ mod tests {
             .enumerate()
             .filter(|(i, _)| *i < DATA_SHREDS / 2 || *i >= TOTAL_SHREDS - DATA_SHREDS / 2)
         {
-            ctx.blockstore.add_shred_from_dissemination(shred).await?;
+            ctx.blockstore.add_shred_from_dissemination(shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_some());
 
@@ -706,8 +706,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn out_of_order_slices() -> Result<()> {
+    #[test]
+    fn out_of_order_slices() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_none());
@@ -717,7 +717,7 @@ mod tests {
 
         // second slice alone is not enough
         for shred in slices[0].clone() {
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_none());
 
@@ -726,7 +726,7 @@ mod tests {
 
         // after also also inserting first slice we should have the block
         for shred in slices[1].clone() {
-            add_shred_ignore_duplicate(&mut ctx.blockstore, shred).await?;
+            add_shred_ignore_duplicate(&mut ctx.blockstore, shred)?;
         }
         assert!(ctx.blockstore.disseminated_block_hash(slot).is_some());
 
@@ -739,8 +739,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn duplicate_shreds() -> Result<()> {
+    #[test]
+    fn duplicate_shreds() -> Result<()> {
         let mut ctx = setup();
         let slot = Slot::genesis().next();
         let (_hash, _tree, slices) = create_random_shredded_block(slot, 1, &ctx.sk);
@@ -748,15 +748,13 @@ mod tests {
         // inserting single shred should not throw errors
         let res = ctx
             .blockstore
-            .add_shred_from_dissemination(slices[0][0].clone())
-            .await;
+            .add_shred_from_dissemination(slices[0][0].clone());
         assert!(res.is_ok());
 
         // inserting same shred again should give duplicate error
         let res = ctx
             .blockstore
-            .add_shred_from_dissemination(slices[0][0].clone())
-            .await;
+            .add_shred_from_dissemination(slices[0][0].clone());
         assert_eq!(res, Err(AddShredError::Duplicate));
 
         // should only store one copy
@@ -774,8 +772,8 @@ mod tests {
             .count()
     }
 
-    #[tokio::test]
-    async fn dissemination_equivocation() -> Result<()> {
+    #[test]
+    fn dissemination_equivocation() -> Result<()> {
         let sk = SecretKey::new(&mut rand::rng());
         let mut blockstore = BlockstoreImpl::new();
         let slot = Slot::genesis().next();
@@ -783,26 +781,22 @@ mod tests {
         // disseminate two distinct blocks for the same slot
         let (_h0, _t0, slices0) = create_random_shredded_block(slot, 1, &sk);
         let (_h1, _t1, slices1) = create_random_shredded_block(slot, 1, &sk);
-        blockstore
-            .add_shred_from_dissemination(slices0[0][0].clone())
-            .await?;
-        let res = blockstore
-            .add_shred_from_dissemination(slices1[0][0].clone())
-            .await;
+        blockstore.add_shred_from_dissemination(slices0[0][0].clone())?;
+        let res = blockstore.add_shred_from_dissemination(slices1[0][0].clone());
 
         // equivocation detected, Votor should be notified
         assert_eq!(res, Err(AddShredError::Equivocation));
         assert_eq!(count_invalid_block_events(&mut blockstore, slot), 1);
 
         // idempotent: later misbehavior does not re-notify
-        blockstore.flag_leader_misbehavior(slot).await;
+        blockstore.flag_leader_misbehavior(slot);
         assert_eq!(count_invalid_block_events(&mut blockstore, slot), 0);
 
         Ok(())
     }
 
-    #[tokio::test]
-    async fn repair_conflicting_block_not_flagged_as_equivocation() -> Result<()> {
+    #[test]
+    fn repair_conflicting_block_not_flagged_as_equivocation() -> Result<()> {
         let sk = SecretKey::new(&mut rand::rng());
         let mut blockstore = BlockstoreImpl::new();
         let slot = Slot::genesis().next();
@@ -810,12 +804,8 @@ mod tests {
         // see different blocks from dissemination and repair
         let (_h0, _t0, slices0) = create_random_shredded_block(slot, 1, &sk);
         let (hash, _t1, slices1) = create_random_shredded_block(slot, 1, &sk);
-        blockstore
-            .add_shred_from_dissemination(slices0[0][0].clone())
-            .await?;
-        let res = blockstore
-            .add_shred_from_repair(hash, slices1[0][0].clone())
-            .await;
+        blockstore.add_shred_from_dissemination(slices0[0][0].clone())?;
+        let res = blockstore.add_shred_from_repair(hash, slices1[0][0].clone());
 
         // TODO: Detect equivocation across the dissemination and repair spots.
         assert_eq!(res, Ok(None));
@@ -824,8 +814,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn pruning() -> Result<()> {
+    #[test]
+    fn pruning() -> Result<()> {
         let mut ctx = setup();
         let block0_slot = Slot::genesis().next();
         let block1_slot = block0_slot.next();
@@ -843,7 +833,7 @@ mod tests {
         shreds.extend(block1.2.into_iter().flatten());
         shreds.extend(block2.2.into_iter().flatten());
         for shred in shreds {
-            add_shred_ignore_duplicate(blockstore, shred).await?;
+            add_shred_ignore_duplicate(blockstore, shred)?;
         }
         assert!(blockstore.disseminated_block_hash(block0_slot).is_some());
         assert!(blockstore.disseminated_block_hash(block1_slot).is_some());
@@ -881,17 +871,17 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn add_own_slice_matches_dissemination_single_slice() -> Result<()> {
-        check_own_slice_matches_dissemination(1).await
+    #[test]
+    fn add_own_slice_matches_dissemination_single_slice() -> Result<()> {
+        check_own_slice_matches_dissemination(1)
     }
 
-    #[tokio::test]
-    async fn add_own_slice_matches_dissemination_multi_slice() -> Result<()> {
-        check_own_slice_matches_dissemination(3).await
+    #[test]
+    fn add_own_slice_matches_dissemination_multi_slice() -> Result<()> {
+        check_own_slice_matches_dissemination(3)
     }
 
-    async fn check_own_slice_matches_dissemination(num_slices: usize) -> Result<()> {
+    fn check_own_slice_matches_dissemination(num_slices: usize) -> Result<()> {
         let sk = SecretKey::new(&mut rand::rng());
         let slot = Slot::genesis().next();
         let slices = create_random_block(slot, num_slices);
@@ -901,7 +891,7 @@ mod tests {
         for slice in &slices {
             let shreds = RegularShredder::default().shred(slice, &sk).unwrap();
             for shred in shreds {
-                add_shred_ignore_duplicate(&mut dissem, shred).await?;
+                add_shred_ignore_duplicate(&mut dissem, shred)?;
             }
         }
         let expected_hash = dissem.disseminated_block_hash(slot).unwrap().clone();
@@ -912,7 +902,7 @@ mod tests {
         for slice in slices {
             let is_last = slice.is_last;
             let (payload, shreds) = shred_as_leader(slice, &sk);
-            let block_info = own.add_own_slice(payload, Box::new(shreds)).await;
+            let block_info = own.add_own_slice(payload, Box::new(shreds));
             // only the last slice completes the block
             assert_eq!(block_info.is_some(), is_last);
             if let Some(info) = block_info {

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -118,11 +118,8 @@ pub struct BlockstoreImpl {
     block_data: BTreeMap<Slot, SlotBlockData>,
     /// Shredders used for reconstructing blocks.
     shredders: ShredderPool<RegularShredder>,
-    /// Buffer of events to be delivered to Votor, drained via [`Blockstore::take_events`].
-    ///
-    /// Events are buffered here (under whatever lock guards the blockstore) rather
-    /// than sent directly, so the caller can forward them to Votor *after* dropping
-    /// the write lock. See `BlockstoreImpl::emit` for the rationale.
+    /// Events buffered for Votor, drained via [`Blockstore::take_events`].
+    /// See [`Self::emit`] for why they are buffered rather than sent.
     events: Vec<BlockstoreEvent>,
 }
 
@@ -157,15 +154,10 @@ impl BlockstoreImpl {
     /// Records a [`BlockstoreEvent`] in the outbox, returning the [`BlockInfo`] of a
     /// newly reconstructed block iff `event` is a [`BlockstoreEvent::Block`].
     ///
-    /// The event is buffered rather than sent on purpose: the shred-ingest path
-    /// holds the blockstore write lock while adding a shred (see
-    /// [`super::Alpenglow::handle_disseminator_shred`]), so a *blocking* send here
-    /// would let a slow or stalled Votor apply back-pressure that jams every other
-    /// task waiting on that lock. Instead the caller drains the outbox via
-    /// [`Blockstore::take_events`] and forwards it to Votor *after* dropping the
-    /// lock, where a blocking send is safe: it back-pressures the ingest task only,
-    /// never dropping the event. Losing a reconstructed-block event would otherwise
-    /// silently cost this node its vote for that block, with no retry path.
+    /// Events are buffered rather than sent so the caller can forward them off the
+    /// write lock (see [`super::EventForwarder`]). This matters most for the `Block`
+    /// event: dropping it would silently cost this node its vote for that block,
+    /// with no retry path.
     fn emit(&mut self, event: BlockstoreEvent) -> Option<BlockInfo> {
         let block_info = if let BlockstoreEvent::Block { slot, block_info } = &event {
             debug!(

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -9,9 +9,10 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use log::debug;
+use log::{debug, warn};
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::error::TrySendError;
 
 pub use self::slot_block_data::AddShredError;
 use self::slot_block_data::SlotBlockData;
@@ -138,24 +139,40 @@ impl BlockstoreImpl {
         self.block_data = self.block_data.split_off(&slot);
     }
 
-    async fn send_blockstore_event(&self, event: BlockstoreEvent) -> Option<BlockInfo> {
-        let block_info = match &event {
-            BlockstoreEvent::FirstShred(_) | BlockstoreEvent::InvalidBlock(_) => None,
-            BlockstoreEvent::Block { slot, block_info } => {
-                debug!(
-                    "reconstructed block {} in slot {} with parent {} in slot {}",
-                    block_info.hash.short_hex(),
-                    slot,
-                    block_info.parent.1.short_hex(),
-                    block_info.parent.0,
-                );
-                Some(block_info.clone())
-            }
+    /// Forwards a [`BlockstoreEvent`] to Votor, returning the [`BlockInfo`] of a
+    /// newly reconstructed block iff `event` is a [`BlockstoreEvent::Block`].
+    ///
+    /// This uses a non-blocking [`Sender::try_send`] on purpose: the shred-ingest
+    /// path holds the blockstore write lock while adding a shred (see
+    /// [`super::Alpenglow::handle_disseminator_shred`]), so a blocking send would
+    /// let a slow or stalled Votor apply back-pressure that jams every other task
+    /// waiting on that lock. Instead, on overflow (channel full) or a closed
+    /// channel (Votor shutting down) we drop the event with a log message rather
+    /// than panicking. The block itself is still stored and handed to the Pool by
+    /// the caller, so a dropped event only costs this node its own vote for that
+    /// block under extreme back-pressure.
+    fn send_blockstore_event(&self, event: BlockstoreEvent) -> Option<BlockInfo> {
+        let block_info = if let BlockstoreEvent::Block { slot, block_info } = &event {
+            debug!(
+                "reconstructed block {} in slot {} with parent {} in slot {}",
+                block_info.hash.short_hex(),
+                slot,
+                block_info.parent.1.short_hex(),
+                block_info.parent.0,
+            );
+            Some(block_info.clone())
+        } else {
+            None
         };
-        self.votor_channel
-            .send(event)
-            .await
-            .expect("votor should not drop the event receiver");
+        match self.votor_channel.try_send(event) {
+            Ok(()) => {}
+            Err(TrySendError::Full(event)) => {
+                warn!("Votor event channel full, dropping blockstore event: {event:?}");
+            }
+            Err(TrySendError::Closed(event)) => {
+                debug!("Votor event channel closed, dropping blockstore event: {event:?}");
+            }
+        }
         block_info
     }
 
@@ -259,7 +276,7 @@ impl Blockstore for BlockstoreImpl {
             .slot_data_mut(slot)
             .add_shred_from_dissemination(shred, &mut shredder)
         {
-            Ok(Some(event)) => Ok(self.send_blockstore_event(event).await),
+            Ok(Some(event)) => Ok(self.send_blockstore_event(event)),
             Ok(None) => Ok(None),
             Err(err @ (AddShredError::Equivocation | AddShredError::InvalidShred)) => {
                 self.flag_leader_misbehavior(slot).await;
@@ -303,7 +320,7 @@ impl Blockstore for BlockstoreImpl {
             self.flag_leader_misbehavior(slot).await;
         }
         match result? {
-            Some(event) => Ok(self.send_blockstore_event(event).await),
+            Some(event) => Ok(self.send_blockstore_event(event)),
             None => Ok(None),
         }
     }
@@ -325,13 +342,11 @@ impl Blockstore for BlockstoreImpl {
         let slot = shreds[0].payload().header.slot;
         let (first_shred, completed) = self.slot_data_mut(slot).add_own_slice(payload, *shreds);
         if first_shred {
-            self.send_blockstore_event(BlockstoreEvent::FirstShred(slot))
-                .await;
+            self.send_blockstore_event(BlockstoreEvent::FirstShred(slot));
         }
         match completed {
             Some(block_info) => {
                 self.send_blockstore_event(BlockstoreEvent::Block { slot, block_info })
-                    .await
             }
             None => None,
         }
@@ -342,8 +357,7 @@ impl Blockstore for BlockstoreImpl {
     /// Emits [`BlockstoreEvent::InvalidBlock`] the first time the slot is flagged.
     async fn flag_leader_misbehavior(&mut self, slot: Slot) {
         if self.slot_data_mut(slot).mark_leader_misbehaved() {
-            self.send_blockstore_event(BlockstoreEvent::InvalidBlock(slot))
-                .await;
+            self.send_blockstore_event(BlockstoreEvent::InvalidBlock(slot));
         }
     }
 
@@ -484,6 +498,49 @@ mod tests {
         let shreds = RegularShredder::default().shred(&slice, sk).unwrap();
         let (_header, payload) = slice.deconstruct();
         (payload, shreds)
+    }
+
+    /// Feeds every shred of a fresh single-slice block into `blockstore` and
+    /// returns the [`BlockInfo`] of the reconstructed block.
+    ///
+    /// Reconstruction makes the blockstore emit `FirstShred` + `Block` events to
+    /// Votor via the (non-blocking) `send_blockstore_event`.
+    async fn store_full_block(blockstore: &mut BlockstoreImpl, sk: &SecretKey) -> BlockInfo {
+        let slot = Slot::genesis().next();
+        let (block_hash, _, shreds) = create_random_shredded_block(slot, 1, sk);
+        let mut reconstructed = None;
+        for shred in shreds.into_iter().flatten() {
+            if let Some(info) = add_shred_ignore_duplicate(blockstore, shred).await.unwrap() {
+                reconstructed = Some(info);
+            }
+        }
+        let info = reconstructed.expect("block should reconstruct from all its shreds");
+        assert_eq!(info.hash, block_hash);
+        info
+    }
+
+    /// A full Votor channel must not panic or block the blockstore: the event is
+    /// dropped on overflow, yet the block is still reconstructed and returned.
+    #[tokio::test]
+    async fn block_event_dropped_when_channel_full() {
+        let sk = SecretKey::new(&mut rand::rng());
+        // Capacity 1, never drained: `FirstShred` fills it, `Block` overflows.
+        let (tx, _rx) = mpsc::channel(1);
+        let mut blockstore = BlockstoreImpl::new(tx);
+
+        store_full_block(&mut blockstore, &sk).await;
+    }
+
+    /// A closed Votor channel (Votor shutting down) must not panic the blockstore;
+    /// the event is dropped and the block is still reconstructed and returned.
+    #[tokio::test]
+    async fn block_event_dropped_when_channel_closed() {
+        let sk = SecretKey::new(&mut rand::rng());
+        let (tx, rx) = mpsc::channel(1000);
+        let mut blockstore = BlockstoreImpl::new(tx);
+        drop(rx);
+
+        store_full_block(&mut blockstore, &sk).await;
     }
 
     #[tokio::test]

--- a/src/consensus/core.rs
+++ b/src/consensus/core.rs
@@ -1,0 +1,327 @@
+// Copyright (c) Anza Technology, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Synchronous consensus core state machine.
+//!
+//! [`ConsensusCore`] combines the [`PoolImpl`] and [`VotorState`] state
+//! machines (plus standstill detection) into a single deterministic transition
+//! function: [`ConsensusCore::handle`] consumes an [`Input`], advances the
+//! state, and appends the resulting [`Output`]s to a buffer. It performs no
+//! I/O, holds no locks and never awaits; all networking happens in the
+//! [`super::driver`] task and the ingest tasks feeding it.
+//!
+//! What used to flow through channels between the pool, Votor and the
+//! standstill loop is now plain function calls inside [`ConsensusCore::handle`],
+//! so event ordering is deterministic and the whole consensus logic can be
+//! driven (and tested) without a tokio runtime.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use log::{trace, warn};
+
+use super::blockstore::BlockstoreEvent;
+use super::pool::{PoolEvent, PoolImpl, PoolOutbox};
+use super::votor::VotorState;
+use super::{
+    AddVoteError, ConsensusMessage, DELTA_STANDSTILL, ValidatedCert, ValidatedVote,
+    ValidatorEpochInfo,
+};
+use crate::crypto::aggsig;
+use crate::{BlockId, Slot};
+
+/// Inputs consumed by [`ConsensusCore::handle`].
+///
+/// Everything the consensus logic reacts to arrives as one of these,
+/// pre-validated by the ingest tasks (signature checks happen *before* an
+/// input is constructed, so the core never verifies crypto).
+#[derive(Debug)]
+pub(crate) enum Input {
+    /// A verified vote received from another validator.
+    Vote(ValidatedVote),
+    /// A verified certificate received from another validator.
+    Cert(ValidatedCert),
+    /// An event drained from the blockstore by an ingest task
+    /// (dissemination, repair, or own block production).
+    BlockstoreEvent(BlockstoreEvent),
+    /// The clock advanced to [`ConsensusCore::next_timeout`].
+    Tick,
+}
+
+/// Side-effects produced by [`ConsensusCore::handle`].
+///
+/// The [`super::driver`] task routes each output to the edge task that
+/// performs the corresponding I/O.
+// PERF: Short-lived buffer entry; boxing the message isn't worth the allocation.
+#[expect(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub(crate) enum Output {
+    /// Broadcast a consensus message to all validators (best-effort).
+    Broadcast(ConsensusMessage),
+    /// Ask the repair loop to fetch this block.
+    RequestRepair(BlockId),
+    /// The slot (a window start) has a valid parent for block production.
+    ParentReady { slot: Slot, parent: BlockId },
+    /// A new highest slot was finalized.
+    Finalized(Slot),
+}
+
+/// The consensus protocol as a synchronous state machine.
+///
+/// Owns the vote/cert pool and the voting logic outright — no locks, no
+/// channels. Mutations enter exclusively through [`Self::handle`].
+pub(crate) struct ConsensusCore {
+    /// Pool of votes and certificates.
+    pool: PoolImpl,
+    /// Voting state machine.
+    votor: VotorState,
+    /// Highest finalized slot already reported via [`Output::Finalized`].
+    finalized_slot: Slot,
+    /// Time of the last observed finalization progress (or standstill recovery),
+    /// used for standstill detection.
+    last_progress: Instant,
+}
+
+impl ConsensusCore {
+    /// Creates a new consensus core with an empty pool and fresh voting state.
+    ///
+    /// Votor timeouts for the genesis window and the standstill deadline are
+    /// scheduled relative to `now`.
+    pub(crate) fn new(
+        epoch_info: Arc<ValidatorEpochInfo>,
+        voting_key: aggsig::SecretKey,
+        now: Instant,
+    ) -> Self {
+        let own_id = epoch_info.own_id();
+        Self {
+            pool: PoolImpl::new(epoch_info),
+            votor: VotorState::new(own_id, voting_key, now),
+            finalized_slot: Slot::genesis(),
+            last_progress: now,
+        }
+    }
+
+    /// Advances the state machine by one input, appending side-effects to `out`.
+    pub(crate) fn handle(&mut self, input: Input, now: Instant, out: &mut Vec<Output>) {
+        match input {
+            Input::Vote(vote) => {
+                match self.pool.add_vote(vote) {
+                    Ok(()) => {}
+                    Err(AddVoteError::Slashable(offence)) => {
+                        warn!("slashable offence detected: {offence}");
+                    }
+                    Err(err) => trace!("ignoring invalid vote: {err}"),
+                }
+                self.drain_pool(now, out);
+            }
+            Input::Cert(cert) => {
+                match self.pool.add_cert(cert) {
+                    Ok(()) => {}
+                    Err(err) => trace!("ignoring invalid cert: {err}"),
+                }
+                self.drain_pool(now, out);
+            }
+            Input::BlockstoreEvent(event) => {
+                // a completed block is registered with the pool, which needs the
+                // parent info for its parent-ready and safe-to-notar tracking
+                if let BlockstoreEvent::Block { slot, block_info } = &event {
+                    self.pool
+                        .add_block((*slot, block_info.hash.clone()), block_info.parent.clone());
+                }
+                self.votor.handle_blockstore_event(event);
+                self.drain_pool(now, out);
+            }
+            Input::Tick => {
+                self.votor.handle_due_timeouts(now);
+                self.drain_votor(out);
+                if now.duration_since(self.last_progress) >= DELTA_STANDSTILL {
+                    let outbox = self.pool.recover_from_standstill();
+                    self.apply_pool_outbox(outbox, now, out);
+                    self.last_progress = now;
+                }
+            }
+        }
+    }
+
+    /// Returns the deadline at which [`Input::Tick`] must be fed next.
+    ///
+    /// This is the earlier of the next Votor timeout and the standstill
+    /// deadline, so there is always a finite deadline to sleep towards.
+    pub(crate) fn next_timeout(&self) -> Instant {
+        let standstill = self.last_progress + DELTA_STANDSTILL;
+        match self.votor.next_timeout() {
+            Some(votor) => votor.min(standstill),
+            None => standstill,
+        }
+    }
+
+    /// Drains the pool outbox, feeding events through Votor and into `out`.
+    fn drain_pool(&mut self, now: Instant, out: &mut Vec<Output>) {
+        let outbox = self.pool.take_outbox();
+        self.apply_pool_outbox(outbox, now, out);
+        if self.pool.finalized_slot() > self.finalized_slot {
+            self.finalized_slot = self.pool.finalized_slot();
+            self.last_progress = now;
+            out.push(Output::Finalized(self.finalized_slot));
+        }
+    }
+
+    /// Routes a [`PoolOutbox`]: repair requests become [`Output`]s directly,
+    /// pool events feed Votor (parent-ready ones are additionally surfaced for
+    /// the block producer), then Votor's queued broadcasts are drained.
+    fn apply_pool_outbox(&mut self, outbox: PoolOutbox, now: Instant, out: &mut Vec<Output>) {
+        for block_id in outbox.repairs {
+            out.push(Output::RequestRepair(block_id));
+        }
+        for event in outbox.votor_events {
+            if let PoolEvent::ParentReady { slot, parent } = &event {
+                out.push(Output::ParentReady {
+                    slot: *slot,
+                    parent: parent.clone(),
+                });
+            }
+            self.votor.handle_pool_event(event, now);
+        }
+        self.drain_votor(out);
+    }
+
+    /// Moves Votor's queued broadcasts into `out`.
+    fn drain_votor(&mut self, out: &mut Vec<Output>) {
+        out.extend(
+            self.votor
+                .take_broadcasts()
+                .into_iter()
+                .map(Output::Broadcast),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::super::blockstore::BlockInfo;
+    use super::super::{Cert, EpochInfo, Vote};
+    use super::*;
+    use crate::ValidatorIndex;
+    use crate::crypto::Hash;
+    use crate::crypto::aggsig::SecretKey;
+    use crate::crypto::merkle::GENESIS_BLOCK_HASH;
+    use crate::test_utils::generate_validators;
+    use crate::types::Slot;
+
+    struct TestContext {
+        sks: Vec<SecretKey>,
+        epoch_info: EpochInfo,
+        core: ConsensusCore,
+        now: Instant,
+    }
+
+    fn setup() -> TestContext {
+        let (sks, epoch_info) = generate_validators(11);
+        let validator_epoch_info = Arc::new(ValidatorEpochInfo::new(
+            ValidatorIndex::new(0),
+            epoch_info.clone(),
+        ));
+        let now = Instant::now();
+        let core = ConsensusCore::new(validator_epoch_info, sks[0].clone(), now);
+        TestContext {
+            sks,
+            epoch_info,
+            core,
+            now,
+        }
+    }
+
+    impl TestContext {
+        fn handle(&mut self, input: Input) -> Vec<Output> {
+            let mut out = Vec::new();
+            self.core.handle(input, self.now, &mut out);
+            out
+        }
+
+        fn notar_vote(&self, slot: Slot, v: u64) -> Input {
+            let v = ValidatorIndex::new(v);
+            let vote = Vote::new_notar(slot, GENESIS_BLOCK_HASH, &self.sks[v.as_usize()], v);
+            let vote = ValidatedVote::try_new(vote, &self.epoch_info)
+                .expect("test vote should pass verification");
+            Input::Vote(vote)
+        }
+    }
+
+    /// A notarization quorum produces a cert that is broadcast as an output.
+    #[test]
+    fn vote_quorum_produces_cert_broadcast() {
+        let mut ctx = setup();
+        let mut outputs = Vec::new();
+        for v in 0..7 {
+            outputs.extend(ctx.handle(ctx.notar_vote(Slot::genesis(), v)));
+        }
+        assert!(
+            outputs
+                .iter()
+                .any(|o| matches!(o, Output::Broadcast(ConsensusMessage::Cert(Cert::Notar(_))))),
+            "expected a notar cert broadcast, got {outputs:?}"
+        );
+    }
+
+    /// A reconstructed block is registered with the pool: once its parent is
+    /// certified, the safe-to-notar machinery can request its repair or notify
+    /// Votor without any external `add_block` call.
+    #[test]
+    fn block_event_registers_block_with_pool() {
+        let mut ctx = setup();
+        let slot = Slot::genesis().next();
+        let block_info = BlockInfo {
+            hash: Hash::random_for_test().into(),
+            parent: (Slot::genesis(), GENESIS_BLOCK_HASH),
+        };
+        let event = BlockstoreEvent::Block { slot, block_info };
+        ctx.handle(Input::BlockstoreEvent(event));
+        assert_eq!(ctx.core.pool.parents_ready(slot), &[]);
+        // the pool saw the block: a notar quorum for it now triggers
+        // finalization tracking through the registered parent link
+        let mut outputs = Vec::new();
+        for v in 0..7 {
+            outputs.extend(ctx.handle(ctx.notar_vote(Slot::genesis(), v)));
+        }
+        assert!(!outputs.is_empty());
+    }
+
+    /// Without finalization progress, a tick past the standstill deadline
+    /// re-broadcasts certificates and own votes.
+    #[test]
+    fn standstill_tick_rebroadcasts() {
+        let mut ctx = setup();
+        // fast-finalize genesis so the pool holds a finalization cert
+        // (like on startup, this does not count as finalization *progress*)
+        let mut outputs = Vec::new();
+        for v in 0..11 {
+            outputs.extend(ctx.handle(ctx.notar_vote(Slot::genesis(), v)));
+        }
+        assert!(
+            outputs.iter().any(|o| matches!(
+                o,
+                Output::Broadcast(ConsensusMessage::Cert(Cert::FastFinal(_)))
+            )),
+            "expected genesis to fast-finalize, got {outputs:?}"
+        );
+
+        // no progress for DELTA_STANDSTILL: recovery bundle is broadcast
+        ctx.now += DELTA_STANDSTILL + Duration::from_millis(1);
+        let outputs = ctx.handle(Input::Tick);
+        assert!(
+            outputs
+                .iter()
+                .any(|o| matches!(o, Output::Broadcast(ConsensusMessage::Cert(_)))),
+            "expected standstill recovery to re-broadcast certs, got {outputs:?}"
+        );
+    }
+
+    /// The next timeout is never later than the standstill deadline.
+    #[test]
+    fn next_timeout_capped_by_standstill() {
+        let ctx = setup();
+        assert!(ctx.core.next_timeout() <= ctx.now + DELTA_STANDSTILL);
+    }
+}

--- a/src/consensus/driver.rs
+++ b/src/consensus/driver.rs
@@ -1,0 +1,275 @@
+// Copyright (c) Anza Technology, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Async driver for the synchronous [`ConsensusCore`].
+//!
+//! The driver task is the only owner of the [`ConsensusCore`]: it feeds the
+//! core [`Input`]s from the shared inbox (filled by the ingest tasks), fires
+//! [`Input::Tick`] when the core's next deadline is due, and routes each
+//! [`Output`] to the edge that performs the corresponding I/O:
+//!
+//! - [`Output::Broadcast`] → best-effort [`All2All`] broadcast, inline
+//! - [`Output::RequestRepair`] → the repair loop's channel
+//! - [`Output::ParentReady`] / [`Output::Finalized`] → watch channels observed
+//!   by the block producer and external callers
+//!
+//! The repair loop both consumes repair requests from this task *and* feeds
+//! reconstructed blocks back into the inbox, forming the one cycle in the task
+//! graph. To keep it deadlock-free, repair requests are never sent blockingly:
+//! they are parked in [`Driver::pending_repairs`] and flushed whenever the
+//! channel has capacity.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use std::time::Instant;
+
+use log::warn;
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+use super::core::{ConsensusCore, Input, Output};
+use crate::{All2All, BlockId, Slot};
+
+/// First ready parent per window-start slot, published for the block producer.
+pub(crate) type ParentReadyMap = BTreeMap<Slot, BlockId>;
+
+/// Owns the [`ConsensusCore`] and its I/O edges; see the module docs.
+pub(crate) struct Driver<A: All2All> {
+    core: ConsensusCore,
+    /// Inputs from the ingest tasks (message loop, block producer, repair loop).
+    inbox: mpsc::Receiver<Input>,
+    /// Network for broadcasting consensus messages to all validators.
+    all2all: Arc<A>,
+    /// Repair requests destined for the repair loop.
+    repairs: mpsc::Sender<BlockId>,
+    /// Repair requests waiting for capacity on [`Self::repairs`].
+    ///
+    /// A set rather than a queue: re-requesting the same block is idempotent,
+    /// so duplicates are merged for free.
+    pending_repairs: BTreeSet<BlockId>,
+    /// Publishes the first ready parent per window, keyed by window-start slot.
+    parent_ready: watch::Sender<ParentReadyMap>,
+    /// Publishes the highest finalized slot.
+    finalized: watch::Sender<Slot>,
+    /// Indicates whether the node is shutting down.
+    cancel_token: CancellationToken,
+}
+
+impl<A: All2All> Driver<A> {
+    pub(crate) fn new(
+        core: ConsensusCore,
+        inbox: mpsc::Receiver<Input>,
+        all2all: Arc<A>,
+        repairs: mpsc::Sender<BlockId>,
+        parent_ready: watch::Sender<ParentReadyMap>,
+        finalized: watch::Sender<Slot>,
+        cancel_token: CancellationToken,
+    ) -> Self {
+        Self {
+            core,
+            inbox,
+            all2all,
+            repairs,
+            pending_repairs: BTreeSet::new(),
+            parent_ready,
+            finalized,
+            cancel_token,
+        }
+    }
+
+    /// Runs the driver until shutdown (cancellation or a closed inbox).
+    #[fastrace::trace]
+    pub(crate) async fn run(mut self) {
+        let mut out = Vec::new();
+        loop {
+            tokio::select! {
+                () = self.cancel_token.cancelled() => return,
+                input = self.inbox.recv() => match input {
+                    Some(input) => self.core.handle(input, Instant::now(), &mut out),
+                    None => return,
+                },
+                () = tokio::time::sleep_until(self.core.next_timeout().into()) => {
+                    self.core.handle(Input::Tick, Instant::now(), &mut out);
+                }
+                // Flush a pending repair request once the channel has capacity.
+                // The repair loop also feeds our inbox, so a blocking send here
+                // could deadlock the cycle; parking requests keeps this edge
+                // non-blocking (see module docs).
+                permit = self.repairs.reserve(), if !self.pending_repairs.is_empty() => {
+                    if let Ok(permit) = permit {
+                        let block_id = self
+                            .pending_repairs
+                            .pop_first()
+                            .expect("pending_repairs is non-empty");
+                        permit.send(block_id);
+                    }
+                }
+            }
+            for output in out.drain(..) {
+                self.route(output).await;
+            }
+        }
+    }
+
+    /// Routes a single core output to its I/O edge.
+    ///
+    /// Broadcasts are best-effort: a failure of the underlying [`All2All`]
+    /// network is logged and otherwise ignored. A transient network error must
+    /// not bring down the consensus driver, and a dropped vote/cert is
+    /// re-broadcast later via standstill recovery, so a one-off failure
+    /// self-heals.
+    ///
+    /// NOTE: a *persistent* broadcast failure (e.g. a misconfigured firewall or
+    /// a full partition) means this node silently stops contributing to
+    /// consensus while only logging. Once there is a metrics system, this
+    /// should also bump a failure counter so persistent failures become
+    /// alertable.
+    async fn route(&mut self, output: Output) {
+        match output {
+            Output::Broadcast(msg) => {
+                if let Err(err) = self.all2all.broadcast(&msg).await {
+                    warn!("failed to broadcast consensus message: {err}");
+                }
+            }
+            Output::RequestRepair(block_id) => {
+                self.pending_repairs.insert(block_id);
+            }
+            Output::ParentReady { slot, parent } => {
+                self.parent_ready.send_modify(|map| {
+                    // keep the first ready parent per window; later ones are
+                    // alternatives the block producer does not need
+                    map.entry(slot).or_insert(parent);
+                });
+            }
+            Output::Finalized(slot) => {
+                // prune windows at/below the finalized slot's window start;
+                // the block producer no longer needs their parents
+                let window_start = slot.first_slot_in_window();
+                self.parent_ready
+                    .send_modify(|map| map.retain(|s, _| *s > window_start));
+                let _ = self.finalized.send(slot);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+
+    use super::super::{ConsensusMessage, Vote};
+    use super::*;
+    use crate::ValidatorIndex;
+    use crate::consensus::ValidatorEpochInfo;
+    use crate::crypto::merkle::GENESIS_BLOCK_HASH;
+    use crate::test_utils::generate_validators;
+
+    /// An [`All2All`] whose `broadcast` always fails, to exercise the driver's
+    /// best-effort error handling. `receive` never resolves.
+    struct FailingAll2All;
+
+    #[async_trait]
+    impl All2All for FailingAll2All {
+        async fn broadcast(&self, _msg: &ConsensusMessage) -> std::io::Result<()> {
+            Err(std::io::Error::other("simulated broadcast failure"))
+        }
+
+        async fn receive(&self) -> std::io::Result<ConsensusMessage> {
+            std::future::pending().await
+        }
+    }
+
+    fn test_driver(
+        all2all: Arc<FailingAll2All>,
+        inbox: mpsc::Receiver<Input>,
+        repairs: mpsc::Sender<BlockId>,
+    ) -> Driver<FailingAll2All> {
+        let (sks, epoch_info) = generate_validators(2);
+        let epoch_info = Arc::new(ValidatorEpochInfo::new(ValidatorIndex::new(0), epoch_info));
+        let core = ConsensusCore::new(epoch_info, sks[0].clone(), Instant::now());
+        let (parent_ready_tx, _) = watch::channel(ParentReadyMap::new());
+        let (finalized_tx, _) = watch::channel(Slot::genesis());
+        Driver::new(
+            core,
+            inbox,
+            all2all,
+            repairs,
+            parent_ready_tx,
+            finalized_tx,
+            CancellationToken::new(),
+        )
+    }
+
+    /// A failing network broadcast must be logged and swallowed, never panic
+    /// the driver (which has to keep running to preserve liveness).
+    #[tokio::test]
+    async fn broadcast_failure_does_not_panic() {
+        let (_input_tx, input_rx) = mpsc::channel(8);
+        let (repair_tx, _repair_rx) = mpsc::channel(8);
+        let mut driver = test_driver(Arc::new(FailingAll2All), input_rx, repair_tx);
+
+        let (sks, _) = generate_validators(2);
+        let vote = Vote::new_skip(Slot::new(1), &sks[0], ValidatorIndex::new(0));
+        driver.route(Output::Broadcast(vote.into())).await;
+    }
+
+    /// Repair requests are parked and flushed once the channel has capacity,
+    /// never blocking the driver.
+    #[tokio::test]
+    async fn pending_repairs_flush_on_capacity() {
+        let (input_tx, input_rx) = mpsc::channel(8);
+        let (repair_tx, mut repair_rx) = mpsc::channel(1);
+        let mut driver = test_driver(Arc::new(FailingAll2All), input_rx, repair_tx);
+
+        // fill the repair channel so the first flush has no capacity
+        driver
+            .repairs
+            .try_send((Slot::new(9), GENESIS_BLOCK_HASH))
+            .unwrap();
+
+        let b1 = (Slot::new(1), GENESIS_BLOCK_HASH);
+        let b2 = (Slot::new(2), GENESIS_BLOCK_HASH);
+        driver.route(Output::RequestRepair(b1.clone())).await;
+        driver.route(Output::RequestRepair(b2.clone())).await;
+        // duplicates merge
+        driver.route(Output::RequestRepair(b1.clone())).await;
+        assert_eq!(driver.pending_repairs.len(), 2);
+
+        // run the driver; drain the channel and expect the parked requests
+        tokio::spawn(driver.run());
+        assert_eq!(
+            repair_rx.recv().await.unwrap(),
+            (Slot::new(9), GENESIS_BLOCK_HASH)
+        );
+        assert_eq!(repair_rx.recv().await.unwrap(), b1);
+        assert_eq!(repair_rx.recv().await.unwrap(), b2);
+        // closing the inbox shuts the driver down
+        drop(input_tx);
+    }
+
+    /// The first ready parent per window wins; later alternatives are ignored.
+    #[tokio::test]
+    async fn parent_ready_keeps_first_parent() {
+        let (_input_tx, input_rx) = mpsc::channel(8);
+        let (repair_tx, _repair_rx) = mpsc::channel(8);
+        let mut driver = test_driver(Arc::new(FailingAll2All), input_rx, repair_tx);
+        let mut watch_rx = driver.parent_ready.subscribe();
+
+        let slot = Slot::new(4);
+        let first = (Slot::new(1), GENESIS_BLOCK_HASH);
+        let second = (Slot::new(2), GENESIS_BLOCK_HASH);
+        driver
+            .route(Output::ParentReady {
+                slot,
+                parent: first.clone(),
+            })
+            .await;
+        driver
+            .route(Output::ParentReady {
+                slot,
+                parent: second,
+            })
+            .await;
+        assert_eq!(watch_rx.borrow_and_update().get(&slot), Some(&first));
+    }
+}

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -15,7 +15,6 @@ use std::collections::BTreeMap;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use either::Either;
 use log::{debug, info, trace, warn};
 use thiserror::Error;
@@ -123,12 +122,15 @@ pub enum SlashableOffence {
 /// Interface for the Pool.
 ///
 /// This is only used for mocking of [`PoolImpl`].
-#[async_trait]
+///
+/// All methods are synchronous: the pool is a pure state machine that performs
+/// no I/O and buffers its side-effects in a [`PoolOutbox`], so no method ever
+/// needs to await (and none may, as callers invoke them under a write lock).
 #[cfg_attr(test, mockall::automock)]
 pub trait Pool {
-    async fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError>;
-    async fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError>;
-    async fn add_block(&mut self, block_id: BlockId, parent_id: BlockId);
+    fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError>;
+    fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError>;
+    fn add_block(&mut self, block_id: BlockId, parent_id: BlockId);
     /// Builds the standstill-recovery bundle to re-broadcast; see [`PoolImpl::recover_from_standstill`].
     fn recover_from_standstill(&self) -> PoolOutbox;
     /// Drains and returns the side-effects buffered since the last call.
@@ -190,7 +192,7 @@ impl PoolImpl {
     /// - slot is not too old or too far in the future
     /// - signature is valid
     /// - certificate is not a duplicate
-    async fn add_valid_cert(&mut self, cert: Cert) {
+    fn add_valid_cert(&mut self, cert: Cert) {
         let slot = cert.slot();
 
         // actually add certificate
@@ -212,7 +214,7 @@ impl PoolImpl {
                 );
                 if matches!(cert, Cert::Notar(_)) {
                     let finalization_event = self.finality_tracker.mark_notarized(block_id.clone());
-                    self.handle_finalization(finalization_event).await;
+                    self.handle_finalization(finalization_event);
                 }
 
                 // potentially notify child waiting for safe-to-notar
@@ -244,12 +246,12 @@ impl PoolImpl {
                 info!("fast finalized slot {slot}");
                 let hash = ff_cert.block_hash().clone();
                 let finalization_event = self.finality_tracker.mark_fast_finalized((slot, hash));
-                self.handle_finalization(finalization_event).await;
+                self.handle_finalization(finalization_event);
             }
             Cert::Final(_) => {
                 info!("slow finalized slot {slot}");
                 let finalization_event = self.finality_tracker.mark_finalized(slot);
-                self.handle_finalization(finalization_event).await;
+                self.handle_finalization(finalization_event);
             }
         }
 
@@ -402,7 +404,7 @@ impl PoolImpl {
             .is_some_and(|state| state.certificates.skip.is_some())
     }
 
-    async fn handle_finalization(&mut self, event: FinalizationEvent) {
+    fn handle_finalization(&mut self, event: FinalizationEvent) {
         let new_parents_ready = self.parent_ready_tracker.handle_finalization(event);
         self.send_parent_ready_events(new_parents_ready);
         self.prune();
@@ -433,11 +435,10 @@ impl PoolImpl {
     }
 }
 
-#[async_trait]
 impl Pool for PoolImpl {
     /// Adds a new certificate to the pool.
     #[hotpath::measure]
-    async fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError> {
+    fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError> {
         // ignore old and far-in-the-future certificates
         let slot = cert.slot();
         // TODO: set bounds exactly correctly
@@ -464,13 +465,13 @@ impl Pool for PoolImpl {
             return Err(AddCertError::Duplicate);
         }
 
-        self.add_valid_cert(cert).await;
+        self.add_valid_cert(cert);
         Ok(())
     }
 
     /// Adds a new vote to the pool.
     #[hotpath::measure]
-    async fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError> {
+    fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError> {
         // ignore old and far-in-the-future votes
         let slot = vote.slot();
         // TODO: set bounds exactly correctly
@@ -509,7 +510,7 @@ impl Pool for PoolImpl {
 
         // handle any resulting events
         for cert in new_certs {
-            self.add_valid_cert(cert).await;
+            self.add_valid_cert(cert);
         }
         for event in votor_events {
             self.enqueue_votor_event(event);
@@ -524,7 +525,7 @@ impl Pool for PoolImpl {
     ///
     /// This should be called once for every valid block (e.g. directly by blockstore).
     /// Ensures that the parent information is available for safe-to-notar checks.
-    async fn add_block(&mut self, block_id: BlockId, parent_id: BlockId) {
+    fn add_block(&mut self, block_id: BlockId, parent_id: BlockId) {
         assert!(block_id.0 > parent_id.0);
         let (slot, block_hash) = &block_id;
         let (parent_slot, parent_hash) = &parent_id;
@@ -713,27 +714,27 @@ mod tests {
         }
 
         /// Verifies `vote` into a [`ValidatedVote`] and adds it to the pool.
-        async fn add_vote(&mut self, vote: Vote) -> Result<(), AddVoteError> {
+        fn add_vote(&mut self, vote: Vote) -> Result<(), AddVoteError> {
             // NOTE: signature-rejection is covered by the [`ValidatedVote`] tests
             let vote = ValidatedVote::try_new(vote, self.epoch_info.epoch_info())
                 .expect("test vote should pass verification");
-            let res = self.pool.add_vote(vote).await;
+            let res = self.pool.add_vote(vote);
             self.forward_outbox();
             res
         }
 
         /// Verifies `cert` into a [`ValidatedCert`] and adds it to the pool.
-        async fn add_cert(&mut self, cert: Cert) -> Result<(), AddCertError> {
+        fn add_cert(&mut self, cert: Cert) -> Result<(), AddCertError> {
             // NOTE: certificate rejection is covered by the [`ValidatedCert`] tests
             let cert = ValidatedCert::try_new(cert, self.epoch_info.epoch_info())
                 .expect("test cert should pass verification");
-            let res = self.pool.add_cert(cert).await;
+            let res = self.pool.add_cert(cert);
             self.forward_outbox();
             res
         }
 
         /// Adds a notarization [`Vote`] for `hash` in `slot` from each of `validators` to the pool.
-        async fn add_notar_votes(
+        fn add_notar_votes(
             &mut self,
             slot: Slot,
             hash: &BlockHash,
@@ -741,12 +742,12 @@ mod tests {
         ) {
             for v in validators.map(|v| ValidatorIndex::new(v as u64)) {
                 let vote = Vote::new_notar(slot, hash.clone(), &self.sks[v.as_usize()], v);
-                assert_eq!(self.add_vote(vote).await, Ok(()));
+                assert_eq!(self.add_vote(vote), Ok(()));
             }
         }
 
         /// Adds a notar-fallback [`Vote`] for `hash` in `slot` from each of `validators` to the pool.
-        async fn add_notar_fallback_votes(
+        fn add_notar_fallback_votes(
             &mut self,
             slot: Slot,
             hash: &BlockHash,
@@ -754,23 +755,23 @@ mod tests {
         ) {
             for v in validators.map(|v| ValidatorIndex::new(v as u64)) {
                 let vote = Vote::new_notar_fallback(slot, hash.clone(), &self.sks[v.as_usize()], v);
-                assert_eq!(self.add_vote(vote).await, Ok(()));
+                assert_eq!(self.add_vote(vote), Ok(()));
             }
         }
 
         /// Adds a skip [`Vote`] for `slot` from each of `validators` to the pool.
-        async fn add_skip_votes(&mut self, slot: Slot, validators: std::ops::Range<usize>) {
+        fn add_skip_votes(&mut self, slot: Slot, validators: std::ops::Range<usize>) {
             for v in validators.map(|v| ValidatorIndex::new(v as u64)) {
                 let vote = Vote::new_skip(slot, &self.sks[v.as_usize()], v);
-                assert_eq!(self.add_vote(vote).await, Ok(()));
+                assert_eq!(self.add_vote(vote), Ok(()));
             }
         }
 
         /// Adds a finalization [`Vote`] for `slot` from each of `validators` to the pool.
-        async fn add_final_votes(&mut self, slot: Slot, validators: std::ops::Range<usize>) {
+        fn add_final_votes(&mut self, slot: Slot, validators: std::ops::Range<usize>) {
             for v in validators.map(|v| ValidatorIndex::new(v as u64)) {
                 let vote = Vote::new_final(slot, &self.sks[v.as_usize()], v);
-                assert_eq!(self.add_vote(vote).await, Ok(()));
+                assert_eq!(self.add_vote(vote), Ok(()));
             }
         }
 
@@ -799,9 +800,9 @@ mod tests {
         }
 
         /// Fast-finalizes the given block by submitting a unanimous fast-final cert.
-        async fn fast_finalize(&mut self, slot: Slot, hash: &BlockHash) {
+        fn fast_finalize(&mut self, slot: Slot, hash: &BlockHash) {
             let cert = self.fast_final_cert(slot, hash, 11);
-            assert_eq!(self.add_cert(Cert::FastFinal(cert)).await, Ok(()));
+            assert_eq!(self.add_cert(Cert::FastFinal(cert)), Ok(()));
         }
 
         /// Drains all pending votor events and reports whether `SafeToNotar(slot, hash)` was emitted.
@@ -822,8 +823,8 @@ mod tests {
     /// Notarizing a block must record a `CertCreated` event in the pool's outbox
     /// (rather than sending it under the lock), so the caller can forward it to
     /// Votor losslessly after releasing the write lock.
-    #[tokio::test]
-    async fn cert_created_event_is_recorded() {
+    #[test]
+    fn cert_created_event_is_recorded() {
         let mut ctx = setup();
 
         // Notarize genesis directly on the pool, bypassing the test helpers so the
@@ -832,7 +833,7 @@ mod tests {
             let vote = Vote::new_notar(Slot::new(0), GENESIS_BLOCK_HASH, &ctx.sks[v.as_usize()], v);
             let vote = ValidatedVote::try_new(vote, ctx.epoch_info.epoch_info())
                 .expect("test vote should pass verification");
-            ctx.pool.add_vote(vote).await.unwrap();
+            ctx.pool.add_vote(vote).unwrap();
         }
         assert!(ctx.pool.has_notar_cert(Slot::new(0)));
 
@@ -850,114 +851,108 @@ mod tests {
         assert!(drained.votor_events.is_empty() && drained.repairs.is_empty());
     }
 
-    #[tokio::test]
-    async fn notarize_block() {
+    #[test]
+    fn notarize_block() {
         let mut ctx = setup();
 
         // all nodes notarize block in slot 0
         assert!(!ctx.pool.has_notar_cert(Slot::new(0)));
-        ctx.add_notar_votes(Slot::new(0), &GENESIS_BLOCK_HASH, 0..11)
-            .await;
+        ctx.add_notar_votes(Slot::new(0), &GENESIS_BLOCK_HASH, 0..11);
         assert!(ctx.pool.has_notar_cert(Slot::new(0)));
 
         // just enough nodes notarize block in slot 1
         assert!(!ctx.pool.has_notar_cert(Slot::new(1)));
-        ctx.add_notar_votes(Slot::new(1), &GENESIS_BLOCK_HASH, 0..7)
-            .await;
+        ctx.add_notar_votes(Slot::new(1), &GENESIS_BLOCK_HASH, 0..7);
         assert!(ctx.pool.has_notar_cert(Slot::new(1)));
 
         // just NOT enough nodes notarize block in slot 2
         assert!(!ctx.pool.has_notar_cert(Slot::new(2)));
-        ctx.add_notar_votes(Slot::new(2), &GENESIS_BLOCK_HASH, 0..6)
-            .await;
+        ctx.add_notar_votes(Slot::new(2), &GENESIS_BLOCK_HASH, 0..6);
         assert!(!ctx.pool.has_notar_cert(Slot::new(2)));
     }
 
-    #[tokio::test]
-    async fn skip_block() {
+    #[test]
+    fn skip_block() {
         let mut ctx = setup();
 
         // all nodes vote skip on slot 0
         assert!(!ctx.pool.has_skip_cert(Slot::new(0)));
-        ctx.add_skip_votes(Slot::new(0), 0..11).await;
+        ctx.add_skip_votes(Slot::new(0), 0..11);
         assert!(ctx.pool.has_skip_cert(Slot::new(0)));
 
         // just enough nodes vote skip on slot 1
         assert!(!ctx.pool.has_skip_cert(Slot::new(1)));
-        ctx.add_skip_votes(Slot::new(1), 0..7).await;
+        ctx.add_skip_votes(Slot::new(1), 0..7);
         assert!(ctx.pool.has_skip_cert(Slot::new(1)));
 
         // just NOT enough nodes notarize block in slot 2
         assert!(!ctx.pool.has_skip_cert(Slot::new(2)));
-        ctx.add_skip_votes(Slot::new(2), 0..6).await;
+        ctx.add_skip_votes(Slot::new(2), 0..6);
         assert!(!ctx.pool.has_skip_cert(Slot::new(2)));
     }
 
-    #[tokio::test]
-    async fn finalize_block() {
+    #[test]
+    fn finalize_block() {
         let mut ctx = setup();
 
         // just enough nodes vote notar, this is NOT enough on its own to finalize
         let slot1 = Slot::genesis().next();
         let hash1: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot1, &hash1, 0..7).await;
+        ctx.add_notar_votes(slot1, &hash1, 0..7);
         assert!(!ctx.pool.has_final_cert(slot1));
         assert_eq!(ctx.pool.finalized_slot(), Slot::genesis());
 
         // just enough nodes vote final, NOW slot 1 should be finalized
-        ctx.add_final_votes(slot1, 0..7).await;
+        ctx.add_final_votes(slot1, 0..7);
         assert!(ctx.pool.has_final_cert(slot1));
         assert_eq!(ctx.pool.finalized_slot(), slot1);
 
         // just enough nodes vote final, this is NOT enough on its own to finalize
         let slot2 = slot1.next();
-        ctx.add_final_votes(slot2, 0..7).await;
+        ctx.add_final_votes(slot2, 0..7);
         assert!(ctx.pool.has_final_cert(slot2));
         assert_eq!(ctx.pool.finalized_slot(), slot1);
 
         // just enough nodes vote notar, NOW slot 2 should be finalized
         let hash2: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot2, &hash2, 0..7).await;
+        ctx.add_notar_votes(slot2, &hash2, 0..7);
         assert!(ctx.pool.has_final_cert(slot2));
         assert_eq!(ctx.pool.finalized_slot(), slot2);
 
         // just NOT enough nodes vote notar + final on slot 3
         let slot3 = slot2.next();
         let hash3: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot3, &hash3, 0..6).await;
-        ctx.add_final_votes(slot3, 0..6).await;
+        ctx.add_notar_votes(slot3, &hash3, 0..6);
+        ctx.add_final_votes(slot3, 0..6);
         assert!(!ctx.pool.has_final_cert(slot3));
         assert_eq!(ctx.pool.finalized_slot(), slot2);
     }
 
-    #[tokio::test]
-    async fn fast_finalize_block() {
+    #[test]
+    fn fast_finalize_block() {
         let mut ctx = setup();
 
         // all nodes vote notarize on slot 0
         assert!(!ctx.pool.has_final_cert(Slot::new(0)));
-        ctx.add_notar_votes(Slot::new(0), &GENESIS_BLOCK_HASH, 0..11)
-            .await;
+        ctx.add_notar_votes(Slot::new(0), &GENESIS_BLOCK_HASH, 0..11);
         assert!(ctx.pool.has_final_cert(Slot::new(0)));
         assert_eq!(ctx.pool.finalized_slot(), Slot::new(0));
 
         // just enough nodes to fast finalize slot 1
         assert!(!ctx.pool.has_final_cert(Slot::new(1)));
-        ctx.add_notar_votes(Slot::new(1), &GENESIS_BLOCK_HASH, 0..9)
-            .await;
+        ctx.add_notar_votes(Slot::new(1), &GENESIS_BLOCK_HASH, 0..9);
         assert!(ctx.pool.has_final_cert(Slot::new(1)));
         assert_eq!(ctx.pool.finalized_slot(), Slot::new(1));
 
         // just NOT enough nodes to fast finalize slot 2
         assert!(!ctx.pool.has_final_cert(Slot::new(2)));
-        ctx.add_notar_votes(Slot::new(2), &GENESIS_BLOCK_HASH, 0..8)
-            .await;
+        ctx.add_notar_votes(Slot::new(2), &GENESIS_BLOCK_HASH, 0..8);
         assert!(!ctx.pool.has_final_cert(Slot::new(2)));
         assert_eq!(ctx.pool.finalized_slot(), Slot::new(1));
     }
 
-    #[tokio::test]
-    async fn simple_branch_certified() {
+    #[test]
+    fn simple_branch_certified() {
         let mut ctx = setup();
 
         let window = Slot::genesis().slots_in_window().collect::<Vec<_>>();
@@ -967,7 +962,7 @@ mod tests {
             .collect();
         for slot in window.iter().skip(1) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(*slot, hash, 0..7).await;
+            ctx.add_notar_votes(*slot, hash, 0..7);
         }
         let slot = *window.last().unwrap();
         let next = slot.next();
@@ -977,8 +972,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn branch_certified_notar_fallback() {
+    #[test]
+    fn branch_certified_notar_fallback() {
         let mut ctx = setup();
 
         // receive mixed notar & notar-fallback votes
@@ -993,8 +988,8 @@ mod tests {
                 !ctx.pool
                     .is_parent_ready(slot.next(), &(*slot, hash.clone()))
             );
-            ctx.add_notar_votes(*slot, hash, 0..4).await;
-            ctx.add_notar_fallback_votes(*slot, hash, 4..7).await;
+            ctx.add_notar_votes(*slot, hash, 0..4);
+            ctx.add_notar_fallback_votes(*slot, hash, 4..7);
         }
         let slot = *window.last().unwrap();
         let next = slot.next();
@@ -1002,8 +997,8 @@ mod tests {
         assert!(ctx.pool.is_parent_ready(next, &(slot, hash)));
     }
 
-    #[tokio::test]
-    async fn branch_certified_out_of_order() {
+    #[test]
+    fn branch_certified_out_of_order() {
         let mut ctx = setup();
 
         // first see skip votes for later slots
@@ -1012,7 +1007,7 @@ mod tests {
         window.remove(0);
         window.remove(0);
         for slot in window.iter() {
-            ctx.add_skip_votes(*slot, 0..7).await;
+            ctx.add_skip_votes(*slot, 0..7);
         }
 
         let next = window.last().unwrap().next();
@@ -1022,7 +1017,7 @@ mod tests {
         // then see notarization votes for slot 1
         let slot1 = Slot::new(1);
         let hash1: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot1, &hash1, 0..7).await;
+        ctx.add_notar_votes(slot1, &hash1, 0..7);
 
         // branch can only be certified once we saw votes other slots in window
         assert!(ctx.pool.is_parent_ready(next, &(slot1, hash1)));
@@ -1030,15 +1025,15 @@ mod tests {
         assert_eq!(ctx.pool.parents_ready(next).len(), 1);
     }
 
-    #[tokio::test]
-    async fn branch_certified_late_cert() {
+    #[test]
+    fn branch_certified_late_cert() {
         let mut ctx = setup();
 
         // first see skip votes for later slots
         let window = Slot::genesis().slots_in_window().collect::<Vec<_>>();
         assert!(window.len() > 2);
         for slot in window.iter().skip(2) {
-            ctx.add_skip_votes(*slot, 0..7).await;
+            ctx.add_skip_votes(*slot, 0..7);
         }
 
         // no blocks are valid parents yet
@@ -1049,14 +1044,14 @@ mod tests {
         let slot1 = Slot::new(1);
         let hash1: BlockHash = Hash::random_for_test().into();
         let cert = ctx.notar_cert(slot1, &hash1, 7);
-        ctx.add_cert(Cert::Notar(cert)).await.unwrap();
+        ctx.add_cert(Cert::Notar(cert)).unwrap();
 
         // branch can only be certified once we saw votes for parent
         assert!(ctx.pool.is_parent_ready(next, &(slot1, hash1)));
     }
 
-    #[tokio::test]
-    async fn regular_handover() {
+    #[test]
+    fn regular_handover() {
         let mut ctx = setup();
 
         let hashes: Vec<BlockHash> = (0..SLOTS_PER_WINDOW)
@@ -1066,7 +1061,7 @@ mod tests {
         // notarize all slots of first window
         for slot in (1..SLOTS_PER_WINDOW).map(Slot::new) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 0..7).await;
+            ctx.add_notar_votes(slot, hash, 0..7);
         }
 
         assert!(ctx.pool.is_parent_ready(
@@ -1078,8 +1073,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn one_skip_handover() {
+    #[test]
+    fn one_skip_handover() {
         let mut ctx = setup();
 
         let hashes: Vec<BlockHash> = (0..SLOTS_PER_WINDOW)
@@ -1089,12 +1084,11 @@ mod tests {
         // notarize all slots but last one
         for slot in (1..SLOTS_PER_WINDOW - 1).map(Slot::new) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 0..7).await;
+            ctx.add_notar_votes(slot, hash, 0..7);
         }
 
         // skip last slot
-        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 1), 0..7)
-            .await;
+        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 1), 0..7);
 
         assert!(ctx.pool.is_parent_ready(
             Slot::new(SLOTS_PER_WINDOW),
@@ -1105,8 +1099,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn two_skip_handover() {
+    #[test]
+    fn two_skip_handover() {
         let mut ctx = setup();
 
         let hashes: Vec<BlockHash> = (0..SLOTS_PER_WINDOW)
@@ -1116,14 +1110,12 @@ mod tests {
         // notarize all slots but last two
         for slot in (1..SLOTS_PER_WINDOW - 2).map(Slot::new) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 0..7).await;
+            ctx.add_notar_votes(slot, hash, 0..7);
         }
 
         // skip last 2 slots
-        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 2), 0..7)
-            .await;
-        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 1), 0..7)
-            .await;
+        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 2), 0..7);
+        ctx.add_skip_votes(Slot::new(SLOTS_PER_WINDOW - 1), 0..7);
 
         assert!(ctx.pool.is_parent_ready(
             Slot::new(SLOTS_PER_WINDOW),
@@ -1134,8 +1126,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn skip_window_handover() {
+    #[test]
+    fn skip_window_handover() {
         let mut ctx = setup();
 
         let hashes: Vec<BlockHash> = (0..SLOTS_PER_WINDOW)
@@ -1145,12 +1137,12 @@ mod tests {
         // notarize all slots in first window
         for slot in (1..SLOTS_PER_WINDOW).map(Slot::new) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 0..7).await;
+            ctx.add_notar_votes(slot, hash, 0..7);
         }
 
         // skip all slots in second window
         for slot in (SLOTS_PER_WINDOW..2 * SLOTS_PER_WINDOW).map(Slot::new) {
-            ctx.add_skip_votes(slot, 0..7).await;
+            ctx.add_skip_votes(slot, 0..7);
         }
 
         assert!(ctx.pool.is_parent_ready(
@@ -1162,8 +1154,8 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn pruning() {
+    #[test]
+    fn pruning() {
         let mut ctx = setup();
 
         let hashes: Vec<BlockHash> = (0..3 * SLOTS_PER_WINDOW + 10)
@@ -1174,7 +1166,7 @@ mod tests {
         for slot in (1..3 * SLOTS_PER_WINDOW).map(Slot::new) {
             let hash: &BlockHash = &hashes[slot.inner() as usize];
             assert!(!ctx.pool.has_final_cert(slot));
-            ctx.add_notar_votes(slot, hash, 0..11).await;
+            ctx.add_notar_votes(slot, hash, 0..11);
             assert!(ctx.pool.has_final_cert(slot));
         }
         let last_slot = Slot::new(3 * SLOTS_PER_WINDOW - 1);
@@ -1190,7 +1182,7 @@ mod tests {
         // NOT enough nodes vote to fast finalize next 10 slots
         for slot in last_slot.future_slots().take(10) {
             let hash: &BlockHash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 0..8).await;
+            ctx.add_notar_votes(slot, hash, 0..8);
             assert!(!ctx.pool.has_final_cert(slot));
         }
         assert_eq!(ctx.pool.finalized_slot(), last_slot);
@@ -1204,7 +1196,7 @@ mod tests {
         // add one more vote each to finalize next 10 slots
         for slot in last_slot.future_slots().take(10) {
             let hash = &hashes[slot.inner() as usize];
-            ctx.add_notar_votes(slot, hash, 8..9).await;
+            ctx.add_notar_votes(slot, hash, 8..9);
             assert!(ctx.pool.has_final_cert(slot));
         }
         assert_eq!(ctx.pool.finalized_slot().inner(), last_slot.inner() + 10);
@@ -1218,8 +1210,8 @@ mod tests {
         assert!(ctx.pool.slot_states.contains_key(&new_last_slot));
     }
 
-    #[tokio::test]
-    async fn duplicate_votes() {
+    #[test]
+    fn duplicate_votes() {
         let mut ctx = setup();
         let slot = Slot::new(0);
 
@@ -1230,26 +1222,26 @@ mod tests {
             &ctx.sks[0],
             ValidatorIndex::new(0),
         );
-        assert_eq!(ctx.add_vote(vote1.clone()).await, Ok(()));
+        assert_eq!(ctx.add_vote(vote1.clone()), Ok(()));
 
         // insert a skip vote from validator 1
         let vote2 = Vote::new_skip(slot, &ctx.sks[1], ValidatorIndex::new(1));
-        assert_eq!(ctx.add_vote(vote2.clone()).await, Ok(()));
+        assert_eq!(ctx.add_vote(vote2.clone()), Ok(()));
 
         // inserting same votes again should fail
-        assert_eq!(ctx.add_vote(vote1).await, Err(AddVoteError::Duplicate));
-        assert_eq!(ctx.add_vote(vote2).await, Err(AddVoteError::Duplicate));
+        assert_eq!(ctx.add_vote(vote1), Err(AddVoteError::Duplicate));
+        assert_eq!(ctx.add_vote(vote2), Err(AddVoteError::Duplicate));
     }
 
-    #[tokio::test]
-    async fn duplicate_certs() {
+    #[test]
+    fn duplicate_certs() {
         let mut ctx = setup();
 
         // insert a notar cert for first slot
         let first_slot = Slot::genesis().next();
         let hash: BlockHash = Hash::random_for_test().into();
         let notar_cert = ctx.notar_cert(first_slot, &hash, 11);
-        assert_eq!(ctx.add_cert(Cert::Notar(notar_cert.clone())).await, Ok(()));
+        assert_eq!(ctx.add_cert(Cert::Notar(notar_cert.clone())), Ok(()));
 
         // insert a skip cert for slot 1
         let second_slot = first_slot.next();
@@ -1257,28 +1249,27 @@ mod tests {
             .map(|v| SkipVote::new(second_slot, &ctx.sks[v as usize], ValidatorIndex::new(v)))
             .collect();
         let skip_cert = SkipCert::try_new(&skip_votes, &[], ctx.validators()).unwrap();
-        assert_eq!(ctx.add_cert(Cert::Skip(skip_cert.clone())).await, Ok(()));
+        assert_eq!(ctx.add_cert(Cert::Skip(skip_cert.clone())), Ok(()));
 
         // inserting same certs again should fail
         assert_eq!(
-            ctx.add_cert(Cert::Notar(notar_cert)).await,
+            ctx.add_cert(Cert::Notar(notar_cert)),
             Err(AddCertError::Duplicate)
         );
         assert_eq!(
-            ctx.add_cert(Cert::Skip(skip_cert)).await,
+            ctx.add_cert(Cert::Skip(skip_cert)),
             Err(AddCertError::Duplicate)
         );
     }
 
-    #[tokio::test]
-    async fn out_of_bounds_votes() {
+    #[test]
+    fn out_of_bounds_votes() {
         let mut ctx = setup();
 
         // fast-finalize a contiguous run of slots so the pruning watermark advances
         let slot = Slot::new(3 * SLOTS_PER_WINDOW - 1);
         for s in 1..=slot.inner() {
-            ctx.add_notar_votes(Slot::new(s), &GENESIS_BLOCK_HASH, 0..11)
-                .await;
+            ctx.add_notar_votes(Slot::new(s), &GENESIS_BLOCK_HASH, 0..11);
         }
         assert_eq!(ctx.pool.finalized_slot(), slot);
         assert_eq!(ctx.pool.first_unpruned_slot(), slot);
@@ -1291,7 +1282,7 @@ mod tests {
                     &ctx.sks[v as usize],
                     ValidatorIndex::new(v),
                 );
-                assert_eq!(ctx.add_vote(vote).await, Err(AddVoteError::SlotOutOfBounds));
+                assert_eq!(ctx.add_vote(vote), Err(AddVoteError::SlotOutOfBounds));
             }
         }
 
@@ -1299,18 +1290,18 @@ mod tests {
         let slot = Slot::new(5 * SLOTS_PER_EPOCH);
         for v in 0..11 {
             let vote = Vote::new_final(slot, &ctx.sks[v as usize], ValidatorIndex::new(v));
-            assert_eq!(ctx.add_vote(vote).await, Err(AddVoteError::SlotOutOfBounds));
+            assert_eq!(ctx.add_vote(vote), Err(AddVoteError::SlotOutOfBounds));
         }
     }
 
-    #[tokio::test]
-    async fn out_of_bounds_certs() {
+    #[test]
+    fn out_of_bounds_certs() {
         let mut ctx = setup();
 
         // fast-finalize a contiguous run of slots so the pruning watermark advances
         let slot = Slot::new(3 * SLOTS_PER_WINDOW - 1);
         for s in 1..=slot.inner() {
-            ctx.fast_finalize(Slot::new(s), &GENESIS_BLOCK_HASH).await;
+            ctx.fast_finalize(Slot::new(s), &GENESIS_BLOCK_HASH);
         }
         assert_eq!(ctx.pool.first_unpruned_slot(), slot);
 
@@ -1327,7 +1318,7 @@ mod tests {
                 .collect();
             let skip_cert = SkipCert::try_new(&skip_votes, &[], ctx.validators()).unwrap();
             assert_eq!(
-                ctx.add_cert(Cert::Skip(skip_cert.clone())).await,
+                ctx.add_cert(Cert::Skip(skip_cert.clone())),
                 Err(AddCertError::SlotOutOfBounds)
             );
         }
@@ -1339,13 +1330,13 @@ mod tests {
             .collect();
         let skip_cert = SkipCert::try_new(&skip_votes, &[], ctx.validators()).unwrap();
         assert_eq!(
-            ctx.add_cert(Cert::Skip(skip_cert.clone())).await,
+            ctx.add_cert(Cert::Skip(skip_cert)),
             Err(AddCertError::SlotOutOfBounds)
         );
     }
 
-    #[tokio::test]
-    async fn slow_finalize_closing_gap_no_double_parent_ready() {
+    #[test]
+    fn slow_finalize_closing_gap_no_double_parent_ready() {
         let mut ctx = setup();
         let next_start = Slot::windows().nth(1).unwrap();
         let gap_slot = next_start.prev();
@@ -1353,25 +1344,25 @@ mod tests {
 
         // fast-finalize every slot below `gap_slot`
         for s in 1..gap_slot.inner() {
-            ctx.fast_finalize(Slot::new(s), &GENESIS_BLOCK_HASH).await;
+            ctx.fast_finalize(Slot::new(s), &GENESIS_BLOCK_HASH);
         }
         // this moves the watermark just below it
         assert_eq!(ctx.pool.first_unpruned_slot(), watermark_slot);
 
         // `gap_slot` gets a final cert but no notarization yet
         let gap_hash: BlockHash = Hash::random_for_test().into();
-        ctx.add_final_votes(gap_slot, 0..7).await;
+        ctx.add_final_votes(gap_slot, 0..7);
         assert!(ctx.pool.has_final_cert(gap_slot));
         assert_eq!(ctx.pool.first_unpruned_slot(), watermark_slot);
 
         // fast-finalize `next_start`, introducing a gap
-        ctx.fast_finalize(next_start, &GENESIS_BLOCK_HASH).await;
+        ctx.fast_finalize(next_start, &GENESIS_BLOCK_HASH);
         assert_eq!(ctx.pool.finalized_slot(), next_start);
         // cannot prune past the gap
         assert_eq!(ctx.pool.first_unpruned_slot(), watermark_slot);
 
         // `gap_slot`'s notarization closes the gap
-        ctx.add_notar_votes(gap_slot, &gap_hash, 0..7).await;
+        ctx.add_notar_votes(gap_slot, &gap_hash, 0..7);
         // jumping the watermark across both slots
         assert_eq!(ctx.pool.first_unpruned_slot(), next_start);
 
@@ -1386,16 +1377,16 @@ mod tests {
         // all nodes vote for first slot (it's fast finalized)
         let slot1 = Slot::genesis().next();
         let hash1: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot1, &hash1, 0..11).await;
+        ctx.add_notar_votes(slot1, &hash1, 0..11);
 
         // we also vote for next slot, see only final votes (it's missing notar)
         let slot2 = slot1.next();
-        ctx.add_final_votes(slot2, 0..7).await;
+        ctx.add_final_votes(slot2, 0..7);
 
         // we also vote for next slot, see no other votes
         let slot3 = slot2.next();
         let hash3: BlockHash = Hash::random_for_test().into();
-        ctx.add_notar_votes(slot3, &hash3, 0..1).await;
+        ctx.add_notar_votes(slot3, &hash3, 0..1);
 
         // initiate standstill
         let outbox = ctx.pool.recover_from_standstill();
@@ -1449,7 +1440,7 @@ mod tests {
         let block0 = random_block_id(slot1.prev());
         let block1 = random_block_id(slot1);
         let block2 = random_block_id(slot1.next());
-        ctx.add_notar_votes(block2.0, &block2.1, 0..11).await;
+        ctx.add_notar_votes(block2.0, &block2.1, 0..11);
 
         // should construct 3 certs (notar-fallback + notar + fast-final)
         for _ in 0..3 {
@@ -1464,8 +1455,8 @@ mod tests {
         );
 
         // add its ancestors
-        ctx.pool.add_block(block2.clone(), block1.clone()).await;
-        ctx.pool.add_block(block1.clone(), block0.clone()).await;
+        ctx.pool.add_block(block2.clone(), block1.clone());
+        ctx.pool.add_block(block1.clone(), block0.clone());
         ctx.forward_outbox();
 
         // should emit ParentReady as a result
@@ -1481,8 +1472,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn safe_to_notar_notar_cert_only() {
+    #[test]
+    fn safe_to_notar_notar_cert_only() {
         let mut ctx = setup();
 
         let slot1 = Slot::genesis().next();
@@ -1492,16 +1483,14 @@ mod tests {
 
         // parent (slot1) is notarized only via a received notar cert
         let cert = ctx.notar_cert(slot1, &hash1, 7);
-        ctx.add_cert(Cert::Notar(cert)).await.unwrap();
+        ctx.add_cert(Cert::Notar(cert)).unwrap();
 
         // register the child block
-        ctx.pool
-            .add_block((slot2, hash2.clone()), (slot1, hash1.clone()))
-            .await;
+        ctx.pool.add_block((slot2, hash2.clone()), (slot1, hash1));
 
         // we skip slot2, but 40% of others notarize the child
-        ctx.add_skip_votes(slot2, 0..1).await;
-        ctx.add_notar_votes(slot2, &hash2, 1..6).await;
+        ctx.add_skip_votes(slot2, 0..1);
+        ctx.add_notar_votes(slot2, &hash2, 1..6);
 
         // child should now be safe-to-notar
         assert!(
@@ -1510,8 +1499,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn safe_to_notar_fast_final_cert_only() {
+    #[test]
+    fn safe_to_notar_fast_final_cert_only() {
         let mut ctx = setup();
 
         let slot1 = Slot::genesis().next();
@@ -1521,16 +1510,14 @@ mod tests {
 
         // parent (slot1) is fast-finalized only via a received cert
         let cert = ctx.fast_final_cert(slot1, &hash1, 9);
-        ctx.add_cert(Cert::FastFinal(cert)).await.unwrap();
+        ctx.add_cert(Cert::FastFinal(cert)).unwrap();
 
         // register the child block
-        ctx.pool
-            .add_block((slot2, hash2.clone()), (slot1, hash1.clone()))
-            .await;
+        ctx.pool.add_block((slot2, hash2.clone()), (slot1, hash1));
 
         // we skip slot2, but 40% of others notarize the child
-        ctx.add_skip_votes(slot2, 0..1).await;
-        ctx.add_notar_votes(slot2, &hash2, 1..6).await;
+        ctx.add_skip_votes(slot2, 0..1);
+        ctx.add_notar_votes(slot2, &hash2, 1..6);
 
         // child should now be safe-to-notar
         assert!(

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -19,8 +19,6 @@ use async_trait::async_trait;
 use either::Either;
 use log::{debug, info, trace, warn};
 use thiserror::Error;
-use tokio::sync::mpsc::Sender;
-use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{RwLock, oneshot};
 
 use self::finality_tracker::FinalityTracker;
@@ -71,6 +69,21 @@ impl PoolEvent {
     }
 }
 
+/// Side-effects the Pool produces while processing under its write lock, to be
+/// drained via [`Pool::take_outbox`] and forwarded once the lock is released.
+///
+/// The Pool buffers these here instead of sending them under the lock: a blocking
+/// send would let a slow Votor or repair loop jam every task contending for the
+/// Pool lock, while a non-blocking send would have to drop events. See
+/// `PoolImpl::enqueue_votor_event` for the rationale.
+#[derive(Debug, Default)]
+pub struct PoolOutbox {
+    /// Events destined for Votor.
+    pub votor_events: Vec<PoolEvent>,
+    /// Repair requests destined for the repair loop.
+    pub repairs: Vec<BlockId>,
+}
+
 /// Errors the Pool may return when adding a vote.
 ///
 /// Signature and signer validity are checked up front by [`ValidatedVote`],
@@ -119,7 +132,13 @@ pub trait Pool {
     async fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError>;
     async fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError>;
     async fn add_block(&mut self, block_id: BlockId, parent_id: BlockId);
-    async fn recover_from_standstill(&self);
+    /// Builds the standstill-recovery bundle to re-broadcast; see [`PoolImpl::recover_from_standstill`].
+    fn recover_from_standstill(&self) -> PoolOutbox;
+    /// Drains and returns the side-effects buffered since the last call.
+    ///
+    /// The caller must forward these to Votor and the repair loop *after* releasing
+    /// the Pool lock; see `PoolImpl::enqueue_votor_event`.
+    fn take_outbox(&mut self) -> PoolOutbox;
     fn finalized_slot(&self) -> Slot;
     fn parents_ready(&self, slot: Slot) -> &[BlockId];
     fn wait_for_parent_ready(&mut self, slot: Slot) -> Either<BlockId, oneshot::Receiver<BlockId>>;
@@ -145,29 +164,26 @@ pub struct PoolImpl {
 
     /// Information about all active validators.
     epoch_info: Arc<ValidatorEpochInfo>,
-    /// Channel for sending events related to voting logic to Votor.
-    votor_event_channel: Sender<PoolEvent>,
-    /// Channel for sending repair requests to the repair loop.
-    repair_channel: Sender<BlockId>,
+    /// Buffered side-effects (Votor events + repair requests) produced under the
+    /// write lock, drained by the caller via [`Pool::take_outbox`].
+    outbox: PoolOutbox,
 }
 
 impl PoolImpl {
     /// Creates a new empty pool containing no votes or certificates.
     ///
-    /// Any later emitted events will be sent on provided `votor_event_channel`.
-    pub fn new(
-        epoch_info: Arc<ValidatorEpochInfo>,
-        votor_event_channel: Sender<PoolEvent>,
-        repair_channel: Sender<BlockId>,
-    ) -> Self {
+    /// Any events the pool emits are buffered in its [`PoolOutbox`] and must be
+    /// drained by the caller via [`Pool::take_outbox`], then forwarded to Votor and
+    /// the repair loop after the write lock is released; see
+    /// `PoolImpl::enqueue_votor_event`.
+    pub fn new(epoch_info: Arc<ValidatorEpochInfo>) -> Self {
         Self {
             slot_states: BTreeMap::new(),
             parent_ready_tracker: ParentReadyTracker::default(),
             finality_tracker: FinalityTracker::default(),
             s2n_waiting_parent_cert: BTreeMap::new(),
             epoch_info,
-            votor_event_channel,
-            repair_channel,
+            outbox: PoolOutbox::default(),
         }
     }
 
@@ -210,8 +226,8 @@ impl PoolImpl {
                         .notify_parent_certified(child_hash)
                 {
                     match output {
-                        Either::Left(event) => self.send_votor_event(event),
-                        Either::Right((slot, hash)) => self.request_repair((slot, hash)),
+                        Either::Left(event) => self.enqueue_votor_event(event),
+                        Either::Right((slot, hash)) => self.enqueue_repair((slot, hash)),
                     }
                 }
 
@@ -220,7 +236,7 @@ impl PoolImpl {
                 self.send_parent_ready_events(new_parents_ready);
 
                 // repair this block, if necessary
-                self.request_repair((slot, block_hash));
+                self.enqueue_repair((slot, block_hash));
             }
             Cert::Skip(_) => {
                 warn!("skipped slot {slot}");
@@ -242,7 +258,7 @@ impl PoolImpl {
 
         // send to votor for broadcasting
         let event = PoolEvent::CertCreated(cert);
-        self.send_votor_event(event);
+        self.enqueue_votor_event(event);
     }
 
     /// Mutably accesses the [`SlotState`] for the given `slot`.
@@ -395,49 +411,32 @@ impl PoolImpl {
         self.prune();
     }
 
-    fn send_parent_ready_events(&self, parents: impl IntoIterator<Item = (Slot, BlockId)>) {
+    fn send_parent_ready_events(&mut self, parents: impl IntoIterator<Item = (Slot, BlockId)>) {
         for (slot, parent) in parents {
             debug_assert!(slot.is_start_of_window());
-            self.send_votor_event(PoolEvent::ParentReady { slot, parent });
+            self.enqueue_votor_event(PoolEvent::ParentReady { slot, parent });
         }
     }
 
-    /// Forwards an event to Votor, returning without blocking.
+    /// Records an event for Votor in the outbox.
     ///
-    /// This uses a non-blocking [`Sender::try_send`] on purpose: the vote/cert
-    /// ingest path holds the Pool write lock while adding to the pool (see
-    /// [`super::Alpenglow::handle_all2all_message`]), so a blocking send would let
-    /// a slow or stalled Votor apply back-pressure that jams every other task
-    /// waiting on that lock. On overflow (channel full) or a closed channel (Votor
-    /// shutting down) the event is dropped with a log message rather than panicking.
-    fn send_votor_event(&self, event: PoolEvent) {
-        match self.votor_event_channel.try_send(event) {
-            Ok(()) => {}
-            Err(TrySendError::Full(event)) => {
-                warn!("Votor event channel full, dropping pool event: {event:?}");
-            }
-            Err(TrySendError::Closed(event)) => {
-                debug!("Votor event channel closed, dropping pool event: {event:?}");
-            }
-        }
+    /// The event is buffered rather than sent on purpose: the vote/cert ingest path
+    /// holds the Pool write lock while adding to the pool (see
+    /// [`super::Alpenglow::handle_all2all_message`]), so a *blocking* send under the
+    /// lock would let a slow or stalled Votor jam every other task waiting on that
+    /// lock. The caller drains the outbox via [`Pool::take_outbox`] and forwards it
+    /// to Votor *after* dropping the lock, where a blocking send is safe: it
+    /// back-pressures the ingest task rather than dropping the event.
+    fn enqueue_votor_event(&mut self, event: PoolEvent) {
+        self.outbox.votor_events.push(event);
     }
 
-    /// Requests a repair of the given block, returning without blocking.
+    /// Records a repair request for the given block in the outbox.
     ///
-    /// Like [`Self::send_votor_event`], this uses a non-blocking
-    /// [`Sender::try_send`] so the Pool write lock is never held waiting on the
-    /// repair loop. On overflow or a closed channel the request is dropped with a
-    /// log message; the block can still be repaired later via standstill recovery.
-    fn request_repair(&self, block_id: BlockId) {
-        match self.repair_channel.try_send(block_id) {
-            Ok(()) => {}
-            Err(TrySendError::Full(block_id)) => {
-                warn!("repair channel full, dropping repair request for {block_id:?}");
-            }
-            Err(TrySendError::Closed(block_id)) => {
-                debug!("repair channel closed, dropping repair request for {block_id:?}");
-            }
-        }
+    /// Buffered rather than sent, for the same reason as
+    /// [`Self::enqueue_votor_event`].
+    fn enqueue_repair(&mut self, block_id: BlockId) {
+        self.outbox.repairs.push(block_id);
     }
 }
 
@@ -520,10 +519,10 @@ impl Pool for PoolImpl {
             self.add_valid_cert(cert).await;
         }
         for event in votor_events {
-            self.send_votor_event(event);
+            self.enqueue_votor_event(event);
         }
         for (slot, block_hash) in blocks_to_repair {
-            self.request_repair((slot, block_hash));
+            self.enqueue_repair((slot, block_hash));
         }
         Ok(())
     }
@@ -553,8 +552,8 @@ impl Pool for PoolImpl {
                 .notify_parent_certified(block_hash.clone())
         {
             match output {
-                Either::Left(event) => self.send_votor_event(event),
-                Either::Right((slot, hash)) => self.request_repair((slot, hash)),
+                Either::Left(event) => self.enqueue_votor_event(event),
+                Either::Right((slot, hash)) => self.enqueue_repair((slot, hash)),
             }
             return;
         }
@@ -563,10 +562,11 @@ impl Pool for PoolImpl {
 
     /// Triggers a recovery from a standstill.
     ///
-    /// Determines which certificates and votes need to be re-broadcast.
-    /// Emits the corresponding [`PoolEvent::Standstill`] event for Votor.
-    /// Should be called after not seeing any progress for the standstill duration.
-    async fn recover_from_standstill(&self) {
+    /// Determines which certificates and votes need to be re-broadcast and returns
+    /// them as a [`PoolOutbox`] holding a single [`PoolEvent::Standstill`] for the
+    /// caller to forward to Votor. Should be called after not seeing any progress
+    /// for the standstill duration.
+    fn recover_from_standstill(&self) -> PoolOutbox {
         let slot = self.finalized_slot();
         let mut certs = self.get_final_certs(slot);
         assert!(!certs.is_empty(), "no final cert");
@@ -587,8 +587,15 @@ impl Pool for PoolImpl {
         // otherwise drop a bundle that Pool emitted precisely because it is stuck.
         let event = PoolEvent::Standstill(slot.next(), certs, votes);
 
-        // send to votor for broadcasting
-        self.send_votor_event(event);
+        // return to the caller for (off-lock) forwarding to Votor
+        PoolOutbox {
+            votor_events: vec![event],
+            repairs: Vec::new(),
+        }
+    }
+
+    fn take_outbox(&mut self) -> PoolOutbox {
+        std::mem::take(&mut self.outbox)
     }
 
     /// Gives the currently highest finalized (fast or slow) slot.
@@ -660,7 +667,9 @@ mod tests {
         sks: Vec<SecretKey>,
         epoch_info: Arc<ValidatorEpochInfo>,
         pool: PoolImpl,
+        votor_tx: mpsc::Sender<PoolEvent>,
         votor_rx: mpsc::Receiver<PoolEvent>,
+        repair_tx: mpsc::Sender<BlockId>,
         _repair_rx: mpsc::Receiver<BlockId>,
     }
 
@@ -669,12 +678,14 @@ mod tests {
         let epoch_info = wrap_epoch_info(epoch_info);
         let (votor_tx, votor_rx) = mpsc::channel(1024);
         let (repair_tx, _repair_rx) = mpsc::channel(1024);
-        let pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
+        let pool = PoolImpl::new(epoch_info.clone());
         TestContext {
             sks,
             epoch_info,
             pool,
+            votor_tx,
             votor_rx,
+            repair_tx,
             _repair_rx,
         }
     }
@@ -685,12 +696,37 @@ mod tests {
             self.epoch_info.epoch_info().validators()
         }
 
+        /// Forwards the given pool outbox into the test channels, mirroring what
+        /// [`EventForwarder`] does in production after releasing the write lock.
+        ///
+        /// [`EventForwarder`]: crate::consensus::EventForwarder
+        fn forward(&mut self, outbox: PoolOutbox) {
+            for event in outbox.votor_events {
+                self.votor_tx
+                    .try_send(event)
+                    .expect("test votor channel should have capacity");
+            }
+            for block in outbox.repairs {
+                self.repair_tx
+                    .try_send(block)
+                    .expect("test repair channel should have capacity");
+            }
+        }
+
+        /// Drains the pool's outbox into the test channels.
+        fn forward_outbox(&mut self) {
+            let outbox = self.pool.take_outbox();
+            self.forward(outbox);
+        }
+
         /// Verifies `vote` into a [`ValidatedVote`] and adds it to the pool.
         async fn add_vote(&mut self, vote: Vote) -> Result<(), AddVoteError> {
             // NOTE: signature-rejection is covered by the [`ValidatedVote`] tests
             let vote = ValidatedVote::try_new(vote, self.epoch_info.epoch_info())
                 .expect("test vote should pass verification");
-            self.pool.add_vote(vote).await
+            let res = self.pool.add_vote(vote).await;
+            self.forward_outbox();
+            res
         }
 
         /// Verifies `cert` into a [`ValidatedCert`] and adds it to the pool.
@@ -698,7 +734,9 @@ mod tests {
             // NOTE: certificate rejection is covered by the [`ValidatedCert`] tests
             let cert = ValidatedCert::try_new(cert, self.epoch_info.epoch_info())
                 .expect("test cert should pass verification");
-            self.pool.add_cert(cert).await
+            let res = self.pool.add_cert(cert).await;
+            self.forward_outbox();
+            res
         }
 
         /// Adds a notarization [`Vote`] for `hash` in `slot` from each of `validators` to the pool.
@@ -788,49 +826,35 @@ mod tests {
         }
     }
 
-    /// Notarizes a block in slot 0, which makes the Pool emit a `CertCreated`
-    /// event to Votor via the (non-blocking) `send_votor_event`.
-    async fn notarize_genesis(
-        pool: &mut PoolImpl,
-        sks: &[SecretKey],
-        epoch_info: &ValidatorEpochInfo,
-    ) {
+    /// Notarizing a block must record a `CertCreated` event in the pool's outbox
+    /// (rather than sending it under the lock), so the caller can forward it to
+    /// Votor losslessly after releasing the write lock.
+    #[tokio::test]
+    async fn cert_created_event_is_recorded() {
+        let mut ctx = setup();
+
+        // Notarize genesis directly on the pool, bypassing the test helpers so the
+        // outbox is not drained before we can inspect it.
         for v in (0..11).map(ValidatorIndex::new) {
-            let vote = Vote::new_notar(Slot::new(0), GENESIS_BLOCK_HASH, &sks[v.as_usize()], v);
-            let vote = ValidatedVote::try_new(vote, epoch_info.epoch_info())
+            let vote = Vote::new_notar(Slot::new(0), GENESIS_BLOCK_HASH, &ctx.sks[v.as_usize()], v);
+            let vote = ValidatedVote::try_new(vote, ctx.epoch_info.epoch_info())
                 .expect("test vote should pass verification");
-            assert_eq!(pool.add_vote(vote).await, Ok(()));
+            ctx.pool.add_vote(vote).await.unwrap();
         }
-        assert!(pool.has_notar_cert(Slot::new(0)));
-    }
+        assert!(ctx.pool.has_notar_cert(Slot::new(0)));
 
-    /// A full Votor channel must not panic or block the Pool: `send_votor_event`
-    /// uses a non-blocking `try_send` and drops the event on overflow.
-    #[tokio::test]
-    async fn votor_event_dropped_when_channel_full() {
-        let (sks, epoch_info) = generate_validators(11);
-        let epoch_info = wrap_epoch_info(epoch_info);
-        // Capacity 1, never drained: the first event fills it, the rest overflow.
-        let (votor_tx, _votor_rx) = mpsc::channel(1);
-        let (repair_tx, _repair_rx) = mpsc::channel(1);
-        let mut pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
-
-        notarize_genesis(&mut pool, &sks, &epoch_info).await;
-    }
-
-    /// A closed Votor channel (Votor shutting down) must not panic the Pool;
-    /// `send_votor_event` drops the event on `TrySendError::Closed`.
-    #[tokio::test]
-    async fn votor_event_dropped_when_channel_closed() {
-        let (sks, epoch_info) = generate_validators(11);
-        let epoch_info = wrap_epoch_info(epoch_info);
-        let (votor_tx, votor_rx) = mpsc::channel(1024);
-        let (repair_tx, repair_rx) = mpsc::channel(1024);
-        let mut pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
-        drop(votor_rx);
-        drop(repair_rx);
-
-        notarize_genesis(&mut pool, &sks, &epoch_info).await;
+        let outbox = ctx.pool.take_outbox();
+        assert!(
+            outbox
+                .votor_events
+                .iter()
+                .any(|e| matches!(e, PoolEvent::CertCreated(Cert::Notar(_)))),
+            "expected a CertCreated event, got {:?}",
+            outbox.votor_events
+        );
+        // Draining leaves the outbox empty.
+        let drained = ctx.pool.take_outbox();
+        assert!(drained.votor_events.is_empty() && drained.repairs.is_empty());
     }
 
     #[tokio::test]
@@ -1381,7 +1405,8 @@ mod tests {
         ctx.add_notar_votes(slot3, &hash3, 0..1).await;
 
         // initiate standstill
-        ctx.pool.recover_from_standstill().await;
+        let outbox = ctx.pool.recover_from_standstill();
+        ctx.forward(outbox);
 
         // wait for standstill event
         let (slot, certs, votes) = loop {
@@ -1448,6 +1473,7 @@ mod tests {
         // add its ancestors
         ctx.pool.add_block(block2.clone(), block1.clone()).await;
         ctx.pool.add_block(block1.clone(), block0.clone()).await;
+        ctx.forward_outbox();
 
         // should emit ParentReady as a result
         let Ok(event) = ctx.votor_rx.try_recv() else {

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -20,6 +20,7 @@ use either::Either;
 use log::{debug, info, trace, warn};
 use thiserror::Error;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{RwLock, oneshot};
 
 use self::finality_tracker::FinalityTracker;
@@ -209,22 +210,22 @@ impl PoolImpl {
                         .notify_parent_certified(child_hash)
                 {
                     match output {
-                        Either::Left(event) => self.send_votor_event(event).await,
-                        Either::Right((slot, hash)) => self.send_repair((slot, hash)).await,
+                        Either::Left(event) => self.send_votor_event(event),
+                        Either::Right((slot, hash)) => self.request_repair((slot, hash)),
                     }
                 }
 
                 // add block to parent-ready tracker, send any new parents to Votor.
                 let new_parents_ready = self.parent_ready_tracker.mark_notar_fallback(&block_id);
-                self.send_parent_ready_events(new_parents_ready).await;
+                self.send_parent_ready_events(new_parents_ready);
 
                 // repair this block, if necessary
-                self.send_repair((slot, block_hash)).await;
+                self.request_repair((slot, block_hash));
             }
             Cert::Skip(_) => {
                 warn!("skipped slot {slot}");
                 let new_parents_ready = self.parent_ready_tracker.mark_skipped(slot);
-                self.send_parent_ready_events(new_parents_ready).await;
+                self.send_parent_ready_events(new_parents_ready);
             }
             Cert::FastFinal(ff_cert) => {
                 info!("fast finalized slot {slot}");
@@ -241,7 +242,7 @@ impl PoolImpl {
 
         // send to votor for broadcasting
         let event = PoolEvent::CertCreated(cert);
-        self.send_votor_event(event).await;
+        self.send_votor_event(event);
     }
 
     /// Mutably accesses the [`SlotState`] for the given `slot`.
@@ -390,32 +391,53 @@ impl PoolImpl {
 
     async fn handle_finalization(&mut self, event: FinalizationEvent) {
         let new_parents_ready = self.parent_ready_tracker.handle_finalization(event);
-        self.send_parent_ready_events(new_parents_ready).await;
+        self.send_parent_ready_events(new_parents_ready);
         self.prune();
     }
 
-    async fn send_parent_ready_events(&self, parents: impl IntoIterator<Item = (Slot, BlockId)>) {
+    fn send_parent_ready_events(&self, parents: impl IntoIterator<Item = (Slot, BlockId)>) {
         for (slot, parent) in parents {
             debug_assert!(slot.is_start_of_window());
-            self.send_votor_event(PoolEvent::ParentReady { slot, parent })
-                .await;
+            self.send_votor_event(PoolEvent::ParentReady { slot, parent });
         }
     }
 
-    /// Sends an event to Votor, panicking if Votor dropped the receiver.
-    async fn send_votor_event(&self, event: PoolEvent) {
-        self.votor_event_channel
-            .send(event)
-            .await
-            .expect("votor should not drop the event receiver");
+    /// Forwards an event to Votor, returning without blocking.
+    ///
+    /// This uses a non-blocking [`Sender::try_send`] on purpose: the vote/cert
+    /// ingest path holds the Pool write lock while adding to the pool (see
+    /// [`super::Alpenglow::handle_all2all_message`]), so a blocking send would let
+    /// a slow or stalled Votor apply back-pressure that jams every other task
+    /// waiting on that lock. On overflow (channel full) or a closed channel (Votor
+    /// shutting down) the event is dropped with a log message rather than panicking.
+    fn send_votor_event(&self, event: PoolEvent) {
+        match self.votor_event_channel.try_send(event) {
+            Ok(()) => {}
+            Err(TrySendError::Full(event)) => {
+                warn!("Votor event channel full, dropping pool event: {event:?}");
+            }
+            Err(TrySendError::Closed(event)) => {
+                debug!("Votor event channel closed, dropping pool event: {event:?}");
+            }
+        }
     }
 
-    /// Requests repair of the given block, panicking if the repair loop dropped the receiver.
-    async fn send_repair(&self, block: BlockId) {
-        self.repair_channel
-            .send(block)
-            .await
-            .expect("repair loop should not drop the receiver");
+    /// Requests a repair of the given block, returning without blocking.
+    ///
+    /// Like [`Self::send_votor_event`], this uses a non-blocking
+    /// [`Sender::try_send`] so the Pool write lock is never held waiting on the
+    /// repair loop. On overflow or a closed channel the request is dropped with a
+    /// log message; the block can still be repaired later via standstill recovery.
+    fn request_repair(&self, block_id: BlockId) {
+        match self.repair_channel.try_send(block_id) {
+            Ok(()) => {}
+            Err(TrySendError::Full(block_id)) => {
+                warn!("repair channel full, dropping repair request for {block_id:?}");
+            }
+            Err(TrySendError::Closed(block_id)) => {
+                debug!("repair channel closed, dropping repair request for {block_id:?}");
+            }
+        }
     }
 }
 
@@ -498,10 +520,10 @@ impl Pool for PoolImpl {
             self.add_valid_cert(cert).await;
         }
         for event in votor_events {
-            self.send_votor_event(event).await;
+            self.send_votor_event(event);
         }
         for (slot, block_hash) in blocks_to_repair {
-            self.send_repair((slot, block_hash)).await;
+            self.request_repair((slot, block_hash));
         }
         Ok(())
     }
@@ -521,7 +543,7 @@ impl Pool for PoolImpl {
         let new_parents_ready = self
             .parent_ready_tracker
             .handle_finalization(finalization_event);
-        self.send_parent_ready_events(new_parents_ready).await;
+        self.send_parent_ready_events(new_parents_ready);
 
         self.slot_state(*slot).notify_parent_known(block_hash);
         if let Some(parent_state) = self.slot_states.get(parent_slot)
@@ -531,8 +553,8 @@ impl Pool for PoolImpl {
                 .notify_parent_certified(block_hash.clone())
         {
             match output {
-                Either::Left(event) => self.send_votor_event(event).await,
-                Either::Right((slot, hash)) => self.send_repair((slot, hash)).await,
+                Either::Left(event) => self.send_votor_event(event),
+                Either::Right((slot, hash)) => self.request_repair((slot, hash)),
             }
             return;
         }
@@ -566,7 +588,7 @@ impl Pool for PoolImpl {
         let event = PoolEvent::Standstill(slot.next(), certs, votes);
 
         // send to votor for broadcasting
-        self.send_votor_event(event).await;
+        self.send_votor_event(event);
     }
 
     /// Gives the currently highest finalized (fast or slow) slot.
@@ -764,6 +786,51 @@ mod tests {
             }
             seen
         }
+    }
+
+    /// Notarizes a block in slot 0, which makes the Pool emit a `CertCreated`
+    /// event to Votor via the (non-blocking) `send_votor_event`.
+    async fn notarize_genesis(
+        pool: &mut PoolImpl,
+        sks: &[SecretKey],
+        epoch_info: &ValidatorEpochInfo,
+    ) {
+        for v in (0..11).map(ValidatorIndex::new) {
+            let vote = Vote::new_notar(Slot::new(0), GENESIS_BLOCK_HASH, &sks[v.as_usize()], v);
+            let vote = ValidatedVote::try_new(vote, epoch_info.epoch_info())
+                .expect("test vote should pass verification");
+            assert_eq!(pool.add_vote(vote).await, Ok(()));
+        }
+        assert!(pool.has_notar_cert(Slot::new(0)));
+    }
+
+    /// A full Votor channel must not panic or block the Pool: `send_votor_event`
+    /// uses a non-blocking `try_send` and drops the event on overflow.
+    #[tokio::test]
+    async fn votor_event_dropped_when_channel_full() {
+        let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
+        // Capacity 1, never drained: the first event fills it, the rest overflow.
+        let (votor_tx, _votor_rx) = mpsc::channel(1);
+        let (repair_tx, _repair_rx) = mpsc::channel(1);
+        let mut pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
+
+        notarize_genesis(&mut pool, &sks, &epoch_info).await;
+    }
+
+    /// A closed Votor channel (Votor shutting down) must not panic the Pool;
+    /// `send_votor_event` drops the event on `TrySendError::Closed`.
+    #[tokio::test]
+    async fn votor_event_dropped_when_channel_closed() {
+        let (sks, epoch_info) = generate_validators(11);
+        let epoch_info = wrap_epoch_info(epoch_info);
+        let (votor_tx, votor_rx) = mpsc::channel(1024);
+        let (repair_tx, repair_rx) = mpsc::channel(1024);
+        let mut pool = PoolImpl::new(epoch_info.clone(), votor_tx, repair_tx);
+        drop(votor_rx);
+        drop(repair_rx);
+
+        notarize_genesis(&mut pool, &sks, &epoch_info).await;
     }
 
     #[tokio::test]

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use either::Either;
 use log::{debug, info, trace, warn};
 use thiserror::Error;
-use tokio::sync::{RwLock, oneshot};
 
 use self::finality_tracker::FinalityTracker;
 use self::parent_ready_tracker::ParentReadyTracker;
@@ -30,9 +29,7 @@ use crate::crypto::merkle::BlockHash;
 use crate::types::SLOTS_PER_EPOCH;
 use crate::{BlockId, Slot, ValidatorIndex};
 
-/// Events emitted by [`PoolImpl`] to [`Votor`].
-///
-/// [`Votor`]: crate::consensus::votor::Votor
+/// Events emitted by [`PoolImpl`] to the consensus core (`VotorState`).
 // PERF: Short-lived channel message; boxing the cert isn't worth the allocation.
 #[expect(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
@@ -68,10 +65,9 @@ impl PoolEvent {
     }
 }
 
-/// Side-effects the Pool produces while processing under its write lock, to be
-/// drained via [`Pool::take_outbox`] and forwarded to Votor and the repair loop
-/// once the lock is released (a blocking send under the lock would jam every task
-/// contending for it).
+/// Side-effects the Pool buffers while processing, to be drained via
+/// [`PoolImpl::take_outbox`] and routed to Votor and the repair loop by the
+/// consensus core.
 #[derive(Debug, Default)]
 pub struct PoolOutbox {
     /// Events destined for Votor.
@@ -119,38 +115,12 @@ pub enum SlashableOffence {
     NotarFallbackAndFinalize(ValidatorIndex, Slot),
 }
 
-/// Interface for the Pool.
-///
-/// This is only used for mocking of [`PoolImpl`].
-///
-/// All methods are synchronous: the pool is a pure state machine that performs
-/// no I/O and buffers its side-effects in a [`PoolOutbox`], so no method ever
-/// needs to await (and none may, as callers invoke them under a write lock).
-#[cfg_attr(test, mockall::automock)]
-pub trait Pool {
-    fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError>;
-    fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError>;
-    fn add_block(&mut self, block_id: BlockId, parent_id: BlockId);
-    /// Builds the standstill-recovery bundle to re-broadcast; see [`PoolImpl::recover_from_standstill`].
-    fn recover_from_standstill(&self) -> PoolOutbox;
-    /// Drains and returns the side-effects buffered since the last call.
-    ///
-    /// The caller must forward these to Votor and the repair loop *after* releasing
-    /// the Pool lock; see `PoolImpl::enqueue_votor_event`.
-    fn take_outbox(&mut self) -> PoolOutbox;
-    fn finalized_slot(&self) -> Slot;
-    fn parents_ready(&self, slot: Slot) -> &[BlockId];
-    fn wait_for_parent_ready(&mut self, slot: Slot) -> Either<BlockId, oneshot::Receiver<BlockId>>;
-}
-
-/// Shared, lock-protected handle to a [`Pool`] trait object.
-pub type SharedPool = Arc<RwLock<dyn Pool + Send + Sync>>;
-
 /// Pool is the central consensus data structure.
 ///
 /// It holds votes and certificates for each slot.
 ///
-/// This is the main implementation to use when you require the [`Pool`] trait.
+/// It is a pure, synchronous state machine: it performs no I/O and buffers
+/// its side-effects in a [`PoolOutbox`], drained via [`PoolImpl::take_outbox`].
 pub struct PoolImpl {
     /// State for each slot. Stores all votes and certificates.
     slot_states: BTreeMap<Slot, SlotState>,
@@ -163,8 +133,8 @@ pub struct PoolImpl {
 
     /// Information about all active validators.
     epoch_info: Arc<ValidatorEpochInfo>,
-    /// Buffered side-effects (Votor events + repair requests) produced under the
-    /// write lock, drained by the caller via [`Pool::take_outbox`].
+    /// Buffered side-effects (Votor events + repair requests),
+    /// drained by the caller via [`PoolImpl::take_outbox`].
     outbox: PoolOutbox,
 }
 
@@ -172,9 +142,8 @@ impl PoolImpl {
     /// Creates a new empty pool containing no votes or certificates.
     ///
     /// Any events the pool emits are buffered in its [`PoolOutbox`] and must be
-    /// drained by the caller via [`Pool::take_outbox`], then forwarded to Votor and
-    /// the repair loop after the write lock is released; see
-    /// `PoolImpl::enqueue_votor_event`.
+    /// drained by the caller via [`PoolImpl::take_outbox`], then routed to Votor
+    /// and the repair loop; see `PoolImpl::enqueue_votor_event`.
     pub fn new(epoch_info: Arc<ValidatorEpochInfo>) -> Self {
         Self {
             slot_states: BTreeMap::new(),
@@ -419,9 +388,8 @@ impl PoolImpl {
 
     /// Records an event for Votor in the outbox.
     ///
-    /// Buffered rather than sent so the caller can forward it off the write lock
-    /// (see [`super::EventForwarder`]); a blocking send under the lock would jam
-    /// every task contending for it.
+    /// Buffered rather than sent so this state machine stays free of I/O; the
+    /// consensus core drains the outbox and routes the events.
     fn enqueue_votor_event(&mut self, event: PoolEvent) {
         self.outbox.votor_events.push(event);
     }
@@ -435,10 +403,14 @@ impl PoolImpl {
     }
 }
 
-impl Pool for PoolImpl {
+impl PoolImpl {
     /// Adds a new certificate to the pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the certificate's slot is out of bounds or it is a duplicate.
     #[hotpath::measure]
-    fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError> {
+    pub fn add_cert(&mut self, cert: ValidatedCert) -> Result<(), AddCertError> {
         // ignore old and far-in-the-future certificates
         let slot = cert.slot();
         // TODO: set bounds exactly correctly
@@ -470,8 +442,13 @@ impl Pool for PoolImpl {
     }
 
     /// Adds a new vote to the pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the vote's slot is out of bounds, it is a duplicate,
+    /// or it constitutes a slashable offence.
     #[hotpath::measure]
-    fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError> {
+    pub fn add_vote(&mut self, vote: ValidatedVote) -> Result<(), AddVoteError> {
         // ignore old and far-in-the-future votes
         let slot = vote.slot();
         // TODO: set bounds exactly correctly
@@ -525,7 +502,7 @@ impl Pool for PoolImpl {
     ///
     /// This should be called once for every valid block (e.g. directly by blockstore).
     /// Ensures that the parent information is available for safe-to-notar checks.
-    fn add_block(&mut self, block_id: BlockId, parent_id: BlockId) {
+    pub fn add_block(&mut self, block_id: BlockId, parent_id: BlockId) {
         assert!(block_id.0 > parent_id.0);
         let (slot, block_hash) = &block_id;
         let (parent_slot, parent_hash) = &parent_id;
@@ -560,7 +537,7 @@ impl Pool for PoolImpl {
     /// them as a [`PoolOutbox`] holding a single [`PoolEvent::Standstill`] for the
     /// caller to forward to Votor. Should be called after not seeing any progress
     /// for the standstill duration.
-    fn recover_from_standstill(&self) -> PoolOutbox {
+    pub fn recover_from_standstill(&self) -> PoolOutbox {
         let slot = self.finalized_slot();
         let mut certs = self.get_final_certs(slot);
         assert!(!certs.is_empty(), "no final cert");
@@ -588,22 +565,24 @@ impl Pool for PoolImpl {
         }
     }
 
-    fn take_outbox(&mut self) -> PoolOutbox {
+    /// Drains and returns the side-effects buffered since the last call.
+    ///
+    /// The caller must forward these to Votor and the repair loop;
+    /// see `PoolImpl::enqueue_votor_event`.
+    pub fn take_outbox(&mut self) -> PoolOutbox {
         std::mem::take(&mut self.outbox)
     }
 
     /// Gives the currently highest finalized (fast or slow) slot.
-    fn finalized_slot(&self) -> Slot {
+    #[must_use]
+    pub fn finalized_slot(&self) -> Slot {
         self.finality_tracker.highest_finalized_slot()
     }
 
     /// Returns all possible parents for the given slot that are ready.
-    fn parents_ready(&self, slot: Slot) -> &[BlockId] {
+    #[must_use]
+    pub fn parents_ready(&self, slot: Slot) -> &[BlockId] {
         self.parent_ready_tracker.parents_ready(slot)
-    }
-
-    fn wait_for_parent_ready(&mut self, slot: Slot) -> Either<BlockId, oneshot::Receiver<BlockId>> {
-        self.parent_ready_tracker.wait_for_parent_ready(slot)
     }
 }
 
@@ -690,10 +669,8 @@ mod tests {
             self.epoch_info.epoch_info().validators()
         }
 
-        /// Forwards the given pool outbox into the test channels, mirroring what
-        /// [`EventForwarder`] does in production after releasing the write lock.
-        ///
-        /// [`EventForwarder`]: crate::consensus::EventForwarder
+        /// Forwards the given pool outbox into the test channels, mirroring how
+        /// the consensus core routes a drained outbox in production.
         fn forward(&mut self, outbox: PoolOutbox) {
             for event in outbox.votor_events {
                 self.votor_tx

--- a/src/consensus/pool.rs
+++ b/src/consensus/pool.rs
@@ -70,12 +70,9 @@ impl PoolEvent {
 }
 
 /// Side-effects the Pool produces while processing under its write lock, to be
-/// drained via [`Pool::take_outbox`] and forwarded once the lock is released.
-///
-/// The Pool buffers these here instead of sending them under the lock: a blocking
-/// send would let a slow Votor or repair loop jam every task contending for the
-/// Pool lock, while a non-blocking send would have to drop events. See
-/// `PoolImpl::enqueue_votor_event` for the rationale.
+/// drained via [`Pool::take_outbox`] and forwarded to Votor and the repair loop
+/// once the lock is released (a blocking send under the lock would jam every task
+/// contending for it).
 #[derive(Debug, Default)]
 pub struct PoolOutbox {
     /// Events destined for Votor.
@@ -420,13 +417,9 @@ impl PoolImpl {
 
     /// Records an event for Votor in the outbox.
     ///
-    /// The event is buffered rather than sent on purpose: the vote/cert ingest path
-    /// holds the Pool write lock while adding to the pool (see
-    /// [`super::Alpenglow::handle_all2all_message`]), so a *blocking* send under the
-    /// lock would let a slow or stalled Votor jam every other task waiting on that
-    /// lock. The caller drains the outbox via [`Pool::take_outbox`] and forwards it
-    /// to Votor *after* dropping the lock, where a blocking send is safe: it
-    /// back-pressures the ingest task rather than dropping the event.
+    /// Buffered rather than sent so the caller can forward it off the write lock
+    /// (see [`super::EventForwarder`]); a blocking send under the lock would jam
+    /// every task contending for it.
     fn enqueue_votor_event(&mut self, event: PoolEvent) {
         self.outbox.votor_events.push(event);
     }
@@ -590,7 +583,7 @@ impl Pool for PoolImpl {
         // return to the caller for (off-lock) forwarding to Votor
         PoolOutbox {
             votor_events: vec![event],
-            repairs: Vec::new(),
+            ..Default::default()
         }
     }
 

--- a/src/consensus/pool/parent_ready_tracker.rs
+++ b/src/consensus/pool/parent_ready_tracker.rs
@@ -19,9 +19,7 @@ mod parent_ready_state;
 
 use std::collections::HashMap;
 
-use either::Either;
 use smallvec::SmallVec;
-use tokio::sync::oneshot;
 
 use self::parent_ready_state::ParentReadyState;
 use crate::consensus::pool::finality_tracker::FinalizationEvent;
@@ -178,17 +176,6 @@ impl ParentReadyTracker {
             .map_or(&[], |state| state.ready_block_ids())
     }
 
-    /// Returns a ready parent if available, otherwise returns a oneshot channel.
-    ///
-    /// The oneshot channel will receive the first ready parent once it becomes available.
-    pub(super) fn wait_for_parent_ready(
-        &mut self,
-        slot: Slot,
-    ) -> Either<BlockId, oneshot::Receiver<BlockId>> {
-        let state = self.states.entry(slot).or_default();
-        state.wait_for_parent_ready()
-    }
-
     /// Removes all tracked state for slots strictly below `new_root`.
     ///
     /// After this, only slots `>= new_root` are retained.
@@ -339,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn wait_for_parent_ready() {
+    fn parents_ready_after_skips() {
         let genesis = genesis_block_id();
         let mut windows = Slot::windows();
         let window1 = windows.next().unwrap();
@@ -355,29 +342,20 @@ mod tests {
             tracker.mark_skipped(slot);
         }
 
-        // genesis should be valid parent for 2nd window
-        let res = tracker.wait_for_parent_ready(window2);
-        let Either::Left((slot, hash)) = res else {
-            panic!("unexpected result {res:?}");
-        };
-        assert_eq!((slot, hash), genesis);
+        // genesis should be valid parent for 2nd window, but not yet for the 3rd
+        assert_eq!(
+            tracker.parents_ready(window2),
+            std::slice::from_ref(&genesis)
+        );
+        assert_eq!(tracker.parents_ready(window3), &[]);
 
-        // parent should not yet be ready
-        let res = tracker.wait_for_parent_ready(window3);
-        let Either::Right(mut rx) = res else {
-            panic!("unexpected result {res:?}");
-        };
-        let Err(oneshot::error::TryRecvError::Empty) = rx.try_recv() else {
-            panic!("parent should not yet be ready");
-        };
-
-        // skip slots in first window
+        // skip slots in second window
         for slot in window2.slots_in_window() {
             tracker.mark_skipped(slot);
         }
 
-        // now we should be notified of genesis as valid parent
-        assert_eq!(rx.try_recv(), Ok(genesis));
+        // now genesis is a valid parent for the 3rd window as well
+        assert_eq!(tracker.parents_ready(window3), &[genesis]);
     }
 
     #[test]

--- a/src/consensus/pool/parent_ready_tracker/parent_ready_state.rs
+++ b/src/consensus/pool/parent_ready_tracker/parent_ready_state.rs
@@ -6,32 +6,10 @@
 //! It holds the necessary state for a given slot to track the parent-ready condition.
 //! This is used by the [`super::ParentReadyTracker`].
 
-use either::Either;
-use log::warn;
-use smallvec::{SmallVec, smallvec};
-use tokio::sync::oneshot;
+use smallvec::SmallVec;
 
 use crate::BlockId;
 use crate::crypto::merkle::{BlockHash, GENESIS_BLOCK_HASH};
-
-/// Status of whether an individual slot has a parent ready.
-enum IsReady {
-    /// Do not have a parent ready for this slot yet.
-    ///
-    /// Might have someone waiting to hear when the slot does become ready.
-    NotReady(Option<oneshot::Sender<BlockId>>),
-    /// Have at least one parent ready for this slot.
-    ///
-    /// We can potentially have multiple parents ready per slot, but we
-    /// optimize for the common case where there will only be one.
-    Ready(SmallVec<[BlockId; 1]>),
-}
-
-impl Default for IsReady {
-    fn default() -> Self {
-        IsReady::NotReady(None)
-    }
-}
 
 /// Holds the relevant state for a single slot.
 #[derive(Default)]
@@ -43,10 +21,11 @@ pub(super) struct ParentReadyState {
     /// We can potentially have multiple notar fallbacks per slot,
     /// but we optimize for the common case where there will only be one.
     notar_fallbacks: SmallVec<[BlockHash; 1]>,
-    /// Current status of the parent-ready condition for this slot.
-    // NOTE: Do not make this field more visible.
-    // Updating it must sometimes produce additional actions.
-    is_ready: IsReady,
+    /// Parents ready for this slot.
+    ///
+    /// We can potentially have multiple parents ready per slot, but we
+    /// optimize for the common case where there will only be one.
+    ready: SmallVec<[BlockId; 1]>,
 }
 
 impl ParentReadyState {
@@ -55,7 +34,7 @@ impl ParentReadyState {
         Self {
             skip: false,
             notar_fallbacks: SmallVec::from([GENESIS_BLOCK_HASH]),
-            is_ready: IsReady::default(),
+            ready: SmallVec::new(),
         }
     }
 
@@ -95,61 +74,17 @@ impl ParentReadyState {
 
     /// Adds a [`BlockId`] to the parents ready list.
     ///
-    /// Additionally, will inform any waiters.
-    ///
     /// # Panics
     ///
     /// If the specific parent is already marked ready for this slot.
     pub(super) fn add_to_ready(&mut self, id: BlockId) {
-        match &mut self.is_ready {
-            IsReady::NotReady(sender) => {
-                let sender = sender.take();
-                match sender {
-                    None => (),
-                    Some(sender) => match sender.send(id.clone()) {
-                        Ok(()) => (),
-                        Err(id) => {
-                            warn!("sending {id:?} failed, receiver deallocated");
-                        }
-                    },
-                }
-                self.is_ready = IsReady::Ready(smallvec![id]);
-            }
-            IsReady::Ready(ready_ids) => {
-                assert!(!ready_ids.contains(&id));
-                ready_ids.push(id);
-            }
-        }
+        assert!(!self.ready.contains(&id));
+        self.ready.push(id);
     }
 
     /// Returns the list of currently valid parents for this slot.
     pub(super) fn ready_block_ids(&self) -> &[BlockId] {
-        match &self.is_ready {
-            IsReady::NotReady(_) => &[],
-            IsReady::Ready(block_ids) => block_ids,
-        }
-    }
-
-    /// Requests to know a valid parent for this slot.
-    ///
-    /// Returns either:
-    /// - The block ID of a parent if at least one parent is already ready.
-    ///   Always returns a parent with minimal slot number if multiple parents are ready.
-    /// - A receiver of a oneshot channel that will receive the first parent's block ID.
-    pub(super) fn wait_for_parent_ready(&mut self) -> Either<BlockId, oneshot::Receiver<BlockId>> {
-        match &mut self.is_ready {
-            IsReady::Ready(block_ids) => {
-                assert!(!block_ids.is_empty());
-                block_ids.sort();
-                Either::Left(block_ids[0].clone())
-            }
-            IsReady::NotReady(maybe_waiter) => {
-                assert!(maybe_waiter.is_none());
-                let (tx, rx) = oneshot::channel();
-                self.is_ready = IsReady::NotReady(Some(tx));
-                Either::Right(rx)
-            }
-        }
+        &self.ready
     }
 }
 
@@ -160,31 +95,11 @@ mod tests {
     use crate::test_utils::random_block_id;
 
     #[test]
-    fn wait_for_parent_ready_no_blocking() {
+    fn ready_parents_are_tracked() {
         let mut state = ParentReadyState::default();
         assert_eq!(state.ready_block_ids().len(), 0);
         let block_id = random_block_id(Slot::new(1));
         state.add_to_ready(block_id.clone());
-        let res = state.wait_for_parent_ready();
-        let Either::Left(received_block_id) = res else {
-            panic!("unexpected result {res:?}");
-        };
-        assert_eq!(received_block_id, block_id);
-        assert_eq!(state.ready_block_ids().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn wait_for_parent_ready_blocking() {
-        let mut state = ParentReadyState::default();
-        assert_eq!(state.ready_block_ids().len(), 0);
-        let res = state.wait_for_parent_ready();
-        let Either::Right(rx) = res else {
-            panic!("unexpected result {res:?}");
-        };
-        let block_id = random_block_id(Slot::new(1));
-        state.add_to_ready(block_id.clone());
-        let received_block_id = rx.await.unwrap();
-        assert_eq!(received_block_id, block_id);
-        assert_eq!(state.ready_block_ids().len(), 1);
+        assert_eq!(state.ready_block_ids(), &[block_id]);
     }
 }

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -3,20 +3,25 @@
 
 //! Main voting logic for the consensus protocol.
 //!
-//! Besides [`super::Pool`], [`Votor`] is the other main internal component Alpenglow.
+//! Besides [`super::Pool`], [`VotorState`] is the other main internal component of Alpenglow.
 //! It handles the main voting decisions for the consensus protocol.
-//! As input it receives events from [`super::Pool`] (on a [`PoolEvent`] channel),
-//! from [`super::Blockstore`] (on a [`BlockstoreEvent`] channel),
-//! and its own internal timeout events.
-//! Votor keeps its own internal state for each slot based on previous events and votes.
+//! As input it receives events from [`super::Pool`] and [`super::Blockstore`],
+//! as well as its own internal timeout events.
+//! It keeps its own internal state for each slot based on previous events and votes.
 //!
-//! Votor has access to an instance of [`All2All`] for broadcasting votes.
+//! [`VotorState`] is a pure, synchronous state machine: it performs no I/O,
+//! tracks timeouts as deadlines instead of sleeping, and queues the votes it
+//! decides to cast in an internal outbox. The [`Votor`] task wraps it, feeding
+//! it events from its channels and firing due timeouts, and broadcasts the
+//! queued votes over an [`All2All`] instance.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use std::sync::Arc;
+use std::time::Instant;
 
 use log::{debug, trace, warn};
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::Receiver;
 
 use super::blockstore::{BlockInfo, BlockstoreEvent};
 use super::pool::PoolEvent;
@@ -26,33 +31,19 @@ use crate::crypto::aggsig::SecretKey;
 use crate::crypto::merkle::{BlockHash, GENESIS_BLOCK_HASH};
 use crate::{All2All, BlockId, Slot, ValidatorIndex};
 
-/// Votor implements the decision process of which votes to cast.
+/// Votor task: drives the `VotorState` state machine.
 ///
-/// It keeps some state for each slot and checks the conditions for voting.
+/// Feeds `VotorState` the events received from [`super::Pool`] and
+/// [`super::Blockstore`] as well as its due timeouts, then broadcasts the
+/// votes and certificates it queued via [`All2All`].
 pub struct Votor<A: All2All> {
-    /// Per-slot voting state, keyed by slot.
-    slots: BTreeMap<Slot, SlotState>,
-    /// Highest slot for which we have seen a (slow) final or fast-final cert.
-    ///
-    /// This is *not* equivalent to e.g. [`super::Pool::finalized_slot`],
-    /// because we may have seen a (slow) final cert without a matching notar.
-    /// We only use it to decide when our own vote for a slot no longer matters,
-    /// at which point the per-slot state for earlier leader windows is pruned.
-    highest_final_cert_slot: Slot,
-
-    /// Own validator index.
-    validator_index: ValidatorIndex,
-    /// Secret key used to sign votes.
-    voting_key: SecretKey,
+    /// The actual voting state machine.
+    state: VotorState,
 
     /// Channel for receiving events from Pool.
     pool_receiver: Receiver<PoolEvent>,
     /// Channel for receiving events from Blockstore.
     blockstore_receiver: Receiver<BlockstoreEvent>,
-    /// Channel for receiving internal timeout events.
-    timeout_receiver: Receiver<VotorTimeout>,
-    /// Sender side of the timeout channel. Used for scheduling timeouts.
-    timeout_sender: Sender<VotorTimeout>,
     /// [`All2All`] instance used to broadcast votes.
     all2all: Arc<A>,
 }
@@ -71,8 +62,131 @@ impl<A: All2All> Votor<A> {
         blockstore_receiver: Receiver<BlockstoreEvent>,
         all2all: Arc<A>,
     ) -> Self {
-        let (timeout_sender, timeout_receiver) = tokio::sync::mpsc::channel(256);
+        Self {
+            state: VotorState::new(validator_index, voting_key, Instant::now()),
+            pool_receiver,
+            blockstore_receiver,
+            all2all,
+        }
+    }
 
+    /// Handles the voting (leader and non-leader) side of consensus protocol.
+    ///
+    /// Checks consensus conditions and broadcasts new votes.
+    /// Returns once either input channel is closed (node shutdown).
+    #[fastrace::trace]
+    pub async fn voting_loop(&mut self) {
+        loop {
+            tokio::select! {
+                event = self.pool_receiver.recv() => match event {
+                    Some(event) => self.handle_pool_event(event).await,
+                    None => break,
+                },
+                event = self.blockstore_receiver.recv() => match event {
+                    Some(event) => self.handle_blockstore_event(event).await,
+                    None => break,
+                },
+                () = sleep_until_next(self.state.next_timeout()) => {
+                    self.handle_due_timeouts().await;
+                }
+            }
+        }
+    }
+
+    /// Feeds a pool event to the state machine and broadcasts resulting votes.
+    async fn handle_pool_event(&mut self, event: PoolEvent) {
+        self.state.handle_pool_event(event, Instant::now());
+        self.flush_broadcasts().await;
+    }
+
+    /// Feeds a blockstore event to the state machine and broadcasts resulting votes.
+    async fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
+        self.state.handle_blockstore_event(event);
+        self.flush_broadcasts().await;
+    }
+
+    /// Feeds a timeout event to the state machine and broadcasts resulting votes.
+    #[cfg(test)]
+    async fn handle_timeout_event(&mut self, event: VotorTimeout) {
+        self.state.handle_timeout_event(event);
+        self.flush_broadcasts().await;
+    }
+
+    /// Fires all due timeouts on the state machine and broadcasts resulting votes.
+    async fn handle_due_timeouts(&mut self) {
+        self.state.handle_due_timeouts(Instant::now());
+        self.flush_broadcasts().await;
+    }
+
+    /// Broadcasts all queued consensus messages on a best-effort basis.
+    ///
+    /// A failure of the underlying [`All2All`] network is logged and otherwise
+    /// ignored. Broadcasts are best-effort by contract, and a transient network
+    /// error must not bring down the voting loop, which has to keep running to
+    /// preserve liveness. A dropped vote/cert is re-broadcast later via standstill
+    /// recovery, so a one-off failure self-heals.
+    ///
+    /// NOTE: a *persistent* failure here (e.g. a misconfigured firewall or a full
+    /// partition) means this node silently stops contributing to consensus while
+    /// only logging. Once there is a metrics system, this should also bump a
+    /// failure counter so persistent failures become alertable.
+    async fn flush_broadcasts(&mut self) {
+        for msg in self.state.take_broadcasts() {
+            if let Err(err) = self.all2all.broadcast(&msg).await {
+                warn!("failed to broadcast consensus message: {err}");
+            }
+        }
+    }
+}
+
+/// Sleeps until the given `deadline`, or forever if there is none.
+async fn sleep_until_next(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline.into()).await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Votor's state machine: implements the decision process of which votes to cast.
+///
+/// It keeps some state for each slot and checks the conditions for voting.
+///
+/// This is a pure, synchronous state machine: it performs no I/O, tracks its
+/// timeouts as deadlines (see [`Self::next_timeout`]) rather than sleeping, and
+/// queues the votes and certificates it wants broadcast in an internal outbox,
+/// drained via [`Self::take_broadcasts`].
+pub(crate) struct VotorState {
+    /// Per-slot voting state, keyed by slot.
+    slots: BTreeMap<Slot, SlotState>,
+    /// Highest slot for which we have seen a (slow) final or fast-final cert.
+    ///
+    /// This is *not* equivalent to e.g. [`super::Pool::finalized_slot`],
+    /// because we may have seen a (slow) final cert without a matching notar.
+    /// We only use it to decide when our own vote for a slot no longer matters,
+    /// at which point the per-slot state for earlier leader windows is pruned.
+    highest_final_cert_slot: Slot,
+
+    /// Own validator index.
+    validator_index: ValidatorIndex,
+    /// Secret key used to sign votes.
+    voting_key: SecretKey,
+
+    /// Pending timeout deadlines, earliest first.
+    timeouts: BinaryHeap<Reverse<(Instant, VotorTimeout)>>,
+    /// Consensus messages queued for (best-effort) broadcast,
+    /// drained via [`Self::take_broadcasts`].
+    broadcasts: Vec<ConsensusMessage>,
+}
+
+impl VotorState {
+    /// Creates a new voting state machine with empty per-slot state.
+    ///
+    /// Timeouts for the genesis window are scheduled relative to `now`.
+    pub(crate) fn new(
+        validator_index: ValidatorIndex,
+        voting_key: SecretKey,
+        now: Instant,
+    ) -> Self {
         // pre-populate the dummy genesis block's state
         let genesis_state = SlotState {
             voted: true,
@@ -86,34 +200,16 @@ impl<A: All2All> Votor<A> {
         };
         let slots = [(Slot::genesis(), genesis_state)].into_iter().collect();
 
-        let votor = Self {
+        let mut state = Self {
             slots,
             highest_final_cert_slot: Slot::genesis(),
             validator_index,
             voting_key,
-            pool_receiver,
-            blockstore_receiver,
-            timeout_receiver,
-            timeout_sender,
-            all2all,
+            timeouts: BinaryHeap::new(),
+            broadcasts: Vec::new(),
         };
-        votor.set_timeouts(Slot::new(0));
-        votor
-    }
-
-    /// Handles the voting (leader and non-leader) side of consensus protocol.
-    ///
-    /// Checks consensus conditions and broadcasts new votes.
-    #[fastrace::trace]
-    pub async fn voting_loop(&mut self) {
-        loop {
-            tokio::select! {
-                Some(event) = self.pool_receiver.recv() => self.handle_pool_event(event).await,
-                Some(event) = self.blockstore_receiver.recv() => self.handle_blockstore_event(event).await,
-                Some(event) = self.timeout_receiver.recv() => self.handle_timeout_event(event).await,
-                else => break,
-            }
-        }
+        state.set_timeouts(Slot::new(0), now);
+        state
     }
 
     /// Returns `true` iff the given slot has been retired.
@@ -173,7 +269,7 @@ impl<A: All2All> Votor<A> {
         }
     }
 
-    async fn handle_pool_event(&mut self, event: PoolEvent) {
+    fn handle_pool_event(&mut self, event: PoolEvent, now: Instant) {
         let slot = event.slot();
         if self.should_ignore_pool_event(&event) {
             trace!("ignoring pool event for old or retired slot {slot}");
@@ -188,49 +284,49 @@ impl<A: All2All> Votor<A> {
                     parent_hash.short_hex()
                 );
                 self.state_mut(slot).parents_ready.insert(parent);
-                self.check_pending_blocks().await;
-                self.set_timeouts(slot);
+                self.check_pending_blocks();
+                self.set_timeouts(slot, now);
             }
             PoolEvent::SafeToNotar((slot, hash)) => {
                 debug!("voted notar-fallback in slot {slot}");
                 let vote =
                     Vote::new_notar_fallback(slot, hash, &self.voting_key, self.validator_index);
-                self.broadcast(vote).await;
-                self.try_skip_window(slot).await;
+                self.enqueue_broadcast(vote);
+                self.try_skip_window(slot);
                 self.state_mut(slot).bad_window = true;
             }
             PoolEvent::SafeToSkip(slot) => {
                 debug!("voted skip-fallback in slot {slot}");
                 let vote = Vote::new_skip_fallback(slot, &self.voting_key, self.validator_index);
-                self.broadcast(vote).await;
-                self.try_skip_window(slot).await;
+                self.enqueue_broadcast(vote);
+                self.try_skip_window(slot);
                 self.state_mut(slot).bad_window = true;
             }
-            PoolEvent::CertCreated(cert) => self.handle_cert_created(cert).await,
+            PoolEvent::CertCreated(cert) => self.handle_cert_created(cert, now),
             PoolEvent::Standstill(_, certs, votes) => {
                 for cert in certs {
-                    self.broadcast(cert).await;
+                    self.enqueue_broadcast(cert);
                 }
                 for vote in votes {
-                    self.broadcast(vote).await;
+                    self.enqueue_broadcast(vote);
                 }
             }
         }
     }
 
     /// Updates state based on a newly created certificate and re-broadcasts it.
-    async fn handle_cert_created(&mut self, cert: Cert) {
+    fn handle_cert_created(&mut self, cert: Cert, now: Instant) {
         match &cert {
             Cert::Notar(notar_cert) => {
                 let hash = notar_cert.block_hash();
                 // need to mark notarized BEFORE trying finalization
                 self.state_mut(cert.slot()).block_notarized = Some(hash.clone());
-                self.try_final(cert.slot(), hash).await;
+                self.try_final(cert.slot(), hash);
             }
             Cert::Final(_) | Cert::FastFinal(_) => {
                 // makes sure we eventually vote skip for these slots,
                 // even if we never issued a ParentReady for this window
-                self.set_timeouts(cert.slot().first_slot_in_window());
+                self.set_timeouts(cert.slot().first_slot_in_window(), now);
 
                 // Votor can already be pruned upon regular final cert,
                 // whereas Pool would only be pruned upon actual finalization,
@@ -241,28 +337,24 @@ impl<A: All2All> Votor<A> {
             Cert::Skip(_) | Cert::NotarFallback(_) => {}
         }
 
-        self.broadcast(cert).await;
+        self.enqueue_broadcast(cert);
     }
 
-    /// Broadcasts a consensus message to all other nodes on a best-effort basis.
+    /// Queues a consensus message for broadcast by the driving task.
     ///
-    /// A failure of the underlying [`All2All`] network is logged and otherwise
-    /// ignored. Broadcasts are best-effort by contract, and a transient network
-    /// error must not bring down the voting loop, which has to keep running to
-    /// preserve liveness. A dropped vote/cert is re-broadcast later via standstill
-    /// recovery, so a one-off failure self-heals.
-    ///
-    /// NOTE: a *persistent* failure here (e.g. a misconfigured firewall or a full
-    /// partition) means this node silently stops contributing to consensus while
-    /// only logging. Once there is a metrics system, this should also bump a
-    /// failure counter so persistent failures become alertable.
-    async fn broadcast(&self, msg: impl Into<ConsensusMessage>) {
-        if let Err(err) = self.all2all.broadcast(&msg.into()).await {
-            warn!("failed to broadcast consensus message: {err}");
-        }
+    /// Buffered rather than sent so this state machine stays free of I/O; the
+    /// [`Votor`] task drains the queue via [`Self::take_broadcasts`] and performs
+    /// the actual (best-effort) [`All2All`] broadcast.
+    fn enqueue_broadcast(&mut self, msg: impl Into<ConsensusMessage>) {
+        self.broadcasts.push(msg.into());
     }
 
-    async fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
+    /// Drains and returns the consensus messages queued for broadcast.
+    pub(crate) fn take_broadcasts(&mut self) -> Vec<ConsensusMessage> {
+        std::mem::take(&mut self.broadcasts)
+    }
+
+    fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
         let slot = event.slot();
         if slot <= self.highest_final_cert_slot || self.is_retired(slot) {
             trace!("ignoring blockstore event for old or retired slot {slot}");
@@ -275,7 +367,7 @@ impl<A: All2All> Votor<A> {
             }
             BlockstoreEvent::InvalidBlock(slot) => {
                 warn!("invalid block from leader for slot {slot}, skipping window");
-                self.try_skip_window(slot).await;
+                self.try_skip_window(slot);
             }
             BlockstoreEvent::Block { slot, block_info } => {
                 if self.has_voted(slot) {
@@ -283,8 +375,8 @@ impl<A: All2All> Votor<A> {
                     warn!("not voting for block {h} in slot {slot}, already voted");
                     return;
                 }
-                if self.try_notar(slot, block_info.clone()).await {
-                    self.check_pending_blocks().await;
+                if self.try_notar(slot, block_info.clone()) {
+                    self.check_pending_blocks();
                 } else {
                     self.state_mut(slot).pending_block = Some(block_info);
                 }
@@ -292,7 +384,7 @@ impl<A: All2All> Votor<A> {
         }
     }
 
-    async fn handle_timeout_event(&mut self, event: VotorTimeout) {
+    fn handle_timeout_event(&mut self, event: VotorTimeout) {
         let slot = event.slot();
         if slot <= self.highest_final_cert_slot || self.is_retired(slot) {
             trace!("ignoring timeout for old or retired slot {slot}");
@@ -303,50 +395,71 @@ impl<A: All2All> Votor<A> {
             VotorTimeout::Timeout(slot) => {
                 trace!("timeout for slot {slot}");
                 if !self.has_voted(slot) {
-                    self.try_skip_window(slot).await;
+                    self.try_skip_window(slot);
                 }
             }
             VotorTimeout::TimeoutCrashedLeader(slot) => {
                 trace!("timeout (crashed leader) for slot {slot}");
                 if !self.received_shred(slot) && !self.has_voted(slot) {
-                    self.try_skip_window(slot).await;
+                    self.try_skip_window(slot);
                 }
             }
         }
     }
 
-    /// Sets timeouts for the leader window starting at the given `slot`.
+    /// Fires all timeouts that are due at `now`.
+    pub(crate) fn handle_due_timeouts(&mut self, now: Instant) {
+        while let Some(Reverse((deadline, _))) = self.timeouts.peek() {
+            if *deadline > now {
+                break;
+            }
+            let Reverse((_, event)) = self.timeouts.pop().expect("peeked entry exists");
+            self.handle_timeout_event(event);
+        }
+    }
+
+    /// Returns the earliest pending timeout deadline, if any.
+    pub(crate) fn next_timeout(&self) -> Option<Instant> {
+        self.timeouts.peek().map(|Reverse((deadline, _))| *deadline)
+    }
+
+    /// Schedules timeouts for the leader window starting at the given `slot`.
+    ///
+    /// Deadlines are computed relative to `now`, mirroring the schedule the
+    /// leader is expected to keep: the crashed-leader timeout fires after
+    /// `DELTA_TIMEOUT + DELTA_FIRST_SLICE`, then one timeout per slot in the
+    /// window, `DELTA_BLOCK` apart. They fire via [`Self::handle_due_timeouts`].
     ///
     /// # Panics
     ///
     /// Panics if `slot` is not the first slot of a window.
-    fn set_timeouts(&self, slot: Slot) {
+    fn set_timeouts(&mut self, slot: Slot, now: Instant) {
         assert!(slot.is_start_of_window());
 
         trace!(
             "setting timeouts for slots {slot}-{}",
             slot.last_slot_in_window()
         );
-        let sender = self.timeout_sender.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(DELTA_TIMEOUT + DELTA_FIRST_SLICE).await;
-            // HACK: ignoring errors to prevent panic when shutting down votor
-            let _ = sender.send(VotorTimeout::TimeoutCrashedLeader(slot)).await;
-            for s in slot.slots_in_window() {
-                if s.is_start_of_window() {
-                    tokio::time::sleep(DELTA_BLOCK.saturating_sub(DELTA_FIRST_SLICE)).await;
-                } else {
-                    tokio::time::sleep(DELTA_BLOCK).await;
-                }
-                let _ = sender.send(VotorTimeout::Timeout(s)).await;
-            }
-        });
+        let mut deadline = now + DELTA_TIMEOUT + DELTA_FIRST_SLICE;
+        self.timeouts.push(Reverse((
+            deadline,
+            VotorTimeout::TimeoutCrashedLeader(slot),
+        )));
+        for s in slot.slots_in_window() {
+            deadline += if s.is_start_of_window() {
+                DELTA_BLOCK.saturating_sub(DELTA_FIRST_SLICE)
+            } else {
+                DELTA_BLOCK
+            };
+            self.timeouts
+                .push(Reverse((deadline, VotorTimeout::Timeout(s))));
+        }
     }
 
     /// Sends a notarization vote for the given block if the conditions are met.
     ///
     /// Returns `true` iff we decided to send a notarization vote for the block.
-    async fn try_notar(&mut self, slot: Slot, block_info: BlockInfo) -> bool {
+    fn try_notar(&mut self, slot: Slot, block_info: BlockInfo) -> bool {
         assert!(slot >= self.first_unpruned_slot());
         if self.has_voted(slot) {
             return false;
@@ -377,17 +490,17 @@ impl<A: All2All> Votor<A> {
         }
         debug!("voted notar for slot {slot}");
         let vote = Vote::new_notar(slot, hash.clone(), &self.voting_key, self.validator_index);
-        self.broadcast(vote).await;
+        self.enqueue_broadcast(vote);
         let state = self.state_mut(slot);
         state.voted = true;
         state.voted_notar = Some(hash.clone());
         state.pending_block = None;
-        self.try_final(slot, &hash).await;
+        self.try_final(slot, &hash);
         true
     }
 
     /// Sends a finalization vote for the given block if the conditions are met.
-    async fn try_final(&mut self, slot: Slot, hash: &BlockHash) {
+    fn try_final(&mut self, slot: Slot, hash: &BlockHash) {
         assert!(slot >= self.first_unpruned_slot());
         let state = self.slots.get(&slot);
         let notarized = state.and_then(|s| s.block_notarized.as_ref()) == Some(hash);
@@ -395,13 +508,13 @@ impl<A: All2All> Votor<A> {
         let not_bad = !state.is_some_and(|s| s.bad_window);
         if notarized && voted_notar && not_bad {
             let vote = Vote::new_final(slot, &self.voting_key, self.validator_index);
-            self.broadcast(vote).await;
+            self.enqueue_broadcast(vote);
             self.state_mut(slot).retired = true;
         }
     }
 
     /// Sends skip votes for all unvoted slots in the window that `slot` belongs to.
-    async fn try_skip_window(&mut self, slot: Slot) {
+    fn try_skip_window(&mut self, slot: Slot) {
         assert!(slot >= self.first_unpruned_slot());
         trace!("try skip window of slot {slot}");
         for s in slot.slots_in_window() {
@@ -412,13 +525,13 @@ impl<A: All2All> Votor<A> {
             state.voted = true;
             state.bad_window = true;
             let vote = Vote::new_skip(s, &self.voting_key, self.validator_index);
-            self.broadcast(vote).await;
+            self.enqueue_broadcast(vote);
             debug!("voted skip for slot {s}");
         }
     }
 
     /// Checks if we can vote on any of the pending blocks by now.
-    async fn check_pending_blocks(&mut self) {
+    fn check_pending_blocks(&mut self) {
         let slots = self
             .slots
             .iter()
@@ -427,7 +540,7 @@ impl<A: All2All> Votor<A> {
             .collect::<Vec<_>>();
         for slot in slots {
             if let Some(block_info) = self.slots.get(&slot).and_then(|s| s.pending_block.clone()) {
-                self.try_notar(slot, block_info).await;
+                self.try_notar(slot, block_info);
             }
         }
     }
@@ -441,8 +554,10 @@ impl<A: All2All> Votor<A> {
     }
 }
 
-/// Internal timeout events generated by [`Votor`] itself.
-#[derive(Debug)]
+/// Internal timeout events generated by [`VotorState`] itself.
+///
+/// Ordered so timeouts can serve as tie-breakers in the deadline heap.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum VotorTimeout {
     /// Regular timeout for the given slot has fired.
     Timeout(Slot),
@@ -845,7 +960,7 @@ mod tests {
             let event = BlockstoreEvent::FirstShred(Slot::new(i));
             votor.handle_blockstore_event(event).await;
         }
-        assert!((0..=highest.inner()).all(|i| votor.slots.contains_key(&Slot::new(i))));
+        assert!((0..=highest.inner()).all(|i| votor.state.slots.contains_key(&Slot::new(i))));
 
         // finalizing a mid-window slot should drop only the slots before its window
         let Vote::Final(final_vote) =
@@ -856,19 +971,19 @@ mod tests {
         let cert = Cert::Final(FinalCert::new(&[final_vote], ctx.epoch_info.validators()));
         let event = PoolEvent::CertCreated(cert);
         votor.handle_pool_event(event).await;
-        assert_eq!(votor.highest_final_cert_slot, finalized);
+        assert_eq!(votor.state.highest_final_cert_slot, finalized);
 
         // the whole finalized window is kept
-        assert!(votor.slots.keys().all(|s| *s >= window_start));
+        assert!(votor.state.slots.keys().all(|s| *s >= window_start));
         for slot in window_start.slots_in_window() {
             assert!(
-                votor.slots.contains_key(&slot),
+                votor.state.slots.contains_key(&slot),
                 "slot {slot} in finalized window should be retained",
             );
         }
 
         // earlier windows are dropped
-        assert!(!votor.slots.contains_key(&Slot::genesis()));
-        assert!(!votor.slots.contains_key(&window_start.prev()));
+        assert!(!votor.state.slots.contains_key(&Slot::genesis()));
+        assert!(!votor.state.slots.contains_key(&window_start.prev()));
     }
 }

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -195,24 +195,24 @@ impl<A: All2All> Votor<A> {
                 debug!("voted notar-fallback in slot {slot}");
                 let vote =
                     Vote::new_notar_fallback(slot, hash, &self.voting_key, self.validator_index);
-                self.broadcast(vote.into()).await;
+                self.broadcast(vote).await;
                 self.try_skip_window(slot).await;
                 self.state_mut(slot).bad_window = true;
             }
             PoolEvent::SafeToSkip(slot) => {
                 debug!("voted skip-fallback in slot {slot}");
                 let vote = Vote::new_skip_fallback(slot, &self.voting_key, self.validator_index);
-                self.broadcast(vote.into()).await;
+                self.broadcast(vote).await;
                 self.try_skip_window(slot).await;
                 self.state_mut(slot).bad_window = true;
             }
             PoolEvent::CertCreated(cert) => self.handle_cert_created(cert).await,
             PoolEvent::Standstill(_, certs, votes) => {
                 for cert in certs {
-                    self.broadcast(cert.into()).await;
+                    self.broadcast(cert).await;
                 }
                 for vote in votes {
-                    self.broadcast(vote.into()).await;
+                    self.broadcast(vote).await;
                 }
             }
         }
@@ -241,17 +241,25 @@ impl<A: All2All> Votor<A> {
             Cert::Skip(_) | Cert::NotarFallback(_) => {}
         }
 
-        self.broadcast(ConsensusMessage::from(cert)).await;
+        self.broadcast(cert).await;
     }
 
-    /// Broadcasts a consensus message to all validators.
+    /// Broadcasts a consensus message to all other nodes on a best-effort basis.
     ///
-    /// Panics on I/O failure: broadcasting votes and certs is liveness-critical.
-    async fn broadcast(&self, msg: ConsensusMessage) {
-        self.all2all
-            .broadcast(&msg)
-            .await
-            .expect("vote/cert broadcast is liveness-critical; a network failure here is fatal");
+    /// A failure of the underlying [`All2All`] network is logged and otherwise
+    /// ignored. Broadcasts are best-effort by contract, and a transient network
+    /// error must not bring down the voting loop, which has to keep running to
+    /// preserve liveness. A dropped vote/cert is re-broadcast later via standstill
+    /// recovery, so a one-off failure self-heals.
+    ///
+    /// NOTE: a *persistent* failure here (e.g. a misconfigured firewall or a full
+    /// partition) means this node silently stops contributing to consensus while
+    /// only logging. Once there is a metrics system, this should also bump a
+    /// failure counter so persistent failures become alertable.
+    async fn broadcast(&self, msg: impl Into<ConsensusMessage>) {
+        if let Err(err) = self.all2all.broadcast(&msg.into()).await {
+            warn!("failed to broadcast consensus message: {err}");
+        }
     }
 
     async fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
@@ -369,7 +377,7 @@ impl<A: All2All> Votor<A> {
         }
         debug!("voted notar for slot {slot}");
         let vote = Vote::new_notar(slot, hash.clone(), &self.voting_key, self.validator_index);
-        self.broadcast(vote.into()).await;
+        self.broadcast(vote).await;
         let state = self.state_mut(slot);
         state.voted = true;
         state.voted_notar = Some(hash.clone());
@@ -387,7 +395,7 @@ impl<A: All2All> Votor<A> {
         let not_bad = !state.is_some_and(|s| s.bad_window);
         if notarized && voted_notar && not_bad {
             let vote = Vote::new_final(slot, &self.voting_key, self.validator_index);
-            self.broadcast(vote.into()).await;
+            self.broadcast(vote).await;
             self.state_mut(slot).retired = true;
         }
     }
@@ -404,7 +412,7 @@ impl<A: All2All> Votor<A> {
             state.voted = true;
             state.bad_window = true;
             let vote = Vote::new_skip(s, &self.voting_key, self.validator_index);
-            self.broadcast(vote.into()).await;
+            self.broadcast(vote).await;
             debug!("voted skip for slot {s}");
         }
     }
@@ -476,6 +484,7 @@ struct SlotState {
 mod tests {
     use std::time::Duration;
 
+    use async_trait::async_trait;
     use tokio::sync::mpsc;
 
     use super::*;
@@ -490,6 +499,21 @@ mod tests {
     use crate::types::SLOTS_PER_WINDOW;
 
     type A2A = TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>;
+
+    /// An [`All2All`] whose `broadcast` always fails, to exercise Votor's
+    /// best-effort error handling. `receive` never resolves.
+    struct FailingAll2All;
+
+    #[async_trait]
+    impl All2All for FailingAll2All {
+        async fn broadcast(&self, _msg: &ConsensusMessage) -> std::io::Result<()> {
+            Err(std::io::Error::other("simulated broadcast failure"))
+        }
+
+        async fn receive(&self) -> std::io::Result<ConsensusMessage> {
+            std::future::pending().await
+        }
+    }
 
     struct TestContext {
         other_a2a: A2A,
@@ -563,6 +587,31 @@ mod tests {
             votor.voting_loop().await;
         });
         ctx
+    }
+
+    /// A failing network broadcast must be logged and swallowed, never panic the
+    /// voting loop (which has to keep running to preserve liveness).
+    #[tokio::test]
+    async fn broadcast_failure_does_not_panic() {
+        let (sks, _epoch_info) = generate_validators(2);
+        let (_pool_tx, pool_rx) = mpsc::channel(100);
+        let (_blockstore_tx, blockstore_rx) = mpsc::channel(100);
+        let mut votor = Votor::new(
+            ValidatorIndex::new(0),
+            sks[0].clone(),
+            pool_rx,
+            blockstore_rx,
+            Arc::new(FailingAll2All),
+        );
+
+        // `SafeToSkip` makes Votor broadcast a skip-fallback vote (and, via
+        // `try_skip_window`, skip votes for the window). All broadcasts fail here;
+        // the handler must still return normally rather than unwrap a network error.
+        // Use a non-genesis slot: the genesis slot starts out retired and would be
+        // ignored before any broadcast.
+        votor
+            .handle_pool_event(PoolEvent::SafeToSkip(Slot::new(1)))
+            .await;
     }
 
     #[tokio::test]

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -3,25 +3,23 @@
 
 //! Main voting logic for the consensus protocol.
 //!
-//! Besides [`super::Pool`], [`VotorState`] is the other main internal component of Alpenglow.
-//! It handles the main voting decisions for the consensus protocol.
-//! As input it receives events from [`super::Pool`] and [`super::Blockstore`],
-//! as well as its own internal timeout events.
+//! Besides [`super::PoolImpl`], [`VotorState`] is the other main internal
+//! component of Alpenglow. It handles the main voting decisions for the
+//! consensus protocol. As input it receives events from [`super::PoolImpl`]
+//! and [`super::Blockstore`], as well as its own internal timeout events.
 //! It keeps its own internal state for each slot based on previous events and votes.
 //!
 //! [`VotorState`] is a pure, synchronous state machine: it performs no I/O,
 //! tracks timeouts as deadlines instead of sleeping, and queues the votes it
-//! decides to cast in an internal outbox. The [`Votor`] task wraps it, feeding
-//! it events from its channels and firing due timeouts, and broadcasts the
-//! queued votes over an [`All2All`] instance.
+//! decides to cast in an internal outbox. It is driven as part of
+//! [`super::core::ConsensusCore`], whose driver task fires due timeouts and
+//! broadcasts the queued votes over the wire.
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
-use std::sync::Arc;
 use std::time::Instant;
 
 use log::{debug, trace, warn};
-use tokio::sync::mpsc::Receiver;
 
 use super::blockstore::{BlockInfo, BlockstoreEvent};
 use super::pool::PoolEvent;
@@ -29,123 +27,7 @@ use super::{Cert, ConsensusMessage, DELTA_BLOCK, DELTA_TIMEOUT, Vote};
 use crate::consensus::DELTA_FIRST_SLICE;
 use crate::crypto::aggsig::SecretKey;
 use crate::crypto::merkle::{BlockHash, GENESIS_BLOCK_HASH};
-use crate::{All2All, BlockId, Slot, ValidatorIndex};
-
-/// Votor task: drives the `VotorState` state machine.
-///
-/// Feeds `VotorState` the events received from [`super::Pool`] and
-/// [`super::Blockstore`] as well as its due timeouts, then broadcasts the
-/// votes and certificates it queued via [`All2All`].
-pub struct Votor<A: All2All> {
-    /// The actual voting state machine.
-    state: VotorState,
-
-    /// Channel for receiving events from Pool.
-    pool_receiver: Receiver<PoolEvent>,
-    /// Channel for receiving events from Blockstore.
-    blockstore_receiver: Receiver<BlockstoreEvent>,
-    /// [`All2All`] instance used to broadcast votes.
-    all2all: Arc<A>,
-}
-
-impl<A: All2All> Votor<A> {
-    /// Creates a new Votor instance with empty state.
-    ///
-    /// On `pool_receiver` and `blockstore_receiver`, it receives events from
-    /// [`super::Pool`] and [`super::Blockstore`] respectively.
-    /// Informed by these events Votor updates its state and generates votes.
-    /// Votes are signed with `voting_key` and broadcast using `all2all`.
-    pub fn new(
-        validator_index: ValidatorIndex,
-        voting_key: SecretKey,
-        pool_receiver: Receiver<PoolEvent>,
-        blockstore_receiver: Receiver<BlockstoreEvent>,
-        all2all: Arc<A>,
-    ) -> Self {
-        Self {
-            state: VotorState::new(validator_index, voting_key, Instant::now()),
-            pool_receiver,
-            blockstore_receiver,
-            all2all,
-        }
-    }
-
-    /// Handles the voting (leader and non-leader) side of consensus protocol.
-    ///
-    /// Checks consensus conditions and broadcasts new votes.
-    /// Returns once either input channel is closed (node shutdown).
-    #[fastrace::trace]
-    pub async fn voting_loop(&mut self) {
-        loop {
-            tokio::select! {
-                event = self.pool_receiver.recv() => match event {
-                    Some(event) => self.handle_pool_event(event).await,
-                    None => break,
-                },
-                event = self.blockstore_receiver.recv() => match event {
-                    Some(event) => self.handle_blockstore_event(event).await,
-                    None => break,
-                },
-                () = sleep_until_next(self.state.next_timeout()) => {
-                    self.handle_due_timeouts().await;
-                }
-            }
-        }
-    }
-
-    /// Feeds a pool event to the state machine and broadcasts resulting votes.
-    async fn handle_pool_event(&mut self, event: PoolEvent) {
-        self.state.handle_pool_event(event, Instant::now());
-        self.flush_broadcasts().await;
-    }
-
-    /// Feeds a blockstore event to the state machine and broadcasts resulting votes.
-    async fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
-        self.state.handle_blockstore_event(event);
-        self.flush_broadcasts().await;
-    }
-
-    /// Feeds a timeout event to the state machine and broadcasts resulting votes.
-    #[cfg(test)]
-    async fn handle_timeout_event(&mut self, event: VotorTimeout) {
-        self.state.handle_timeout_event(event);
-        self.flush_broadcasts().await;
-    }
-
-    /// Fires all due timeouts on the state machine and broadcasts resulting votes.
-    async fn handle_due_timeouts(&mut self) {
-        self.state.handle_due_timeouts(Instant::now());
-        self.flush_broadcasts().await;
-    }
-
-    /// Broadcasts all queued consensus messages on a best-effort basis.
-    ///
-    /// A failure of the underlying [`All2All`] network is logged and otherwise
-    /// ignored. Broadcasts are best-effort by contract, and a transient network
-    /// error must not bring down the voting loop, which has to keep running to
-    /// preserve liveness. A dropped vote/cert is re-broadcast later via standstill
-    /// recovery, so a one-off failure self-heals.
-    ///
-    /// NOTE: a *persistent* failure here (e.g. a misconfigured firewall or a full
-    /// partition) means this node silently stops contributing to consensus while
-    /// only logging. Once there is a metrics system, this should also bump a
-    /// failure counter so persistent failures become alertable.
-    async fn flush_broadcasts(&mut self) {
-        for msg in self.state.take_broadcasts() {
-            if let Err(err) = self.all2all.broadcast(&msg).await {
-                warn!("failed to broadcast consensus message: {err}");
-            }
-        }
-    }
-}
-
-/// Sleeps until the given `deadline`, or forever if there is none.
-async fn sleep_until_next(deadline: Option<Instant>) {
-    match deadline {
-        Some(deadline) => tokio::time::sleep_until(deadline.into()).await,
-        None => std::future::pending().await,
-    }
-}
+use crate::{BlockId, Slot, ValidatorIndex};
 
 /// Votor's state machine: implements the decision process of which votes to cast.
 ///
@@ -160,7 +42,7 @@ pub(crate) struct VotorState {
     slots: BTreeMap<Slot, SlotState>,
     /// Highest slot for which we have seen a (slow) final or fast-final cert.
     ///
-    /// This is *not* equivalent to e.g. [`super::Pool::finalized_slot`],
+    /// This is *not* equivalent to e.g. [`super::PoolImpl::finalized_slot`],
     /// because we may have seen a (slow) final cert without a matching notar.
     /// We only use it to decide when our own vote for a slot no longer matters,
     /// at which point the per-slot state for earlier leader windows is pruned.
@@ -250,7 +132,7 @@ impl VotorState {
     /// However, this comes with exceptions based on the event type:
     /// - [`PoolEvent::Standstill`] is never ignored.
     ///   It carries a recovery bundle spanning multiple slots.
-    ///   See also [`super::Pool::recover_from_standstill`] for more info.
+    ///   See also [`super::PoolImpl::recover_from_standstill`] for more info.
     ///   Simply gating based on [`Self::highest_final_cert_slot`] would not be correct.
     ///   It can run ahead of Pool's finalized slot (final cert vs. final + notar).
     ///   We could drop a bundle that Pool emitted precisely because it is stuck.
@@ -269,7 +151,7 @@ impl VotorState {
         }
     }
 
-    fn handle_pool_event(&mut self, event: PoolEvent, now: Instant) {
+    pub(crate) fn handle_pool_event(&mut self, event: PoolEvent, now: Instant) {
         let slot = event.slot();
         if self.should_ignore_pool_event(&event) {
             trace!("ignoring pool event for old or retired slot {slot}");
@@ -343,8 +225,8 @@ impl VotorState {
     /// Queues a consensus message for broadcast by the driving task.
     ///
     /// Buffered rather than sent so this state machine stays free of I/O; the
-    /// [`Votor`] task drains the queue via [`Self::take_broadcasts`] and performs
-    /// the actual (best-effort) [`All2All`] broadcast.
+    /// driver drains the queue via [`Self::take_broadcasts`] and performs the
+    /// actual (best-effort) broadcast.
     fn enqueue_broadcast(&mut self, msg: impl Into<ConsensusMessage>) {
         self.broadcasts.push(msg.into());
     }
@@ -354,7 +236,7 @@ impl VotorState {
         std::mem::take(&mut self.broadcasts)
     }
 
-    fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
+    pub(crate) fn handle_blockstore_event(&mut self, event: BlockstoreEvent) {
         let slot = event.slot();
         if slot <= self.highest_final_cert_slot || self.is_retired(slot) {
             trace!("ignoring blockstore event for old or retired slot {slot}");
@@ -574,7 +456,7 @@ impl VotorTimeout {
     }
 }
 
-/// Per-slot voting state tracked by [`Votor`].
+/// Per-slot voting state tracked by [`VotorState`].
 #[derive(Default)]
 struct SlotState {
     /// Whether we already voted notar or skip for this slot.
@@ -597,249 +479,157 @@ struct SlotState {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
-    use async_trait::async_trait;
-    use tokio::sync::mpsc;
-
     use super::*;
-    use crate::all2all::TrivialAll2All;
+    use crate::consensus::EpochInfo;
     use crate::consensus::cert::{FinalCert, NotarCert};
-    use crate::consensus::{ConsensusMessage, EpochInfo};
     use crate::crypto::Hash;
-    use crate::network::SimulatedNetwork;
-    use crate::test_utils::{
-        generate_all2all_instances, generate_validators, genesis_block_id, random_block_id,
-    };
+    use crate::test_utils::{generate_validators, genesis_block_id, random_block_id};
     use crate::types::SLOTS_PER_WINDOW;
 
-    type A2A = TrivialAll2All<SimulatedNetwork<ConsensusMessage, ConsensusMessage>>;
-
-    /// An [`All2All`] whose `broadcast` always fails, to exercise Votor's
-    /// best-effort error handling. `receive` never resolves.
-    struct FailingAll2All;
-
-    #[async_trait]
-    impl All2All for FailingAll2All {
-        async fn broadcast(&self, _msg: &ConsensusMessage) -> std::io::Result<()> {
-            Err(std::io::Error::other("simulated broadcast failure"))
-        }
-
-        async fn receive(&self) -> std::io::Result<ConsensusMessage> {
-            std::future::pending().await
-        }
-    }
-
     struct TestContext {
-        other_a2a: A2A,
-        pool_tx: mpsc::Sender<PoolEvent>,
-        blockstore_tx: mpsc::Sender<BlockstoreEvent>,
+        state: VotorState,
+        /// The instant the state machine was constructed at; deadlines for the
+        /// genesis window are relative to this.
+        t0: Instant,
         epoch_info: EpochInfo,
         sks: Vec<SecretKey>,
     }
 
+    fn setup() -> TestContext {
+        let (sks, epoch_info) = generate_validators(2);
+        let t0 = Instant::now();
+        let state = VotorState::new(ValidatorIndex::new(0), sks[0].clone(), t0);
+        TestContext {
+            state,
+            t0,
+            epoch_info,
+            sks,
+        }
+    }
+
+    /// Drains the queued broadcasts and returns just the votes among them.
+    fn drain_votes(state: &mut VotorState) -> Vec<Vote> {
+        state
+            .take_broadcasts()
+            .into_iter()
+            .filter_map(|msg| match msg {
+                ConsensusMessage::Vote(v) => Some(v),
+                ConsensusMessage::Cert(_) => None,
+            })
+            .collect()
+    }
+
     impl TestContext {
-        /// Notifies the votor of a new block and waits for the resulting notar vote.
-        async fn send_block_and_expect_notar(&self, slot: Slot, parent: (Slot, BlockHash)) -> Vote {
-            self.blockstore_tx
-                .send(BlockstoreEvent::FirstShred(slot))
-                .await
-                .unwrap();
+        /// An instant by which every timeout of the genesis window has expired.
+        fn after_genesis_window(&self) -> Instant {
+            self.t0
+                + DELTA_TIMEOUT
+                + DELTA_FIRST_SLICE
+                + DELTA_BLOCK * u32::try_from(SLOTS_PER_WINDOW).unwrap()
+        }
+
+        /// Feeds a reconstructed block and returns the resulting notar vote.
+        fn send_block_and_expect_notar(&mut self, slot: Slot, parent: BlockId) -> Vote {
+            self.state
+                .handle_blockstore_event(BlockstoreEvent::FirstShred(slot));
             let block_info = BlockInfo {
                 hash: Hash::random_for_test().into(),
                 parent,
             };
-            self.blockstore_tx
-                .send(BlockstoreEvent::Block { slot, block_info })
-                .await
-                .unwrap();
-            match self.other_a2a.receive().await.unwrap() {
-                ConsensusMessage::Vote(v) => {
-                    assert!(matches!(v, Vote::Notar(_)));
-                    assert_eq!(v.slot(), slot);
-                    v
-                }
-                m => panic!("other msg: {m:?}"),
-            }
+            self.state
+                .handle_blockstore_event(BlockstoreEvent::Block { slot, block_info });
+            let votes = drain_votes(&mut self.state);
+            assert_eq!(votes.len(), 1, "expected exactly one vote, got {votes:?}");
+            let vote = votes.into_iter().next().unwrap();
+            assert!(matches!(vote, Vote::Notar(_)));
+            assert_eq!(vote.slot(), slot);
+            vote
         }
     }
 
-    /// Creates a fresh fully wired-up [`Votor`] instance.
-    ///
-    /// The returned votor is not running its event loop.
-    /// Callers either run its [`Votor::voting_loop`] (see [`start_votor`])
-    /// or drive its handlers manually.
-    async fn build_votor() -> (Votor<A2A>, TestContext) {
-        let (sks, epoch_info) = generate_validators(2);
-        let mut a2a = generate_all2all_instances(epoch_info.validators().to_vec()).await;
-        let (pool_tx, pool_rx) = mpsc::channel(100);
-        let (blockstore_tx, blockstore_rx) = mpsc::channel(100);
-        let other_a2a = a2a.pop().unwrap();
-        let votor_a2a = a2a.pop().unwrap();
-        let votor = Votor::new(
-            ValidatorIndex::new(0),
-            sks[0].clone(),
-            pool_rx,
-            blockstore_rx,
-            Arc::new(votor_a2a),
-        );
-        let ctx = TestContext {
-            other_a2a,
-            pool_tx,
-            blockstore_tx,
-            epoch_info,
-            sks,
-        };
-        (votor, ctx)
-    }
+    /// Once all genesis-window deadlines expire, every non-genesis slot in the
+    /// window gets a skip vote, in order.
+    #[test]
+    fn timeouts() {
+        let mut ctx = setup();
+        let deadline = ctx.state.next_timeout().expect("timeouts scheduled");
+        assert!(deadline > ctx.t0);
 
-    /// Builds a votor and spawns its [`Votor::voting_loop`].
-    ///
-    /// Returns the votor instance and the test context.
-    async fn start_votor() -> TestContext {
-        let (mut votor, ctx) = build_votor().await;
-        tokio::spawn(async move {
-            votor.voting_loop().await;
-        });
-        ctx
-    }
+        ctx.state.handle_due_timeouts(ctx.after_genesis_window());
+        let votes = drain_votes(&mut ctx.state);
 
-    /// A failing network broadcast must be logged and swallowed, never panic the
-    /// voting loop (which has to keep running to preserve liveness).
-    #[tokio::test]
-    async fn broadcast_failure_does_not_panic() {
-        let (sks, _epoch_info) = generate_validators(2);
-        let (_pool_tx, pool_rx) = mpsc::channel(100);
-        let (_blockstore_tx, blockstore_rx) = mpsc::channel(100);
-        let mut votor = Votor::new(
-            ValidatorIndex::new(0),
-            sks[0].clone(),
-            pool_rx,
-            blockstore_rx,
-            Arc::new(FailingAll2All),
-        );
-
-        // `SafeToSkip` makes Votor broadcast a skip-fallback vote (and, via
-        // `try_skip_window`, skip votes for the window). All broadcasts fail here;
-        // the handler must still return normally rather than unwrap a network error.
-        // Use a non-genesis slot: the genesis slot starts out retired and would be
-        // ignored before any broadcast.
-        votor
-            .handle_pool_event(PoolEvent::SafeToSkip(Slot::new(1)))
-            .await;
-    }
-
-    #[tokio::test]
-    async fn timeouts() {
-        let ctx = start_votor().await;
-
-        // should vote skip for all slots
-        let mut skipped_slots = Vec::new();
+        // should vote skip for all slots except (retired) genesis
         let mut slots = Slot::genesis().slots_in_window().collect::<Vec<_>>();
         slots.remove(0);
-        for _ in slots.clone() {
-            if let Ok(msg) = ctx.other_a2a.receive().await {
-                match msg {
-                    ConsensusMessage::Vote(v) => {
-                        assert!(matches!(v, Vote::Skip(_)));
-                        skipped_slots.push(v.slot());
-                    }
-                    m => panic!("other msg: {m:?}"),
-                }
-            }
-        }
+        assert!(votes.iter().all(|v| matches!(v, Vote::Skip(_))));
+        let skipped_slots = votes.iter().map(Vote::slot).collect::<Vec<_>>();
         assert_eq!(skipped_slots, slots);
     }
 
-    #[tokio::test]
-    async fn notar_and_final() {
-        let ctx = start_votor().await;
+    #[test]
+    fn notar_and_final() {
+        let mut ctx = setup();
         let slot = Slot::genesis().next();
-        let parent = genesis_block_id();
 
         // vote notar after seeing block
-        let vote = ctx.send_block_and_expect_notar(slot, parent).await;
+        let vote = ctx.send_block_and_expect_notar(slot, genesis_block_id());
 
         // vote finalize after seeing branch-certified
         let Vote::Notar(notar_vote) = vote else {
             unreachable!()
         };
         let cert = Cert::Notar(NotarCert::new(&[notar_vote], ctx.epoch_info.validators()));
-        ctx.pool_tx
-            .send(PoolEvent::CertCreated(cert))
-            .await
-            .unwrap();
-        match ctx.other_a2a.receive().await.unwrap() {
-            ConsensusMessage::Vote(v) => {
-                assert!(matches!(v, Vote::Final(_)));
-                assert_eq!(v.slot(), slot);
-            }
-            m => panic!("other msg: {m:?}"),
-        }
+        ctx.state
+            .handle_pool_event(PoolEvent::CertCreated(cert), ctx.t0);
+        let votes = drain_votes(&mut ctx.state);
+        assert!(
+            votes
+                .iter()
+                .any(|v| matches!(v, Vote::Final(_)) && v.slot() == slot),
+            "expected a final vote for slot {slot}, got {votes:?}"
+        );
     }
 
-    #[tokio::test]
-    async fn notar_out_of_order() {
-        let ctx = start_votor().await;
+    #[test]
+    fn notar_out_of_order() {
+        let mut ctx = setup();
         let (slot1, hash1) = (Slot::genesis().next(), Hash::random_for_test());
         let (slot2, hash2) = (slot1.next(), Hash::random_for_test());
 
-        // give later block to votor first
-        ctx.blockstore_tx
-            .send(BlockstoreEvent::FirstShred(slot2))
-            .await
-            .unwrap();
+        // give later block to votor first: no vote yet
+        ctx.state
+            .handle_blockstore_event(BlockstoreEvent::FirstShred(slot2));
         let block_info = BlockInfo {
             hash: hash2.into(),
             parent: (slot1, hash1.clone().into()),
         };
-        ctx.blockstore_tx
-            .send(BlockstoreEvent::Block {
-                slot: slot2,
-                block_info,
-            })
-            .await
-            .unwrap();
+        ctx.state.handle_blockstore_event(BlockstoreEvent::Block {
+            slot: slot2,
+            block_info,
+        });
+        assert!(ctx.state.take_broadcasts().is_empty());
 
-        // should not vote yet
-        assert!(
-            tokio::time::timeout(Duration::from_secs(1), ctx.other_a2a.receive())
-                .await
-                .is_err()
-        );
-
-        // now notify votor of earlier block
-        ctx.blockstore_tx
-            .send(BlockstoreEvent::FirstShred(slot1))
-            .await
-            .unwrap();
+        // now notify votor of earlier block: both blocks get notarized
+        ctx.state
+            .handle_blockstore_event(BlockstoreEvent::FirstShred(slot1));
         let block_info = BlockInfo {
             hash: hash1.into(),
             parent: genesis_block_id(),
         };
-        ctx.blockstore_tx
-            .send(BlockstoreEvent::Block {
-                slot: slot1,
-                block_info,
-            })
-            .await
-            .unwrap();
-
-        // should now see notar votes
-        for _ in 0..2 {
-            match ctx.other_a2a.receive().await.unwrap() {
-                ConsensusMessage::Vote(vote) => {
-                    assert!(matches!(vote, Vote::Notar(_)));
-                    assert!(vote.slot() == slot1 || vote.slot() == slot2);
-                }
-                m => panic!("other msg: {m:?}"),
-            };
-        }
+        ctx.state.handle_blockstore_event(BlockstoreEvent::Block {
+            slot: slot1,
+            block_info,
+        });
+        let votes = drain_votes(&mut ctx.state);
+        assert_eq!(votes.len(), 2, "expected two notar votes, got {votes:?}");
+        assert!(votes.iter().all(|v| matches!(v, Vote::Notar(_))));
+        assert!(votes.iter().any(|v| v.slot() == slot1));
+        assert!(votes.iter().any(|v| v.slot() == slot2));
     }
 
-    #[tokio::test]
-    async fn pending_block_not_notarized_after_skip() {
-        let (mut votor, ctx) = build_votor().await;
+    #[test]
+    fn pending_block_not_notarized_after_skip() {
+        let mut ctx = setup();
 
         // first slot of the second leader window; its parent is not ready yet
         let slot = Slot::new(SLOTS_PER_WINDOW);
@@ -852,28 +642,20 @@ mod tests {
             hash: Hash::random_for_test().into(),
             parent: parent.clone(),
         };
-        let block_event = BlockstoreEvent::Block { slot, block_info };
-        votor.handle_blockstore_event(block_event).await;
+        ctx.state
+            .handle_blockstore_event(BlockstoreEvent::Block { slot, block_info });
 
         // window times out: we vote skip for every slot in the window
-        let timeout_event = VotorTimeout::Timeout(slot);
-        votor.handle_timeout_event(timeout_event).await;
+        ctx.state.handle_timeout_event(VotorTimeout::Timeout(slot));
 
         // parent becomes ready late: re-checks pending blocks
-        let parent_ready_event = PoolEvent::ParentReady { slot, parent };
-        votor.handle_pool_event(parent_ready_event).await;
+        ctx.state
+            .handle_pool_event(PoolEvent::ParentReady { slot, parent }, ctx.t0);
 
-        // collect every vote broadcast for `slot` (network latency is 100ms)
-        let mut votes_for_slot = Vec::new();
-        while let Ok(Ok(msg)) =
-            tokio::time::timeout(Duration::from_millis(500), ctx.other_a2a.receive()).await
-        {
-            if let ConsensusMessage::Vote(v) = msg
-                && v.slot() == slot
-            {
-                votes_for_slot.push(v);
-            }
-        }
+        let votes_for_slot = drain_votes(&mut ctx.state)
+            .into_iter()
+            .filter(|v| v.slot() == slot)
+            .collect::<Vec<_>>();
 
         // must not notarize `slot`, which we already voted skip for
         assert!(
@@ -886,67 +668,48 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn safe_to_notar() {
-        let ctx = start_votor().await;
+    #[test]
+    fn safe_to_notar() {
+        let mut ctx = setup();
         let slot = Slot::genesis().next();
 
-        // wait for skip votes
-        for s in slot.slots_in_window() {
-            if s.is_genesis() {
-                continue;
-            }
-            if let Ok(msg) = ctx.other_a2a.receive().await {
-                match msg {
-                    ConsensusMessage::Vote(v) => assert!(matches!(v, Vote::Skip(_))),
-                    m => panic!("other msg: {m:?}"),
-                }
-            }
-        }
+        // window times out: skip votes for the non-genesis slots
+        ctx.state.handle_due_timeouts(ctx.after_genesis_window());
+        let votes = drain_votes(&mut ctx.state);
+        assert!(votes.iter().all(|v| matches!(v, Vote::Skip(_))));
 
         // vote notar-fallback after safe-to-notar
         let block = random_block_id(slot);
-        ctx.pool_tx
-            .send(PoolEvent::SafeToNotar(block.clone()))
-            .await
-            .unwrap();
-        match ctx.other_a2a.receive().await.unwrap() {
-            ConsensusMessage::Vote(v) => {
-                assert!(matches!(v, Vote::NotarFallback(_)));
-                assert_eq!(v.slot(), block.0);
-                assert_eq!(v.block_hash(), Some(&block.1));
-            }
-            m => panic!("other msg: {m:?}"),
-        }
+        ctx.state
+            .handle_pool_event(PoolEvent::SafeToNotar(block.clone()), ctx.t0);
+        let votes = drain_votes(&mut ctx.state);
+        assert_eq!(votes.len(), 1, "expected one vote, got {votes:?}");
+        assert!(matches!(votes[0], Vote::NotarFallback(_)));
+        assert_eq!(votes[0].slot(), block.0);
+        assert_eq!(votes[0].block_hash(), Some(&block.1));
     }
 
-    #[tokio::test]
-    async fn safe_to_skip() {
-        let ctx = start_votor().await;
+    #[test]
+    fn safe_to_skip() {
+        let mut ctx = setup();
         let slot = Slot::genesis().next();
-        let parent = genesis_block_id();
 
         // vote notar after seeing block
-        ctx.send_block_and_expect_notar(slot, parent).await;
+        ctx.send_block_and_expect_notar(slot, genesis_block_id());
 
         // vote skip-fallback after safe-to-skip
-        ctx.pool_tx.send(PoolEvent::SafeToSkip(slot)).await.unwrap();
-        match ctx.other_a2a.receive().await.unwrap() {
-            ConsensusMessage::Vote(v) => {
-                assert!(matches!(v, Vote::SkipFallback(_)));
-                assert_eq!(v.slot(), slot);
-            }
-            m => panic!("other msg: {m:?}"),
-        }
+        ctx.state
+            .handle_pool_event(PoolEvent::SafeToSkip(slot), ctx.t0);
+        let votes = drain_votes(&mut ctx.state);
+        assert!(
+            matches!(votes[0], Vote::SkipFallback(_)) && votes[0].slot() == slot,
+            "expected a skip-fallback vote for slot {slot}, got {votes:?}"
+        );
     }
 
-    #[tokio::test]
-    async fn prunes_to_finalized_window() {
-        let (mut votor, ctx) = build_votor().await;
-
-        // drain broadcasts so votor's sends never block on the bounded network
-        let other_a2a = ctx.other_a2a;
-        tokio::spawn(async move { while other_a2a.receive().await.is_ok() {} });
+    #[test]
+    fn prunes_to_finalized_window() {
+        let mut ctx = setup();
 
         // finalize a slot that is NOT first in its window and isn't in the genesis window
         let finalized = Slot::new(SLOTS_PER_WINDOW + 1);
@@ -958,9 +721,9 @@ mod tests {
         let highest = Slot::new(2 * SLOTS_PER_WINDOW);
         for i in 1..=highest.inner() {
             let event = BlockstoreEvent::FirstShred(Slot::new(i));
-            votor.handle_blockstore_event(event).await;
+            ctx.state.handle_blockstore_event(event);
         }
-        assert!((0..=highest.inner()).all(|i| votor.state.slots.contains_key(&Slot::new(i))));
+        assert!((0..=highest.inner()).all(|i| ctx.state.slots.contains_key(&Slot::new(i))));
 
         // finalizing a mid-window slot should drop only the slots before its window
         let Vote::Final(final_vote) =
@@ -969,21 +732,21 @@ mod tests {
             unreachable!()
         };
         let cert = Cert::Final(FinalCert::new(&[final_vote], ctx.epoch_info.validators()));
-        let event = PoolEvent::CertCreated(cert);
-        votor.handle_pool_event(event).await;
-        assert_eq!(votor.state.highest_final_cert_slot, finalized);
+        ctx.state
+            .handle_pool_event(PoolEvent::CertCreated(cert), ctx.t0);
+        assert_eq!(ctx.state.highest_final_cert_slot, finalized);
 
         // the whole finalized window is kept
-        assert!(votor.state.slots.keys().all(|s| *s >= window_start));
+        assert!(ctx.state.slots.keys().all(|s| *s >= window_start));
         for slot in window_start.slots_in_window() {
             assert!(
-                votor.state.slots.contains_key(&slot),
+                ctx.state.slots.contains_key(&slot),
                 "slot {slot} in finalized window should be retained",
             );
         }
 
         // earlier windows are dropped
-        assert!(!votor.state.slots.contains_key(&Slot::genesis()));
-        assert!(!votor.state.slots.contains_key(&window_start.prev()));
+        assert!(!ctx.state.slots.contains_key(&Slot::genesis()));
+        assert!(!ctx.state.slots.contains_key(&window_start.prev()));
     }
 }

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 use log::{debug, trace, warn};
 use wincode::{SchemaRead, SchemaWrite};
 
-use crate::consensus::{DELTA, SharedBlockstore, SharedPool, ValidatorEpochInfo};
+use crate::consensus::{DELTA, EventForwarder, SharedBlockstore, SharedPool, ValidatorEpochInfo};
 use crate::crypto::merkle::{DoubleMerkleProof, DoubleMerkleTree, SliceRoot};
 use crate::crypto::{Hash, hash};
 use crate::disseminator::rotor::{SamplingStrategy, StakeWeightedSampler};
@@ -244,6 +244,8 @@ pub struct Repair<N: Network> {
     network: N,
     sampler: StakeWeightedSampler,
     epoch_info: Arc<ValidatorEpochInfo>,
+    /// Forwards blockstore outbox events to Votor off the write lock.
+    event_forwarder: EventForwarder,
 }
 
 impl<N> Repair<N>
@@ -254,11 +256,12 @@ where
     ///
     /// Given `network` will be used for sending repair requests and receiving repair responses.
     /// Any repaired shreds will be written into the provided `blockstore`.
-    pub fn new(
+    pub(crate) fn new(
         blockstore: SharedBlockstore,
         pool: SharedPool,
         network: N,
         epoch_info: Arc<ValidatorEpochInfo>,
+        event_forwarder: EventForwarder,
     ) -> Self {
         let validators = epoch_info.epoch_info().validators().to_vec();
         let sampler = StakeWeightedSampler::new(validators);
@@ -271,6 +274,7 @@ where
             network,
             sampler,
             epoch_info,
+            event_forwarder,
         }
     }
 
@@ -436,20 +440,24 @@ where
                     return;
                 };
 
-                // store shred
-                let res = self
-                    .blockstore
-                    .write()
-                    .await
-                    .add_shred_from_repair(block_hash.clone(), validated)
-                    .await;
+                // store shred, then forward buffered events off the write lock
+                let (res, events) = {
+                    let mut blockstore = self.blockstore.write().await;
+                    let res = blockstore
+                        .add_shred_from_repair(block_hash.clone(), validated)
+                        .await;
+                    (res, blockstore.take_events())
+                };
+                self.event_forwarder.forward_blockstore_events(events).await;
                 if let Ok(Some(block_info)) = res {
                     assert_eq!(block_info.hash, *block_hash);
-                    self.pool
-                        .write()
-                        .await
-                        .add_block((*slot, block_info.hash), block_info.parent)
-                        .await;
+                    let outbox = {
+                        let mut pool = self.pool.write().await;
+                        pool.add_block((*slot, block_info.hash), block_info.parent)
+                            .await;
+                        pool.take_outbox()
+                    };
+                    self.event_forwarder.forward_pool_outbox(outbox).await;
                     debug!(
                         "successfully repaired block {} in slot {}",
                         block_hash.short_hex(),
@@ -554,17 +562,14 @@ mod tests {
 
         // set up blockstore
         let (blockstore_tx, blockstore_rx) = tokio::sync::mpsc::channel(100);
-        let blockstore: SharedBlockstore =
-            Arc::new(RwLock::new(BlockstoreImpl::new(blockstore_tx)));
+        let blockstore: SharedBlockstore = Arc::new(RwLock::new(BlockstoreImpl::new()));
 
         // set up pool
         let (pool_tx, pool_rx) = tokio::sync::mpsc::channel(100);
         let (repair_tx, repair_rx) = tokio::sync::mpsc::channel(100);
-        let pool: SharedPool = Arc::new(RwLock::new(PoolImpl::new(
-            epoch_info.clone(),
-            pool_tx,
-            repair_tx.clone(),
-        )));
+        let pool: SharedPool = Arc::new(RwLock::new(PoolImpl::new(epoch_info.clone())));
+
+        let event_forwarder = EventForwarder::new(blockstore_tx, pool_tx, repair_tx.clone());
 
         // create and start Repair instance
         let mut repair = Repair::new(
@@ -572,6 +577,7 @@ mod tests {
             pool,
             v1_repair_requester_network,
             epoch_info.clone(),
+            event_forwarder,
         );
         tokio::spawn(async move {
             repair.repair_loop(repair_rx).await;

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -18,7 +18,8 @@ use std::time::{Duration, Instant};
 use log::{debug, trace, warn};
 use wincode::{SchemaRead, SchemaWrite};
 
-use crate::consensus::{DELTA, EventForwarder, SharedBlockstore, SharedPool, ValidatorEpochInfo};
+use crate::consensus::core::Input;
+use crate::consensus::{DELTA, SharedBlockstore, ValidatorEpochInfo};
 use crate::crypto::merkle::{DoubleMerkleProof, DoubleMerkleTree, SliceRoot};
 use crate::crypto::{Hash, hash};
 use crate::disseminator::rotor::{SamplingStrategy, StakeWeightedSampler};
@@ -236,7 +237,6 @@ where
 /// This does not answer repair requests from other nodes, that is handled by [`RepairRequestHandler`].
 pub struct Repair<N: Network> {
     blockstore: SharedBlockstore,
-    pool: SharedPool,
     slice_roots: BTreeMap<(BlockId, SliceIndex), SliceRoot>,
     outstanding_requests: BTreeMap<Hash, RepairRequestType>,
     /// Expiry times of outstanding requests, earliest first (min-heap via [`Reverse`]).
@@ -244,8 +244,8 @@ pub struct Repair<N: Network> {
     network: N,
     sampler: StakeWeightedSampler,
     epoch_info: Arc<ValidatorEpochInfo>,
-    /// Forwards blockstore outbox events to Votor off the write lock.
-    event_forwarder: EventForwarder,
+    /// Feeds drained blockstore events to the consensus core.
+    inputs: tokio::sync::mpsc::Sender<Input>,
 }
 
 impl<N> Repair<N>
@@ -258,23 +258,21 @@ where
     /// Any repaired shreds will be written into the provided `blockstore`.
     pub(crate) fn new(
         blockstore: SharedBlockstore,
-        pool: SharedPool,
         network: N,
         epoch_info: Arc<ValidatorEpochInfo>,
-        event_forwarder: EventForwarder,
+        inputs: tokio::sync::mpsc::Sender<Input>,
     ) -> Self {
         let validators = epoch_info.epoch_info().validators().to_vec();
         let sampler = StakeWeightedSampler::new(validators);
         Self {
             blockstore,
-            pool,
             slice_roots: BTreeMap::new(),
             outstanding_requests: BTreeMap::new(),
             request_timeouts: BinaryHeap::new(),
             network,
             sampler,
             epoch_info,
-            event_forwarder,
+            inputs,
         }
     }
 
@@ -440,21 +438,26 @@ where
                     return;
                 };
 
-                // store shred, then forward buffered events off the write lock
+                // Store the shred, then feed the buffered events to the
+                // consensus core off the write lock. The core registers the
+                // completed block with the pool itself.
                 let (res, events) = {
                     let mut blockstore = self.blockstore.write().await;
                     let res = blockstore.add_shred_from_repair(block_hash.clone(), validated);
                     (res, blockstore.take_events())
                 };
-                self.event_forwarder.forward_blockstore_events(events).await;
+                for event in events {
+                    if self
+                        .inputs
+                        .send(Input::BlockstoreEvent(event))
+                        .await
+                        .is_err()
+                    {
+                        debug!("consensus core inbox closed, dropping input");
+                    }
+                }
                 if let Ok(Some(block_info)) = res {
                     assert_eq!(block_info.hash, *block_hash);
-                    let outbox = {
-                        let mut pool = self.pool.write().await;
-                        pool.add_block((*slot, block_info.hash), block_info.parent);
-                        pool.take_outbox()
-                    };
-                    self.event_forwarder.forward_pool_outbox(outbox).await;
                     debug!(
                         "successfully repaired block {} in slot {}",
                         block_hash.short_hex(),
@@ -510,7 +513,7 @@ mod tests {
 
     use super::*;
     use crate::ValidatorIndex;
-    use crate::consensus::{BlockstoreImpl, EpochInfo, PoolImpl};
+    use crate::consensus::{BlockstoreImpl, EpochInfo};
     use crate::crypto::merkle::GENESIS_BLOCK_HASH;
     use crate::crypto::signature::SecretKey;
     use crate::network::simulated::SimulatedNetworkCore;
@@ -558,29 +561,23 @@ mod tests {
         let epoch_info = Arc::new(ValidatorEpochInfo::new(ValidatorIndex::new(1), epoch_info));
 
         // set up blockstore
-        let (blockstore_tx, blockstore_rx) = tokio::sync::mpsc::channel(100);
         let blockstore: SharedBlockstore = Arc::new(RwLock::new(BlockstoreImpl::new()));
 
-        // set up pool
-        let (pool_tx, pool_rx) = tokio::sync::mpsc::channel(100);
+        // set up channels standing in for the driver
+        let (input_tx, input_rx) = tokio::sync::mpsc::channel(100);
         let (repair_tx, repair_rx) = tokio::sync::mpsc::channel(100);
-        let pool: SharedPool = Arc::new(RwLock::new(PoolImpl::new(epoch_info.clone())));
-
-        let event_forwarder = EventForwarder::new(blockstore_tx, pool_tx, repair_tx.clone());
 
         // create and start Repair instance
         let mut repair = Repair::new(
             Arc::clone(&blockstore),
-            pool,
             v1_repair_requester_network,
             epoch_info.clone(),
-            event_forwarder,
+            input_tx,
         );
         tokio::spawn(async move {
             repair.repair_loop(repair_rx).await;
-            // keep event receivers alive so sends from blockstore/pool don't fail
-            drop(blockstore_rx);
-            drop(pool_rx);
+            // keep the input receiver alive so sends from the repair loop don't fail
+            drop(input_rx);
         });
         let repair_request_handler =
             RepairRequestHandler::new(epoch_info, blockstore.clone(), v1_repair_responder_network);

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -443,9 +443,7 @@ where
                 // store shred, then forward buffered events off the write lock
                 let (res, events) = {
                     let mut blockstore = self.blockstore.write().await;
-                    let res = blockstore
-                        .add_shred_from_repair(block_hash.clone(), validated)
-                        .await;
+                    let res = blockstore.add_shred_from_repair(block_hash.clone(), validated);
                     (res, blockstore.take_events())
                 };
                 self.event_forwarder.forward_blockstore_events(events).await;
@@ -453,8 +451,7 @@ where
                     assert_eq!(block_info.hash, *block_hash);
                     let outbox = {
                         let mut pool = self.pool.write().await;
-                        pool.add_block((*slot, block_info.hash), block_info.parent)
-                            .await;
+                        pool.add_block((*slot, block_info.hash), block_info.parent);
                         pool.take_outbox()
                     };
                     self.event_forwarder.forward_pool_outbox(outbox).await;
@@ -774,7 +771,7 @@ mod tests {
         let mut b = ctx.blockstore.write().await;
         for slice_shreds in shreds.clone() {
             for shred in slice_shreds {
-                let _ = b.add_shred_from_dissemination(shred).await;
+                let _ = b.add_shred_from_dissemination(shred);
             }
         }
         drop(b);

--- a/tests/liveness.rs
+++ b/tests/liveness.rs
@@ -65,24 +65,24 @@ async fn liveness_test_internal(num_nodes: usize, num_crashes: usize, should_suc
     // start `num_nodes` nodes
     let nodes = create_test_nodes(num_nodes as u64);
     let mut node_cancel_tokens = Vec::new();
-    let mut pools = Vec::new();
+    let mut finalized_watches = Vec::new();
     for node in nodes {
-        pools.push(node.get_pool());
+        finalized_watches.push(node.finalized_slot());
         node_cancel_tokens.push(node.get_cancel_token());
         tokio::spawn(node.run());
     }
 
-    // spawn a thread checking pool for progress
+    // spawn a thread checking finalization progress
     let cancel_tokens = node_cancel_tokens.clone();
     let mut liveness_tester = tokio::spawn(async move {
-        let mut finalized = vec![Slot::new(0); pools.len()];
+        let mut finalized = vec![Slot::new(0); finalized_watches.len()];
         for t in 1.. {
             tokio::time::sleep(Duration::from_secs(10)).await;
-            for (i, pool) in pools.iter().enumerate() {
+            for (i, watch) in finalized_watches.iter().enumerate() {
                 if cancel_tokens[i].is_cancelled() {
                     continue;
                 }
-                let new_finalized = pool.read().await.finalized_slot();
+                let new_finalized = *watch.borrow();
                 if new_finalized <= finalized[i] {
                     panic!("no progress on node {} after {} s", i, 10 * t);
                 }


### PR DESCRIPTION
Combine PoolImpl and VotorState (plus standstill detection) into ConsensusCore, a synchronous state machine with an explicit Input/Output interface: validated votes, certs and blockstore events go in; broadcasts, repair requests, parent-ready and finalization notifications come out. A single driver task owns the core, fires its deadline ticks, and routes outputs to the I/O edges.

What this deletes:
- EventForwarder and the pool->votor / blockstore->votor channels: what used to be channel hops between tasks is now plain function calls inside ConsensusCore::handle, so event ordering is deterministic again.
- The Pool trait, SharedPool and MockPool: the pool is owned by the core, not shared behind a lock; its methods become inherent on PoolImpl.
- The Votor task and its timeout channel: the driver sleeps until ConsensusCore::next_timeout and feeds a Tick input.
- The standstill loop: absorbed into the core's tick handling.
- The pool's oneshot parent-ready waiter machinery: the driver publishes ready parents and the finalized slot on watch channels, which the block producer (and external observers, via Alpenglow::finalized_slot) observe.

The repair loop is the one task that both consumes driver outputs and feeds the core's inbox; to keep that cycle deadlock-free the driver parks repair requests in a set (deduplicating re-requests) and flushes them opportunistically instead of ever blocking on the repair channel.

Votor's decision logic is now tested synchronously and deterministically in votor.rs; cross-component behavior is covered by new core.rs and driver.rs tests. The blockstore remains lock-shared for ingest and repair serving; folding it into the core is the next step.

Step 3 of the sans-IO consensus core migration.