### PR TITLE
refactor: move blockstore into the core; repair via Input/Output

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -8,11 +8,11 @@
 //! to the different necessary network protocols.
 //!
 //! Most important component data structures defined in this module are:
-//! - [`Blockstore`] holds individual shreds and reconstructed blocks for each slot.
+//! - [`BlockstoreImpl`] holds individual shreds and reconstructed blocks for each slot.
 //! - [`PoolImpl`] holds votes and certificates for each slot.
 //! - `VotorState` handles the main voting logic.
-//! - `ConsensusCore` combines the latter two into one synchronous state
-//!   machine, driven by a single `Driver` task that performs all I/O.
+//! - `ConsensusCore` combines the three into one synchronous state machine,
+//!   driven by a single `Driver` task that performs all I/O.
 //!
 //! Some other data types for consensus are also defined here:
 //! - [`Cert`] represents a certificate of votes of a specific type.
@@ -41,16 +41,14 @@ use fastrace::Span;
 use fastrace::future::FutureExt;
 use log::{debug, trace};
 use static_assertions::const_assert;
-use tokio::sync::{RwLock, mpsc, watch};
+use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use wincode::{SchemaRead, SchemaWrite};
 
-pub use self::blockstore::{
-    AddShredError, BlockInfo, Blockstore, BlockstoreEvent, BlockstoreImpl, SharedBlockstore,
-};
+pub use self::blockstore::{AddShredError, BlockInfo, BlockstoreEvent, BlockstoreImpl};
 pub use self::cert::{Cert, CertError, NotarCert};
 use self::core::{ConsensusCore, Input};
-use self::driver::{Driver, ParentReadyMap};
+use self::driver::{CommitmentCache, DisseminatedMap, Driver, ParentReadyMap};
 pub use self::epoch_info::{EpochInfo, ValidatorEpochInfo};
 #[cfg(feature = "test-utils")]
 pub use self::pool::bench_replay_votes;
@@ -117,13 +115,14 @@ where
     /// Other validators' info.
     epoch_info: Arc<ValidatorEpochInfo>,
 
-    /// Blockstore for storing raw block data.
-    blockstore: SharedBlockstore,
     /// Inputs destined for the consensus core (driver task).
     ///
     /// A full channel back-pressures the ingest tasks; a closed one means the
     /// driver shut down, at which point remaining messages are dropped.
     inputs: mpsc::Sender<Input>,
+    /// Per-slice commitment cache read by the shred-ingest path; written by the
+    /// driver from the core's [`core::Output::SliceCommitment`] outputs.
+    commitments: CommitmentCache,
     /// Observes the highest finalized slot, published by the driver.
     finalized: watch::Receiver<Slot>,
 
@@ -190,10 +189,10 @@ where
         let (input_tx, input_rx) = mpsc::channel(1024);
         let (repair_tx, repair_rx) = mpsc::channel(1024);
         let (parent_ready_tx, parent_ready_rx) = watch::channel(ParentReadyMap::new());
+        let (disseminated_tx, disseminated_rx) = watch::channel(DisseminatedMap::new());
         let (finalized_tx, finalized_rx) = watch::channel(Slot::genesis());
+        let commitments = CommitmentCache::default();
         let all2all = Arc::new(all2all);
-
-        let blockstore: SharedBlockstore = Arc::new(RwLock::new(BlockstoreImpl::new()));
 
         let core = ConsensusCore::new(epoch_info.clone(), voting_secret_key, Instant::now());
         let driver = Driver::new(
@@ -202,7 +201,9 @@ where
             all2all.clone(),
             repair_tx,
             parent_ready_tx,
+            disseminated_tx,
             finalized_tx,
+            commitments.clone(),
             cancel_token.clone(),
         );
         let driver_handle = tokio::spawn(
@@ -213,14 +214,13 @@ where
 
         let repair_request_handler = RepairRequestHandler::new(
             epoch_info.clone(),
-            blockstore.clone(),
+            input_tx.clone(),
             repair_responder_network,
         );
         let _repair_request_handler =
             tokio::spawn(async move { repair_request_handler.run().await });
 
         let mut repair = Repair::new(
-            Arc::clone(&blockstore),
             repair_requester_network,
             epoch_info.clone(),
             input_tx.clone(),
@@ -238,9 +238,9 @@ where
             epoch_info.clone(),
             disseminator.clone(),
             txs_receiver,
-            blockstore.clone(),
             input_tx.clone(),
             parent_ready_rx,
+            disseminated_rx,
             finalized_rx.clone(),
             cancel_token.clone(),
             DELTA_BLOCK,
@@ -249,8 +249,8 @@ where
 
         Self {
             epoch_info,
-            blockstore,
             inputs: input_tx,
+            commitments,
             finalized: finalized_rx,
             block_producer,
             all2all,
@@ -363,12 +363,10 @@ where
         let slot = shred.payload().header.slot;
         let slice_index = shred.payload().header.slice_index;
         let leader_pk = self.epoch_info.epoch_info().leader(slot).pubkey;
-        // use cached commitment, if we have it, to skip signature verification
-        let cached = self
-            .blockstore
-            .read()
-            .await
-            .cached_commitment(slot, slice_index);
+        // use cached commitment, if we have it, to skip signature verification;
+        // the cache is fed by the core's `SliceCommitment` outputs (the core
+        // owns the blockstore, so this edge can no longer read it directly)
+        let cached = self.commitments.get(slot, slice_index);
         let validated = match ValidatedShred::try_new(shred, cached.as_ref(), &leader_pk) {
             Ok(v) => v,
             Err(_) => return Ok(()),
@@ -382,18 +380,9 @@ where
             return Ok(());
         }
 
-        // Ingest into the blockstore, then feed the buffered events to the
-        // consensus core *after* releasing the write lock. The core registers
-        // completed blocks with the pool itself, so no separate `add_block`
-        // call is needed here.
-        let events = {
-            let mut blockstore = self.blockstore.write().await;
-            let _ = blockstore.add_shred_from_dissemination(validated);
-            blockstore.take_events()
-        };
-        for event in events {
-            self.send_input(Input::BlockstoreEvent(event)).await;
-        }
+        // Hand the validated shred to the consensus core, which owns the
+        // blockstore, ingests it and registers any completed block with the pool.
+        self.send_input(Input::DisseminatedShred(validated)).await;
         Ok(())
     }
 }

--- a/src/consensus/block_producer.rs
+++ b/src/consensus/block_producer.rs
@@ -15,9 +15,9 @@ use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
+use crate::consensus::ValidatorEpochInfo;
 use crate::consensus::core::Input;
-use crate::consensus::driver::ParentReadyMap;
-use crate::consensus::{SharedBlockstore, ValidatorEpochInfo};
+use crate::consensus::driver::{DisseminatedMap, ParentReadyMap};
 use crate::crypto::merkle::{BlockHash, GENESIS_BLOCK_HASH};
 use crate::crypto::signature;
 use crate::network::{Network, TransactionNetwork};
@@ -38,12 +38,12 @@ pub(super) struct BlockProducer<D: Disseminator, T: Network> {
     /// Other validators' info.
     epoch_info: Arc<ValidatorEpochInfo>,
 
-    /// Blockstore for storing raw block data.
-    blockstore: SharedBlockstore,
-    /// Feeds drained blockstore events to the consensus core.
+    /// Feeds our own produced slices (and repaired shreds) to the consensus core.
     inputs: mpsc::Sender<Input>,
     /// Observes the first ready parent per window, published by the driver.
     parent_ready: watch::Receiver<ParentReadyMap>,
+    /// Observes the disseminated block hash per slot, published by the driver.
+    disseminated: watch::Receiver<DisseminatedMap>,
     /// Observes the highest finalized slot, published by the driver.
     finalized: watch::Receiver<Slot>,
 
@@ -79,9 +79,9 @@ where
         epoch_info: Arc<ValidatorEpochInfo>,
         disseminator: Arc<D>,
         txs_receiver: T,
-        blockstore: SharedBlockstore,
         inputs: mpsc::Sender<Input>,
         parent_ready: watch::Receiver<ParentReadyMap>,
+        disseminated: watch::Receiver<DisseminatedMap>,
         finalized: watch::Receiver<Slot>,
         cancel_token: CancellationToken,
         delta_block: Duration,
@@ -91,9 +91,9 @@ where
         Self {
             secret_key,
             epoch_info,
-            blockstore,
             inputs,
             parent_ready,
+            disseminated,
             finalized,
             disseminator,
             txs_receiver,
@@ -130,8 +130,8 @@ where
             // wait for ParentReady or block in previous slot
             let slot_ready = wait_for_first_slot(
                 self.parent_ready.clone(),
+                self.disseminated.clone(),
                 self.finalized.clone(),
-                self.blockstore.clone(),
                 first_slot_in_window,
             )
             .await;
@@ -373,25 +373,23 @@ where
         }
 
         // Fast path: we already have every shred and the decoded payload, so the
-        // blockstore can skip RS-decode, Merkle verification and the per-shred
-        // lock churn. The completed block hands back (slot, hash). Feed the
-        // buffered events to the consensus core after releasing the write lock;
-        // the core registers the completed block with the pool itself.
-        let (block_info, events) = {
-            let mut blockstore = self.blockstore.write().await;
-            let block_info = blockstore.add_own_slice(payload, shreds);
-            (block_info, blockstore.take_events())
+        // blockstore (owned by the consensus core) can skip RS-decode, Merkle
+        // verification and per-shred churn. Hand the slice to the core, which
+        // ingests it, registers any completed block with the pool, and replies
+        // with the reconstructed block's info once the last slice lands.
+        let (completed_tx, completed_rx) = oneshot::channel();
+        let input = Input::OwnSlice {
+            payload,
+            shreds,
+            completed: completed_tx,
         };
-        for event in events {
-            if self
-                .inputs
-                .send(Input::BlockstoreEvent(event))
-                .await
-                .is_err()
-            {
-                debug!("consensus core inbox closed, dropping input");
-            }
+        if self.inputs.send(input).await.is_err() {
+            debug!("consensus core inbox closed, aborting block production");
+            return Ok(None);
         }
+        let block_info = completed_rx
+            .await
+            .expect("consensus core should reply to own slice");
 
         if let Some(e) = first_err {
             warn!(
@@ -512,24 +510,26 @@ enum SlotReady {
 ///
 /// Ready here can mean:
 /// - the driver published a ready parent for it (Pool's `ParentReady`), OR
-/// - the blockstore has stored a block for the previous slot.
+/// - a block was disseminated for the previous slot.
 ///
-/// See [`SlotReady`] for what is returned.
+/// Both are observed on driver-published watch channels. See [`SlotReady`] for
+/// what is returned.
 async fn wait_for_first_slot(
     mut parent_ready: watch::Receiver<ParentReadyMap>,
-    finalized: watch::Receiver<Slot>,
-    blockstore: SharedBlockstore,
+    mut disseminated: watch::Receiver<DisseminatedMap>,
+    mut finalized: watch::Receiver<Slot>,
     first_slot_in_window: Slot,
 ) -> SlotReady {
     assert!(first_slot_in_window.is_start_of_window());
     if first_slot_in_window.is_genesis_window() {
         return SlotReady::Ready((Slot::genesis(), GENESIS_BLOCK_HASH));
     }
+    let last_slot_in_prev_window = first_slot_in_window.prev();
 
     // Concurrently wait for:
     // - a ready parent published by the driver,
-    // - block reconstruction in blockstore, OR
-    // - notification that a later slot was finalized.
+    // - a disseminated block for the previous slot, OR
+    // - notification that a later slot was finalized (skip this window).
     let watch_for_oneshot = parent_ready.clone();
     tokio::select! {
         res = parent_ready.wait_for(|map| map.contains_key(&first_slot_in_window)) => {
@@ -540,31 +540,20 @@ async fn wait_for_first_slot(
             }
         }
 
-        res = async {
-            let handle = tokio::spawn(async move {
-                // PERF: These are burning a CPU. Can we use async here?
-                loop {
-                    let last_slot_in_prev_window = first_slot_in_window.prev();
-                    if let Some(hash) = blockstore.read().await
-                        .disseminated_block_hash(last_slot_in_prev_window)
-                    {
-                        return Some((last_slot_in_prev_window, hash.clone()));
-                    }
-                    if *finalized.borrow() >= first_slot_in_window {
-                        return None;
-                    }
-                    sleep(Duration::from_millis(1)).await;
-                }
-            });
-            handle.await.expect("error in task")
-        } => {
+        res = disseminated.wait_for(|map| map.contains_key(&last_slot_in_prev_window)) => {
             match res {
-                None => SlotReady::Skip,
-                Some((slot, hash)) => {
+                Ok(map) => {
+                    let hash = map[&last_slot_in_prev_window].clone();
+                    let parent = (last_slot_in_prev_window, hash);
                     let rx = parent_ready_oneshot(watch_for_oneshot, first_slot_in_window);
-                    SlotReady::ParentReadyNotSeen((slot, hash), rx)
+                    SlotReady::ParentReadyNotSeen(parent, rx)
                 }
+                Err(_) => SlotReady::Skip,
             }
+        }
+
+        _ = finalized.wait_for(|slot| *slot >= first_slot_in_window) => {
+            SlotReady::Skip
         }
     }
 }
@@ -592,11 +581,7 @@ fn parent_ready_oneshot(
 mod tests {
     use std::time::Duration;
 
-    use mockall::Sequence;
-    use tokio::sync::RwLock;
-
     use super::*;
-    use crate::consensus::blockstore::MockBlockstore;
     use crate::consensus::{BlockInfo, ValidatorEpochInfo};
     use crate::crypto::Hash;
     use crate::disseminator::MockDisseminator;
@@ -604,14 +589,38 @@ mod tests {
     use crate::test_utils::{generate_validators, random_block_id};
     use crate::{Transaction, ValidatorIndex};
 
-    /// Fresh channels standing in for the driver's side of the wiring.
+    /// Channels standing in for the driver's side of the wiring.
     ///
-    /// Held (not read) for the duration of a test so the producer never
-    /// sees closed channels.
+    /// The senders/receiver are held (or driven) by the test so the producer
+    /// never sees closed channels. `input_rx` receives the producer's
+    /// [`Input::OwnSlice`] messages, which a test-supplied responder answers.
     struct DriverStandIn {
-        _input_rx: mpsc::Receiver<Input>,
-        _parent_ready_tx: watch::Sender<ParentReadyMap>,
-        _finalized_tx: watch::Sender<Slot>,
+        input_rx: mpsc::Receiver<Input>,
+        parent_ready_tx: watch::Sender<ParentReadyMap>,
+        disseminated_tx: watch::Sender<DisseminatedMap>,
+        finalized_tx: watch::Sender<Slot>,
+    }
+
+    /// Spawns a task that answers each [`Input::OwnSlice`] with the next block
+    /// info from `responses`, mirroring what the consensus core does on ingest.
+    fn spawn_own_slice_responder(
+        mut input_rx: mpsc::Receiver<Input>,
+        responses: Vec<Option<BlockInfo>>,
+    ) {
+        tokio::spawn(async move {
+            for response in responses {
+                match input_rx
+                    .recv()
+                    .await
+                    .expect("producer should send OwnSlice")
+                {
+                    Input::OwnSlice { completed, .. } => {
+                        completed.send(response).expect("producer awaits the reply");
+                    }
+                    other => panic!("expected OwnSlice, got {other:?}"),
+                }
+            }
+        });
     }
 
     #[tokio::test]
@@ -663,35 +672,59 @@ mod tests {
         assert!(payload.data.len() + MAX_TRANSACTION_SIZE + 8 > max_len);
     }
 
+    /// The driver-published watches [`wait_for_first_slot`] observes.
+    ///
+    /// Every sender is retained: a dropped watch sender makes the corresponding
+    /// `wait_for` resolve to `Err` (which `wait_for_first_slot` treats as
+    /// shutdown → `Skip`), which the live driver never triggers.
+    struct Watches {
+        parent_ready_tx: watch::Sender<ParentReadyMap>,
+        parent_ready_rx: watch::Receiver<ParentReadyMap>,
+        _disseminated_tx: watch::Sender<DisseminatedMap>,
+        disseminated_rx: watch::Receiver<DisseminatedMap>,
+        finalized_tx: watch::Sender<Slot>,
+        finalized_rx: watch::Receiver<Slot>,
+    }
+
+    /// Builds the driver watches with the given initial parent-ready map.
+    ///
+    /// The disseminated map starts empty and the finalized slot at genesis.
+    fn watches(parents: ParentReadyMap) -> Watches {
+        let (parent_ready_tx, parent_ready_rx) = watch::channel(parents);
+        let (_disseminated_tx, disseminated_rx) = watch::channel(DisseminatedMap::new());
+        let (finalized_tx, finalized_rx) = watch::channel(Slot::genesis());
+        Watches {
+            parent_ready_tx,
+            parent_ready_rx,
+            _disseminated_tx,
+            disseminated_rx,
+            finalized_tx,
+            finalized_rx,
+        }
+    }
+
     #[tokio::test]
     async fn wait_for_first_slot_genesis() {
-        let blockstore: SharedBlockstore = Arc::new(RwLock::new(MockBlockstore::new()));
-        let (_parent_ready_tx, parent_ready_rx) = watch::channel(ParentReadyMap::new());
-        let (_finalized_tx, finalized_rx) = watch::channel(Slot::genesis());
-
-        let status =
-            wait_for_first_slot(parent_ready_rx, finalized_rx, blockstore, Slot::genesis()).await;
+        let w = watches(ParentReadyMap::new());
+        let status = wait_for_first_slot(
+            w.parent_ready_rx,
+            w.disseminated_rx,
+            w.finalized_rx,
+            Slot::genesis(),
+        )
+        .await;
         assert!(matches!(status, SlotReady::Ready(_)));
     }
 
     #[tokio::test]
     async fn wait_for_first_slot_parent_already_ready() {
-        // the concurrent blockstore poll may run before the ready parent wins
-        let mut mock_blockstore = MockBlockstore::new();
-        mock_blockstore
-            .expect_disseminated_block_hash()
-            .returning(|_| None);
-        let blockstore: SharedBlockstore = Arc::new(RwLock::new(mock_blockstore));
-        let (parent_ready_tx, parent_ready_rx) = watch::channel(ParentReadyMap::new());
-        let (_finalized_tx, finalized_rx) = watch::channel(Slot::genesis());
-
         let slot = Slot::windows().nth(10).unwrap();
         let parent = (slot.prev(), GENESIS_BLOCK_HASH);
-        parent_ready_tx.send_modify(|map| {
-            map.insert(slot, parent.clone());
-        });
+        let parents = [(slot, parent.clone())].into_iter().collect();
+        let w = watches(parents);
 
-        let status = wait_for_first_slot(parent_ready_rx, finalized_rx, blockstore, slot).await;
+        let status =
+            wait_for_first_slot(w.parent_ready_rx, w.disseminated_rx, w.finalized_rx, slot).await;
         match status {
             SlotReady::Ready(p) => assert_eq!(p, parent),
             other => panic!("unexpected {other:?}"),
@@ -700,19 +733,13 @@ mod tests {
 
     #[tokio::test]
     async fn wait_for_first_slot_parent_ready_later() {
-        // the blockstore poll runs until the (delayed) parent becomes ready
-        let mut mock_blockstore = MockBlockstore::new();
-        mock_blockstore
-            .expect_disseminated_block_hash()
-            .returning(|_| None);
-        let blockstore: SharedBlockstore = Arc::new(RwLock::new(mock_blockstore));
-        let (parent_ready_tx, parent_ready_rx) = watch::channel(ParentReadyMap::new());
-        let (_finalized_tx, finalized_rx) = watch::channel(Slot::genesis());
-
         let slot = Slot::windows().nth(10).unwrap();
         let parent = (slot.prev(), GENESIS_BLOCK_HASH);
+        let w = watches(ParentReadyMap::new());
 
-        // parent becomes ready only while we are already waiting
+        // parent becomes ready only while we are already waiting (move just the
+        // sender into the task so `w` keeps the other watches alive)
+        let parent_ready_tx = w.parent_ready_tx;
         let p = parent.clone();
         tokio::spawn(async move {
             sleep(Duration::from_millis(50)).await;
@@ -721,16 +748,33 @@ mod tests {
             });
         });
 
-        let status = wait_for_first_slot(parent_ready_rx, finalized_rx, blockstore, slot).await;
+        let status =
+            wait_for_first_slot(w.parent_ready_rx, w.disseminated_rx, w.finalized_rx, slot).await;
         match status {
             SlotReady::Ready(p) => assert_eq!(p, parent),
             other => panic!("unexpected {other:?}"),
         }
     }
 
+    #[tokio::test]
+    async fn wait_for_first_slot_skips_on_finalization() {
+        let slot = Slot::windows().nth(10).unwrap();
+        let w = watches(ParentReadyMap::new());
+
+        // a later slot finalizes while we wait: the window is skipped
+        let finalized_tx = w.finalized_tx;
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(50)).await;
+            finalized_tx.send(slot).unwrap();
+        });
+
+        let status =
+            wait_for_first_slot(w.parent_ready_rx, w.disseminated_rx, w.finalized_rx, slot).await;
+        assert!(matches!(status, SlotReady::Skip));
+    }
+
     /// A bunch of boilerplate to initialize and return a [`BlockProducer`].
     fn setup(
-        blockstore: MockBlockstore,
         disseminator: MockDisseminator,
         delta_block: Duration,
         delta_first_slice: Duration,
@@ -741,12 +785,12 @@ mod tests {
         let secret_key = signature::SecretKey::new(&mut rand::rng());
         let (_, epoch_info) = generate_validators(11);
         let epoch_info = Arc::new(ValidatorEpochInfo::new(ValidatorIndex::new(0), epoch_info));
-        let blockstore: SharedBlockstore = Arc::new(RwLock::new(blockstore));
         let disseminator = Arc::new(disseminator);
         let txs_receiver = UdpNetwork::new_with_any_port();
         let cancel_token = CancellationToken::new();
         let (input_tx, input_rx) = mpsc::channel(100);
         let (parent_ready_tx, parent_ready_rx) = watch::channel(ParentReadyMap::new());
+        let (disseminated_tx, disseminated_rx) = watch::channel(DisseminatedMap::new());
         let (finalized_tx, finalized_rx) = watch::channel(Slot::genesis());
 
         let producer = BlockProducer::new(
@@ -754,18 +798,19 @@ mod tests {
             epoch_info,
             disseminator,
             txs_receiver,
-            blockstore,
             input_tx,
             parent_ready_rx,
+            disseminated_rx,
             finalized_rx,
             cancel_token,
             delta_block,
             delta_first_slice,
         );
         let stand_in = DriverStandIn {
-            _input_rx: input_rx,
-            _parent_ready_tx: parent_ready_tx,
-            _finalized_tx: finalized_tx,
+            input_rx,
+            parent_ready_tx,
+            disseminated_tx,
+            finalized_tx,
         };
         (producer, stand_in)
     }
@@ -780,25 +825,25 @@ mod tests {
             parent: (slot.prev(), hash_prev.clone()),
         };
 
-        // The producer ingests its own block one slice at a time via the fast
-        // path; a single-slice block completes on the only `add_own_slice` call.
-        let mut blockstore = MockBlockstore::new();
-        let bi = block_info.clone();
-        blockstore
-            .expect_add_own_slice()
-            .times(1)
-            .returning(move |_slice, _shreds| Some(bi.clone()));
-        blockstore.expect_take_events().returning(Vec::new);
-
         let mut disseminator = MockDisseminator::new();
         disseminator
             .expect_send()
             .returning(|_| Box::pin(async { Ok(()) }));
-        let (block_producer, _driver) = setup(
-            blockstore,
+        let (block_producer, driver) = setup(
             disseminator,
             Duration::from_micros(0),
             Duration::from_micros(0),
+        );
+
+        // The producer ingests its own block one slice at a time via the fast
+        // path; a single-slice block completes on the only `OwnSlice` input,
+        // which the core (here, our responder) answers with the block info.
+        spawn_own_slice_responder(driver.input_rx, vec![Some(block_info.clone())]);
+        // keep the driver watches alive for the duration of the test
+        let _watches = (
+            driver.parent_ready_tx,
+            driver.disseminated_tx,
+            driver.finalized_tx,
         );
 
         let ret = block_producer
@@ -824,52 +869,49 @@ mod tests {
             parent: new_parent.clone(),
         };
 
-        // NOTE: the blockstore is now sync, so the rendezvous blocks on std
-        // channels inside the mock (briefly blocking the runtime thread) and a
-        // plain OS thread plays the coordinator that reacts in between.
-        let (first_slice_finished_tx, first_slice_finished_rx) = std::sync::mpsc::channel();
-        let (start_second_slice_tx, start_second_slice_rx) = std::sync::mpsc::channel();
-
-        let mut seq = Sequence::new();
-        let mut blockstore = MockBlockstore::new();
-
-        // first slice: signal completion, then wait for the parent-ready event
-        // before the producer moves on to the second slice
-        blockstore
-            .expect_add_own_slice()
-            .times(1)
-            .in_sequence(&mut seq)
-            .return_once(move |_slice, _shreds| {
-                first_slice_finished_tx.send(()).unwrap();
-                let () = start_second_slice_rx.recv().unwrap();
-                None
-            });
-
-        // second (last) slice: block is constructed with the new parent
-        let nbi = new_block_info.clone();
-        blockstore
-            .expect_add_own_slice()
-            .times(1)
-            .in_sequence(&mut seq)
-            .returning(move |_slice, _shreds| Some(nbi.clone()));
-        blockstore.expect_take_events().returning(Vec::new);
-
         let mut disseminator = MockDisseminator::new();
         disseminator
             .expect_send()
             .returning(|_| Box::pin(async { Ok(()) }));
-        let (block_producer, _driver) = setup(
-            blockstore,
+        let (block_producer, driver) = setup(
             disseminator,
             Duration::from_micros(0),
             Duration::from_millis(0),
         );
+        let _watches = (
+            driver.parent_ready_tx,
+            driver.disseminated_tx,
+            driver.finalized_tx,
+        );
 
+        // OwnSlice responder that rendezvouses like the old blocking mock: it
+        // signals when the first slice's input arrives, waits until the parent
+        // becomes ready, then replies `None`; the second (last) slice completes
+        // the block with the new parent.
+        let (first_slice_finished_tx, first_slice_finished_rx) = oneshot::channel();
+        let (start_second_slice_tx, start_second_slice_rx) = oneshot::channel::<()>();
+        let mut input_rx = driver.input_rx;
+        let nbi = new_block_info.clone();
+        tokio::spawn(async move {
+            let Some(Input::OwnSlice { completed, .. }) = input_rx.recv().await else {
+                panic!("expected first OwnSlice");
+            };
+            first_slice_finished_tx.send(()).unwrap();
+            start_second_slice_rx.await.unwrap();
+            completed.send(None).unwrap();
+
+            let Some(Input::OwnSlice { completed, .. }) = input_rx.recv().await else {
+                panic!("expected second OwnSlice");
+            };
+            completed.send(Some(nbi)).unwrap();
+        });
+
+        // Coordinator: once the first slice is in, make the new parent ready,
+        // then let the second slice proceed.
         let (parent_ready_tx, parent_ready_rx) = oneshot::channel();
-
         let np = new_parent.clone();
-        std::thread::spawn(move || {
-            let () = first_slice_finished_rx.recv().unwrap();
+        tokio::spawn(async move {
+            first_slice_finished_rx.await.unwrap();
             parent_ready_tx.send(np).unwrap();
             start_second_slice_tx.send(()).unwrap();
         });

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -6,10 +6,8 @@
 mod slot_block_data;
 
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 use log::debug;
-use tokio::sync::RwLock;
 
 pub use self::slot_block_data::AddShredError;
 use self::slot_block_data::SlotBlockData;
@@ -59,69 +57,17 @@ impl From<&Block> for BlockInfo {
     }
 }
 
-/// Interface for the blockstore.
-///
-/// This is only used for mocking of [`BlockstoreImpl`].
-///
-/// All methods are synchronous: the blockstore is a pure state machine that
-/// performs no I/O and buffers its side-effects as [`BlockstoreEvent`]s, so no
-/// method ever needs to await (and none may, as callers invoke them under a
-/// write lock).
-#[cfg_attr(test, mockall::automock)]
-pub trait Blockstore {
-    fn add_shred_from_dissemination(
-        &mut self,
-        shred: ValidatedShred,
-    ) -> Result<Option<BlockInfo>, AddShredError>;
-    fn add_shred_from_repair(
-        &mut self,
-        hash: BlockHash,
-        shred: ValidatedShred,
-    ) -> Result<Option<BlockInfo>, AddShredError>;
-    fn add_own_slice(
-        &mut self,
-        payload: SlicePayload,
-        shreds: Box<[ValidatedShred; TOTAL_SHREDS]>,
-    ) -> Option<BlockInfo>;
-    fn flag_leader_misbehavior(&mut self, slot: Slot);
-    /// Drains and returns the [`BlockstoreEvent`]s buffered since the last call.
-    ///
-    /// The caller must forward these to Votor *after* releasing the blockstore
-    /// lock, so that a slow Votor back-pressures the ingest task instead of
-    /// jamming the lock. See `BlockstoreImpl::emit` for the rationale.
-    fn take_events(&mut self) -> Vec<BlockstoreEvent>;
-    #[expect(
-        clippy::needless_lifetimes,
-        reason = "explicit lifetime is required by mockall::automock"
-    )]
-    fn disseminated_block_hash<'a>(&'a self, slot: Slot) -> Option<&'a BlockHash>;
-    fn get_block<'a>(&'a self, block_id: &BlockId) -> Option<&'a Block>;
-    fn get_last_slice_index(&self, block_id: &BlockId) -> Option<SliceIndex>;
-    fn get_slice_root(&self, block_id: &BlockId, slice: SliceIndex) -> Option<SliceRoot>;
-    fn cached_commitment(&self, slot: Slot, slice: SliceIndex) -> Option<SliceCommitment>;
-    fn get_shred<'a>(
-        &'a self,
-        block_id: &BlockId,
-        slice_index: SliceIndex,
-        shred_index: ShredIndex,
-    ) -> Option<&'a ValidatedShred>;
-    fn create_double_merkle_proof(
-        &self,
-        block_id: &BlockId,
-        slice_index: SliceIndex,
-    ) -> Option<DoubleMerkleProof>;
-}
-
-/// Shared, lock-protected handle to a [`Blockstore`] trait object.
-pub type SharedBlockstore = Arc<RwLock<dyn Blockstore + Send + Sync>>;
-
 /// Blockstore is the fundamental data structure holding block data per slot.
+///
+/// It is a pure, synchronous state machine: it performs no I/O and buffers its
+/// side-effects as [`BlockstoreEvent`]s, drained via
+/// [`BlockstoreImpl::take_events`].
 pub struct BlockstoreImpl {
     /// Data structure holding the actual block data per slot.
     block_data: BTreeMap<Slot, SlotBlockData>,
     /// Shredders used for reconstructing blocks.
     shredders: ShredderPool<RegularShredder>,
-    /// Events buffered for Votor, drained via [`Blockstore::take_events`].
+    /// Events buffered for the consensus core, drained via [`BlockstoreImpl::take_events`].
     /// See [`Self::emit`] for why they are buffered rather than sent.
     events: Vec<BlockstoreEvent>,
 }
@@ -136,7 +82,7 @@ impl BlockstoreImpl {
     /// Initializes a new empty blockstore.
     ///
     /// The blockstore records the following [`BlockstoreEvent`]s into its outbox, to
-    /// be drained by the caller via [`Blockstore::take_events`] and forwarded to Votor:
+    /// be drained by the caller via [`BlockstoreImpl::take_events`] and forwarded to Votor:
     /// - [`BlockstoreEvent::FirstShred`] when receiving the first shred for a slot
     ///   from the block dissemination protocol
     /// - [`BlockstoreEvent::Block`] for any reconstructed block
@@ -157,8 +103,8 @@ impl BlockstoreImpl {
     /// Records a [`BlockstoreEvent`] in the outbox, returning the [`BlockInfo`] of a
     /// newly reconstructed block iff `event` is a [`BlockstoreEvent::Block`].
     ///
-    /// Events are buffered rather than sent so the caller can forward them off the
-    /// consensus core off the write lock. This matters most for the `Block`
+    /// Events are buffered rather than sent so the consensus core can route them
+    /// deterministically. This matters most for the `Block`
     /// event: dropping it would silently cost this node its vote for that block,
     /// with no retry path.
     fn emit(&mut self, event: BlockstoreEvent) -> Option<BlockInfo> {
@@ -250,12 +196,12 @@ impl BlockstoreImpl {
     }
 }
 
-impl Blockstore for BlockstoreImpl {
+impl BlockstoreImpl {
     /// Stores a new shred in the blockstore.
     ///
     /// This shred is stored in the default spot without a known block hash.
     /// For shreds obtained through repair,
-    /// [`Blockstore::add_shred_from_repair`] should be used instead.
+    /// [`BlockstoreImpl::add_shred_from_repair`] should be used instead.
     /// Compared to that function, this one checks for leader equivocation.
     ///
     /// Reconstructs the corresponding slice and block if possible and necessary.
@@ -264,7 +210,7 @@ impl Blockstore for BlockstoreImpl {
     /// Returns the block's [`BlockInfo`] on reconstruction, `None` otherwise.
     #[hotpath::measure]
     #[fastrace::trace(short_name = true)]
-    fn add_shred_from_dissemination(
+    pub fn add_shred_from_dissemination(
         &mut self,
         shred: ValidatedShred,
     ) -> Result<Option<BlockInfo>, AddShredError> {
@@ -291,7 +237,7 @@ impl Blockstore for BlockstoreImpl {
     ///
     /// This shred is stored in a spot associated with the given block`hash`.
     /// For shreds obtained through block dissemination,
-    /// [`Blockstore::add_shred_from_dissemination`] should be used instead.
+    /// [`BlockstoreImpl::add_shred_from_dissemination`] should be used instead.
     /// Compared to that function, this one does not check for leader equivocation.
     ///
     /// Reconstructs the corresponding slice and block if possible and necessary.
@@ -300,7 +246,7 @@ impl Blockstore for BlockstoreImpl {
     /// Returns the block's [`BlockInfo`] on reconstruction, `None` otherwise.
     #[hotpath::measure]
     #[fastrace::trace(short_name = true)]
-    fn add_shred_from_repair(
+    pub fn add_shred_from_repair(
         &mut self,
         hash: BlockHash,
         shred: ValidatedShred,
@@ -335,7 +281,7 @@ impl Blockstore for BlockstoreImpl {
     /// Returns the block's [`BlockInfo`] on reconstruction, `None` otherwise.
     #[hotpath::measure]
     #[fastrace::trace(short_name = true)]
-    fn add_own_slice(
+    pub fn add_own_slice(
         &mut self,
         payload: SlicePayload,
         shreds: Box<[ValidatedShred; TOTAL_SHREDS]>,
@@ -354,13 +300,13 @@ impl Blockstore for BlockstoreImpl {
     /// Flags the leader as misbehaving for `slot`, notifying Votor exactly once.
     ///
     /// Emits [`BlockstoreEvent::InvalidBlock`] the first time the slot is flagged.
-    fn flag_leader_misbehavior(&mut self, slot: Slot) {
+    pub fn flag_leader_misbehavior(&mut self, slot: Slot) {
         if self.slot_data_mut(slot).mark_leader_misbehaved() {
             self.emit(BlockstoreEvent::InvalidBlock(slot));
         }
     }
 
-    fn take_events(&mut self) -> Vec<BlockstoreEvent> {
+    pub fn take_events(&mut self) -> Vec<BlockstoreEvent> {
         std::mem::take(&mut self.events)
     }
 
@@ -369,7 +315,7 @@ impl Blockstore for BlockstoreImpl {
     /// This refers to the block we received from block dissemination.
     ///
     /// Returns `None` if we have no block or only blocks from repair.
-    fn disseminated_block_hash(&self, slot: Slot) -> Option<&BlockHash> {
+    pub fn disseminated_block_hash(&self, slot: Slot) -> Option<&BlockHash> {
         self.slot_data(slot)?
             .disseminated
             .completed
@@ -383,7 +329,7 @@ impl Blockstore for BlockstoreImpl {
     /// However, the dissminated block can only be considered if it's complete.
     ///
     /// Returns `None` if blockstore does not know a block for that hash.
-    fn get_block(&self, block_id: &BlockId) -> Option<&Block> {
+    pub fn get_block(&self, block_id: &BlockId) -> Option<&Block> {
         let block_data = self.get_block_data(block_id)?;
         if let Some((hash, block)) = block_data.completed.as_ref() {
             debug_assert_eq!(*hash, block_id.1);
@@ -396,7 +342,7 @@ impl Blockstore for BlockstoreImpl {
     /// Gives the last slice index for the given `block_id`.
     ///
     /// Returns `None` if blockstore does not know the last slice yet.
-    fn get_last_slice_index(&self, block_id: &BlockId) -> Option<SliceIndex> {
+    pub fn get_last_slice_index(&self, block_id: &BlockId) -> Option<SliceIndex> {
         let block_data = self.get_block_data(block_id)?;
         block_data.last_slice
     }
@@ -404,7 +350,7 @@ impl Blockstore for BlockstoreImpl {
     /// Gives the Merkle root for the given `slice_index` of the given `block_id`.
     ///
     /// Returns `None` if blockstore does not hold any shred for that slice.
-    fn get_slice_root(&self, block_id: &BlockId, slice_index: SliceIndex) -> Option<SliceRoot> {
+    pub fn get_slice_root(&self, block_id: &BlockId, slice_index: SliceIndex) -> Option<SliceRoot> {
         let block_data = self.get_block_data(block_id)?;
         block_data
             .shreds
@@ -418,7 +364,7 @@ impl Blockstore for BlockstoreImpl {
     ///
     /// Lets the dissemination path short-circuit verification for the same slice.
     /// This is also what allows us to detect leader equivocation.
-    fn cached_commitment(&self, slot: Slot, slice: SliceIndex) -> Option<SliceCommitment> {
+    pub fn cached_commitment(&self, slot: Slot, slice: SliceIndex) -> Option<SliceCommitment> {
         self.slot_data(slot)?
             .disseminated
             .commitment_cache
@@ -429,7 +375,7 @@ impl Blockstore for BlockstoreImpl {
     /// Gives reference to stored shred for given `block_id`, `slice_index` and `shred_index`.
     ///
     /// Returns `None` if blockstore does not hold that shred.
-    fn get_shred(
+    pub fn get_shred(
         &self,
         block_id: &BlockId,
         slice_index: SliceIndex,
@@ -443,7 +389,7 @@ impl Blockstore for BlockstoreImpl {
     /// Generates a Merkle proof for the given `slice_index` of the given `block_id`.
     ///
     /// Returns `None` if blockstore does not hold that block yet.
-    fn create_double_merkle_proof(
+    pub fn create_double_merkle_proof(
         &self,
         block_id: &BlockId,
         slice_index: SliceIndex,
@@ -500,7 +446,7 @@ mod tests {
     /// returns the [`BlockInfo`] of the reconstructed block.
     ///
     /// Reconstruction records `FirstShred` + `Block` events in the blockstore's
-    /// outbox, to be drained via [`Blockstore::take_events`].
+    /// outbox, to be drained via [`BlockstoreImpl::take_events`].
     fn store_full_block(blockstore: &mut BlockstoreImpl, sk: &SecretKey) -> BlockInfo {
         let slot = Slot::genesis().next();
         let (block_hash, _, shreds) = create_random_shredded_block(slot, 1, sk);

--- a/src/consensus/core.rs
+++ b/src/consensus/core.rs
@@ -3,24 +3,26 @@
 
 //! Synchronous consensus core state machine.
 //!
-//! [`ConsensusCore`] combines the [`PoolImpl`] and [`VotorState`] state
-//! machines (plus standstill detection) into a single deterministic transition
-//! function: [`ConsensusCore::handle`] consumes an [`Input`], advances the
-//! state, and appends the resulting [`Output`]s to a buffer. It performs no
-//! I/O, holds no locks and never awaits; all networking happens in the
-//! [`super::driver`] task and the ingest tasks feeding it.
+//! [`ConsensusCore`] combines the [`BlockstoreImpl`], [`PoolImpl`] and
+//! [`VotorState`] state machines (plus standstill detection) into a single
+//! deterministic transition function: [`ConsensusCore::handle`] consumes an
+//! [`Input`], advances the state, and appends the resulting [`Output`]s to a
+//! buffer. It performs no I/O, holds no locks and never awaits; all networking
+//! and crypto verification happens in the [`super::driver`] task and the
+//! ingest tasks feeding it.
 //!
-//! What used to flow through channels between the pool, Votor and the
-//! standstill loop is now plain function calls inside [`ConsensusCore::handle`],
-//! so event ordering is deterministic and the whole consensus logic can be
-//! driven (and tested) without a tokio runtime.
+//! What used to flow through channels between the blockstore, pool, Votor and
+//! the standstill loop is now plain function calls inside
+//! [`ConsensusCore::handle`], so event ordering is deterministic and the whole
+//! consensus logic can be driven (and tested) without a tokio runtime.
 
 use std::sync::Arc;
 use std::time::Instant;
 
-use log::{trace, warn};
+use log::{debug, trace, warn};
+use tokio::sync::oneshot;
 
-use super::blockstore::BlockstoreEvent;
+use super::blockstore::{BlockInfo, BlockstoreEvent, BlockstoreImpl};
 use super::pool::{PoolEvent, PoolImpl, PoolOutbox};
 use super::votor::VotorState;
 use super::{
@@ -28,22 +30,50 @@ use super::{
     ValidatorEpochInfo,
 };
 use crate::crypto::aggsig;
+use crate::crypto::merkle::BlockHash;
+use crate::repair::{RepairRequest, RepairResponse};
+use crate::shredder::{SliceCommitment, TOTAL_SHREDS, ValidatedShred};
+use crate::types::{SliceIndex, SlicePayload};
 use crate::{BlockId, Slot};
 
 /// Inputs consumed by [`ConsensusCore::handle`].
 ///
 /// Everything the consensus logic reacts to arrives as one of these,
-/// pre-validated by the ingest tasks (signature checks happen *before* an
-/// input is constructed, so the core never verifies crypto).
+/// pre-validated by the ingest tasks (signature and proof checks happen
+/// *before* an input is constructed, so the core never verifies crypto).
 #[derive(Debug)]
 pub(crate) enum Input {
     /// A verified vote received from another validator.
     Vote(ValidatedVote),
     /// A verified certificate received from another validator.
     Cert(ValidatedCert),
-    /// An event drained from the blockstore by an ingest task
-    /// (dissemination, repair, or own block production).
-    BlockstoreEvent(BlockstoreEvent),
+    /// A verified shred received from the block dissemination protocol.
+    DisseminatedShred(ValidatedShred),
+    /// A verified shred received in a repair response for the given block.
+    RepairedShred {
+        block_hash: BlockHash,
+        shred: ValidatedShred,
+    },
+    /// A slice of our own produced block (leader fast path).
+    ///
+    /// The core replies on `completed` with the reconstructed block's info
+    /// once the last slice arrives (`None` before that); the block producer
+    /// awaits this to pace block production.
+    OwnSlice {
+        payload: SlicePayload,
+        shreds: Box<[ValidatedShred; TOTAL_SHREDS]>,
+        completed: oneshot::Sender<Option<BlockInfo>>,
+    },
+    /// A repair request from a validated peer, answered from the blockstore.
+    ///
+    /// The core builds the response synchronously and sends it back on `reply`;
+    /// the responder task then writes it to the requesting peer's socket. This
+    /// mirrors [`Input::OwnSlice`] and keeps the responder socket owned by its
+    /// task rather than split across the driver.
+    RepairRequest {
+        request: RepairRequest,
+        reply: oneshot::Sender<RepairResponse>,
+    },
     /// The clock advanced to [`ConsensusCore::next_timeout`].
     Tick,
 }
@@ -64,13 +94,26 @@ pub(crate) enum Output {
     ParentReady { slot: Slot, parent: BlockId },
     /// A new highest slot was finalized.
     Finalized(Slot),
+    /// A commitment for this slice is now cached; the shred ingest edge can
+    /// skip signature verification for further shreds of the same slice.
+    SliceCommitment {
+        slot: Slot,
+        slice: SliceIndex,
+        commitment: SliceCommitment,
+    },
+    /// The disseminated block for `slot` completed reconstruction.
+    ///
+    /// Observed by the block producer to detect a block in the previous slot.
+    BlockDisseminated { slot: Slot, hash: BlockHash },
 }
 
 /// The consensus protocol as a synchronous state machine.
 ///
-/// Owns the vote/cert pool and the voting logic outright — no locks, no
-/// channels. Mutations enter exclusively through [`Self::handle`].
+/// Owns the blockstore, the vote/cert pool and the voting logic outright —
+/// no locks, no channels. Mutations enter exclusively through [`Self::handle`].
 pub(crate) struct ConsensusCore {
+    /// Blockstore holding shreds and reconstructed blocks.
+    blockstore: BlockstoreImpl,
     /// Pool of votes and certificates.
     pool: PoolImpl,
     /// Voting state machine.
@@ -83,7 +126,8 @@ pub(crate) struct ConsensusCore {
 }
 
 impl ConsensusCore {
-    /// Creates a new consensus core with an empty pool and fresh voting state.
+    /// Creates a new consensus core with an empty blockstore and pool and
+    /// fresh voting state.
     ///
     /// Votor timeouts for the genesis window and the standstill deadline are
     /// scheduled relative to `now`.
@@ -94,6 +138,7 @@ impl ConsensusCore {
     ) -> Self {
         let own_id = epoch_info.own_id();
         Self {
+            blockstore: BlockstoreImpl::new(),
             pool: PoolImpl::new(epoch_info),
             votor: VotorState::new(own_id, voting_key, now),
             finalized_slot: Slot::genesis(),
@@ -121,15 +166,48 @@ impl ConsensusCore {
                 }
                 self.drain_pool(now, out);
             }
-            Input::BlockstoreEvent(event) => {
-                // a completed block is registered with the pool, which needs the
-                // parent info for its parent-ready and safe-to-notar tracking
-                if let BlockstoreEvent::Block { slot, block_info } = &event {
-                    self.pool
-                        .add_block((*slot, block_info.hash.clone()), block_info.parent.clone());
+            Input::DisseminatedShred(shred) => {
+                let slot = shred.payload().header.slot;
+                let slice = shred.payload().header.slice_index;
+                let _ = self.blockstore.add_shred_from_dissemination(shred);
+                // Publish the commitment cached for this slice, if any, so the
+                // ingest edge can skip verifying further shreds of the slice.
+                // PERF: re-published per shred; the edge cache insert is cheap.
+                if let Some(commitment) = self.blockstore.cached_commitment(slot, slice) {
+                    out.push(Output::SliceCommitment {
+                        slot,
+                        slice,
+                        commitment,
+                    });
                 }
-                self.votor.handle_blockstore_event(event);
-                self.drain_pool(now, out);
+                self.drain_blockstore(true, now, out);
+            }
+            Input::RepairedShred { block_hash, shred } => {
+                let res = self
+                    .blockstore
+                    .add_shred_from_repair(block_hash.clone(), shred);
+                if let Ok(Some(block_info)) = &res {
+                    // trusted local invariant: repair stores under the requested hash
+                    assert_eq!(block_info.hash, block_hash);
+                    debug!("successfully repaired block {}", block_hash.short_hex());
+                }
+                self.drain_blockstore(false, now, out);
+            }
+            Input::OwnSlice {
+                payload,
+                shreds,
+                completed,
+            } => {
+                let block_info = self.blockstore.add_own_slice(payload, shreds);
+                // the block producer paces block production on this reply;
+                // it may have shut down already, so a send error is fine
+                let _ = completed.send(block_info);
+                self.drain_blockstore(true, now, out);
+            }
+            Input::RepairRequest { request, reply } => {
+                let response = request.build_response(&self.blockstore);
+                // the responder task may have shut down; a send error is fine
+                let _ = reply.send(response);
             }
             Input::Tick => {
                 self.votor.handle_due_timeouts(now);
@@ -141,6 +219,29 @@ impl ConsensusCore {
                 }
             }
         }
+    }
+
+    /// Drains the blockstore's buffered events, registering completed blocks
+    /// with the pool and feeding all events through Votor.
+    ///
+    /// `disseminated` says whether the triggering input came from the
+    /// dissemination path (including own slices); only then is a completed
+    /// block surfaced as [`Output::BlockDisseminated`].
+    fn drain_blockstore(&mut self, disseminated: bool, now: Instant, out: &mut Vec<Output>) {
+        for event in self.blockstore.take_events() {
+            if let BlockstoreEvent::Block { slot, block_info } = &event {
+                self.pool
+                    .add_block((*slot, block_info.hash.clone()), block_info.parent.clone());
+                if disseminated {
+                    out.push(Output::BlockDisseminated {
+                        slot: *slot,
+                        hash: block_info.hash.clone(),
+                    });
+                }
+            }
+            self.votor.handle_blockstore_event(event);
+        }
+        self.drain_pool(now, out);
     }
 
     /// Returns the deadline at which [`Input::Tick`] must be fed next.
@@ -171,7 +272,12 @@ impl ConsensusCore {
     /// the block producer), then Votor's queued broadcasts are drained.
     fn apply_pool_outbox(&mut self, outbox: PoolOutbox, now: Instant, out: &mut Vec<Output>) {
         for block_id in outbox.repairs {
-            out.push(Output::RequestRepair(block_id));
+            // suppress repair for blocks we have already reconstructed; the
+            // blockstore lives here now, so the repair loop no longer needs to
+            // read it to make this check (as it used to in `repair_block`)
+            if self.blockstore.get_block(&block_id).is_none() {
+                out.push(Output::RequestRepair(block_id));
+            }
         }
         for event in outbox.votor_events {
             if let PoolEvent::ParentReady { slot, parent } = &event {
@@ -194,20 +300,26 @@ impl ConsensusCore {
                 .map(Output::Broadcast),
         );
     }
+
+    /// Read access to the owned blockstore, for tests and repair-serving assertions.
+    #[cfg(test)]
+    pub(crate) fn blockstore(&self) -> &BlockstoreImpl {
+        &self.blockstore
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
-    use super::super::blockstore::BlockInfo;
     use super::super::{Cert, EpochInfo, Vote};
     use super::*;
     use crate::ValidatorIndex;
-    use crate::crypto::Hash;
     use crate::crypto::aggsig::SecretKey;
     use crate::crypto::merkle::GENESIS_BLOCK_HASH;
-    use crate::test_utils::generate_validators;
+    use crate::crypto::signature;
+    use crate::repair::RepairRequestType;
+    use crate::test_utils::{create_random_shredded_block, generate_validators};
     use crate::types::Slot;
 
     struct TestContext {
@@ -249,6 +361,50 @@ mod tests {
         }
     }
 
+    /// The blockstore now lives inside the core: feeding a full block's shreds
+    /// via the dissemination path reconstructs it and surfaces the completion
+    /// as an output (with a commitment cached for the ingest edge).
+    #[test]
+    fn disseminated_shreds_reconstruct_block_in_core() {
+        let mut ctx = setup();
+        let leader_sk = signature::SecretKey::new(&mut rand::rng());
+        let slot = Slot::genesis().next();
+        let (block_hash, _tree, shreds) = create_random_shredded_block(slot, 1, &leader_sk);
+
+        let mut outputs = Vec::new();
+        for shred in shreds.into_iter().flatten() {
+            outputs.extend(ctx.handle(Input::DisseminatedShred(shred)));
+        }
+
+        assert!(
+            outputs.iter().any(|o| matches!(
+                o,
+                Output::BlockDisseminated { slot: s, hash } if *s == slot && hash == &block_hash
+            )),
+            "expected a BlockDisseminated output, got {outputs:?}"
+        );
+        assert!(
+            outputs
+                .iter()
+                .any(|o| matches!(o, Output::SliceCommitment { slot: s, .. } if *s == slot)),
+            "expected a SliceCommitment output, got {outputs:?}"
+        );
+    }
+
+    /// A repair request for a block we do not have is answered with a Nack,
+    /// built from the core's blockstore and returned on the reply channel.
+    #[tokio::test]
+    async fn repair_request_for_unknown_block_nacks() {
+        let mut ctx = setup();
+        let req_type = RepairRequestType::LastSliceRoot((Slot::new(1), GENESIS_BLOCK_HASH));
+        let request = RepairRequest::new_for_test(ValidatorIndex::new(1), req_type.clone());
+        let (reply, reply_rx) = oneshot::channel();
+        ctx.handle(Input::RepairRequest { request, reply });
+
+        let response = reply_rx.await.expect("core should reply to repair request");
+        assert!(matches!(response, RepairResponse::Nack(rt) if rt == req_type));
+    }
+
     /// A notarization quorum produces a cert that is broadcast as an output.
     #[test]
     fn vote_quorum_produces_cert_broadcast() {
@@ -263,29 +419,6 @@ mod tests {
                 .any(|o| matches!(o, Output::Broadcast(ConsensusMessage::Cert(Cert::Notar(_))))),
             "expected a notar cert broadcast, got {outputs:?}"
         );
-    }
-
-    /// A reconstructed block is registered with the pool: once its parent is
-    /// certified, the safe-to-notar machinery can request its repair or notify
-    /// Votor without any external `add_block` call.
-    #[test]
-    fn block_event_registers_block_with_pool() {
-        let mut ctx = setup();
-        let slot = Slot::genesis().next();
-        let block_info = BlockInfo {
-            hash: Hash::random_for_test().into(),
-            parent: (Slot::genesis(), GENESIS_BLOCK_HASH),
-        };
-        let event = BlockstoreEvent::Block { slot, block_info };
-        ctx.handle(Input::BlockstoreEvent(event));
-        assert_eq!(ctx.core.pool.parents_ready(slot), &[]);
-        // the pool saw the block: a notar quorum for it now triggers
-        // finalization tracking through the registered parent link
-        let mut outputs = Vec::new();
-        for v in 0..7 {
-            outputs.extend(ctx.handle(ctx.notar_vote(Slot::genesis(), v)));
-        }
-        assert!(!outputs.is_empty());
     }
 
     /// Without finalization progress, a tick past the standstill deadline

--- a/src/consensus/driver.rs
+++ b/src/consensus/driver.rs
@@ -10,8 +10,9 @@
 //!
 //! - [`Output::Broadcast`] → best-effort [`All2All`] broadcast, inline
 //! - [`Output::RequestRepair`] → the repair loop's channel
-//! - [`Output::ParentReady`] / [`Output::Finalized`] → watch channels observed
-//!   by the block producer and external callers
+//! - [`Output::ParentReady`] / [`Output::Finalized`] / [`Output::BlockDisseminated`]
+//!   → watch channels observed by the block producer and external callers
+//! - [`Output::SliceCommitment`] → the shred-ingest [`CommitmentCache`]
 //!
 //! The repair loop both consumes repair requests from this task *and* feeds
 //! reconstructed blocks back into the inbox, forming the one cycle in the task
@@ -20,7 +21,7 @@
 //! channel has capacity.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use log::warn;
@@ -28,10 +29,49 @@ use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use super::core::{ConsensusCore, Input, Output};
+use crate::crypto::merkle::BlockHash;
+use crate::shredder::SliceCommitment;
+use crate::types::SliceIndex;
 use crate::{All2All, BlockId, Slot};
 
 /// First ready parent per window-start slot, published for the block producer.
 pub(crate) type ParentReadyMap = BTreeMap<Slot, BlockId>;
+
+/// Hash of the disseminated block per slot, published for the block producer.
+pub(crate) type DisseminatedMap = BTreeMap<Slot, BlockHash>;
+
+/// Edge-side cache of per-slice commitments, populated from
+/// [`Output::SliceCommitment`].
+///
+/// The shred-ingest task reads it to skip signature verification for further
+/// shreds of a slice whose commitment the core has already cached. This
+/// mirrors the blockstore's internal commitment cache, which the ingest task
+/// can no longer read directly now that the blockstore lives inside the core.
+///
+/// NOTE: entries are never evicted, matching the blockstore itself (whose
+/// `prune` has no production caller yet). When blockstore pruning is wired up,
+/// this cache should be pruned alongside it.
+#[derive(Clone, Default)]
+pub(crate) struct CommitmentCache {
+    inner: Arc<Mutex<BTreeMap<(Slot, SliceIndex), SliceCommitment>>>,
+}
+
+impl CommitmentCache {
+    /// Returns the cached commitment for `(slot, slice)`, if any.
+    #[must_use]
+    pub(crate) fn get(&self, slot: Slot, slice: SliceIndex) -> Option<SliceCommitment> {
+        self.lock().get(&(slot, slice)).copied()
+    }
+
+    /// Caches `commitment` for `(slot, slice)`.
+    fn insert(&self, slot: Slot, slice: SliceIndex, commitment: SliceCommitment) {
+        self.lock().insert((slot, slice), commitment);
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, BTreeMap<(Slot, SliceIndex), SliceCommitment>> {
+        self.inner.lock().expect("commitment cache mutex poisoned")
+    }
+}
 
 /// Owns the [`ConsensusCore`] and its I/O edges; see the module docs.
 pub(crate) struct Driver<A: All2All> {
@@ -49,20 +89,27 @@ pub(crate) struct Driver<A: All2All> {
     pending_repairs: BTreeSet<BlockId>,
     /// Publishes the first ready parent per window, keyed by window-start slot.
     parent_ready: watch::Sender<ParentReadyMap>,
+    /// Publishes the disseminated block hash per slot.
+    disseminated: watch::Sender<DisseminatedMap>,
     /// Publishes the highest finalized slot.
     finalized: watch::Sender<Slot>,
+    /// Shared with the shred-ingest task; updated on [`Output::SliceCommitment`].
+    commitments: CommitmentCache,
     /// Indicates whether the node is shutting down.
     cancel_token: CancellationToken,
 }
 
 impl<A: All2All> Driver<A> {
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         core: ConsensusCore,
         inbox: mpsc::Receiver<Input>,
         all2all: Arc<A>,
         repairs: mpsc::Sender<BlockId>,
         parent_ready: watch::Sender<ParentReadyMap>,
+        disseminated: watch::Sender<DisseminatedMap>,
         finalized: watch::Sender<Slot>,
+        commitments: CommitmentCache,
         cancel_token: CancellationToken,
     ) -> Self {
         Self {
@@ -72,7 +119,9 @@ impl<A: All2All> Driver<A> {
             repairs,
             pending_repairs: BTreeSet::new(),
             parent_ready,
+            disseminated,
             finalized,
+            commitments,
             cancel_token,
         }
     }
@@ -141,12 +190,26 @@ impl<A: All2All> Driver<A> {
                     map.entry(slot).or_insert(parent);
                 });
             }
+            Output::BlockDisseminated { slot, hash } => {
+                self.disseminated.send_modify(|map| {
+                    map.entry(slot).or_insert(hash);
+                });
+            }
+            Output::SliceCommitment {
+                slot,
+                slice,
+                commitment,
+            } => {
+                self.commitments.insert(slot, slice, commitment);
+            }
             Output::Finalized(slot) => {
                 // prune windows at/below the finalized slot's window start;
-                // the block producer no longer needs their parents
+                // the block producer no longer needs their parents or blocks
                 let window_start = slot.first_slot_in_window();
                 self.parent_ready
                     .send_modify(|map| map.retain(|s, _| *s > window_start));
+                self.disseminated
+                    .send_modify(|map| map.retain(|s, _| *s >= window_start));
                 let _ = self.finalized.send(slot);
             }
         }
@@ -188,6 +251,7 @@ mod tests {
         let epoch_info = Arc::new(ValidatorEpochInfo::new(ValidatorIndex::new(0), epoch_info));
         let core = ConsensusCore::new(epoch_info, sks[0].clone(), Instant::now());
         let (parent_ready_tx, _) = watch::channel(ParentReadyMap::new());
+        let (disseminated_tx, _) = watch::channel(DisseminatedMap::new());
         let (finalized_tx, _) = watch::channel(Slot::genesis());
         Driver::new(
             core,
@@ -195,7 +259,9 @@ mod tests {
             all2all,
             repairs,
             parent_ready_tx,
+            disseminated_tx,
             finalized_tx,
+            CommitmentCache::default(),
             CancellationToken::new(),
         )
     }

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -16,10 +16,11 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use log::{debug, trace, warn};
+use tokio::sync::{mpsc, oneshot};
 use wincode::{SchemaRead, SchemaWrite};
 
 use crate::consensus::core::Input;
-use crate::consensus::{DELTA, SharedBlockstore, ValidatorEpochInfo};
+use crate::consensus::{BlockstoreImpl, DELTA, ValidatorEpochInfo};
 use crate::crypto::merkle::{DoubleMerkleProof, DoubleMerkleTree, SliceRoot};
 use crate::crypto::{Hash, hash};
 use crate::disseminator::rotor::{SamplingStrategy, StakeWeightedSampler};
@@ -65,6 +66,68 @@ pub struct RepairRequest {
     req_type: RepairRequestType,
 }
 
+impl RepairRequest {
+    /// The validator that sent this request.
+    #[must_use]
+    pub(crate) fn sender(&self) -> ValidatorIndex {
+        self.sender
+    }
+
+    /// Builds a response to this request from `blockstore`.
+    ///
+    /// Returns the requested data if the blockstore holds it, otherwise a
+    /// [`RepairResponse::Nack`] so the requester can immediately try another
+    /// peer. Called by [`crate::consensus`]'s core, which owns the blockstore.
+    #[must_use]
+    pub(crate) fn build_response(&self, blockstore: &BlockstoreImpl) -> RepairResponse {
+        self.try_build_response(blockstore)
+            .unwrap_or_else(|| RepairResponse::Nack(self.req_type.clone()))
+    }
+
+    /// Tries to build a positive response for this request.
+    ///
+    /// Returns `None` if the requested data is not available in the blockstore.
+    fn try_build_response(&self, blockstore: &BlockstoreImpl) -> Option<RepairResponse> {
+        match &self.req_type {
+            RepairRequestType::LastSliceRoot(block_id) => {
+                let last_slice = blockstore.get_last_slice_index(block_id)?;
+                let root = blockstore.get_slice_root(block_id, last_slice)?;
+                let proof = blockstore.create_double_merkle_proof(block_id, last_slice)?;
+                Some(RepairResponse::LastSliceRoot(
+                    self.req_type.clone(),
+                    last_slice,
+                    root,
+                    proof,
+                ))
+            }
+            RepairRequestType::SliceRoot(block_id, slice) => {
+                let root = blockstore.get_slice_root(block_id, *slice)?;
+                let proof = blockstore.create_double_merkle_proof(block_id, *slice)?;
+                Some(RepairResponse::SliceRoot(
+                    self.req_type.clone(),
+                    root,
+                    proof,
+                ))
+            }
+            RepairRequestType::Shred(block_id, slice, shred_index) => {
+                let shred = blockstore
+                    .get_shred(block_id, *slice, *shred_index)
+                    .cloned()?;
+                Some(RepairResponse::Shred(
+                    self.req_type.clone(),
+                    shred.into_shred(),
+                ))
+            }
+        }
+    }
+
+    /// Constructs a request as if received from `sender`; for tests only.
+    #[cfg(test)]
+    pub(crate) fn new_for_test(sender: ValidatorIndex, req_type: RepairRequestType) -> Self {
+        Self { sender, req_type }
+    }
+}
+
 /// Response messages for the repair sub-protocol.
 ///
 /// Each response type corresponds to a specific request message type.
@@ -101,10 +164,19 @@ impl RepairResponse {
 /// Handle repair requests from other nodes.
 ///
 /// This is separated from [`Repair`] to handle repair requests and responses on separate sockets and tokio tasks.
-/// This allows us to prioritise repairing blocks for ourselves over serving repair requests for other nodes.
+/// The blockstore lives inside the consensus core, so this handler forwards each
+/// (validated) request to the core as an `Input::RepairRequest` and writes the
+/// core's reply back to the requesting peer.
+///
+/// NOTE: serving requests now shares the core's single-threaded inbox with
+/// consensus processing, rather than the dedicated read-lock the previous
+/// design used. Repair serving is network-bound and not latency-critical, so
+/// this is acceptable, but if it ever shows up in `performance_test` the core
+/// could grow a priority lane for serve requests.
 pub struct RepairRequestHandler<N: Network> {
     epoch_info: Arc<ValidatorEpochInfo>,
-    blockstore: SharedBlockstore,
+    /// Feeds validated repair requests to the consensus core.
+    inputs: mpsc::Sender<Input>,
     network: N,
 }
 
@@ -115,23 +187,23 @@ where
     /// Creates a new repair request handler instance.
     ///
     /// Given `network` instance will be used for receiving repair requests and sending repair responses.
-    /// The blockstore will be used to handle the repair requests.
-    pub fn new(
+    /// Requests are answered by the consensus core, reached via `inputs`.
+    pub(crate) fn new(
         epoch_info: Arc<ValidatorEpochInfo>,
-        blockstore: SharedBlockstore,
+        inputs: mpsc::Sender<Input>,
         network: N,
     ) -> Self {
         Self {
             epoch_info,
-            blockstore,
+            inputs,
             network,
         }
     }
 
     /// Main loop of the repair request handler.
     ///
-    /// Listens for repair requests on `self.network`.
-    /// Looks up the corresponding data in `self.blockstore` and sends replies.
+    /// Listens for repair requests on `self.network`, forwards each to the
+    /// consensus core, and sends the core's reply back to the requester.
     pub async fn run(&self) {
         loop {
             let request = match self.network.receive().await {
@@ -147,10 +219,11 @@ where
         }
     }
 
-    /// Tries to answer the given repair request.
+    /// Answers a repair request by asking the core to build a response.
     ///
-    /// If we have the information in blockstore, it is sent to the requester.
-    /// Otherwise, a [`RepairResponse::Nack`] is sent back to the requester.
+    /// The core reads its blockstore and replies (with the data or a
+    /// [`RepairResponse::Nack`]) on a oneshot channel; the reply is then written
+    /// to the requesting peer's socket.
     #[hotpath::measure]
     async fn answer_request(&self, request: RepairRequest) -> std::io::Result<()> {
         trace!("answering repair request: {request:?}");
@@ -158,62 +231,30 @@ where
         // drop requests from validators outside the current epoch's set,
         // otherwise `validator()` indexing in `send_response` would panic on byzantine input
         let epoch = self.epoch_info.epoch_info();
-        if request.sender.as_usize() >= epoch.validators().len() {
+        if request.sender().as_usize() >= epoch.validators().len() {
             warn!(
                 "dropping repair request from unknown validator {:?}",
-                request.sender
+                request.sender()
             );
             return Ok(());
         }
+        let sender = request.sender();
 
-        let response = self
-            .try_build_response(&request)
+        let (reply, reply_rx) = oneshot::channel();
+        if self
+            .inputs
+            .send(Input::RepairRequest { request, reply })
             .await
-            .unwrap_or_else(|| RepairResponse::Nack(request.req_type.clone()));
-        self.send_response(response, request.sender).await
-    }
-
-    /// Tries to build a positive response for the given repair request.
-    ///
-    /// Returns `None` if the requested data is not available in the blockstore.
-    async fn try_build_response(&self, request: &RepairRequest) -> Option<RepairResponse> {
-        match &request.req_type {
-            RepairRequestType::LastSliceRoot(block_id) => {
-                let blockstore = self.blockstore.read().await;
-                let last_slice = blockstore.get_last_slice_index(block_id)?;
-                let root = blockstore.get_slice_root(block_id, last_slice)?;
-                let proof = blockstore.create_double_merkle_proof(block_id, last_slice)?;
-                drop(blockstore);
-                Some(RepairResponse::LastSliceRoot(
-                    request.req_type.clone(),
-                    last_slice,
-                    root,
-                    proof,
-                ))
-            }
-            RepairRequestType::SliceRoot(block_id, slice) => {
-                let blockstore = self.blockstore.read().await;
-                let root = blockstore.get_slice_root(block_id, *slice)?;
-                let proof = blockstore.create_double_merkle_proof(block_id, *slice)?;
-                drop(blockstore);
-                Some(RepairResponse::SliceRoot(
-                    request.req_type.clone(),
-                    root,
-                    proof,
-                ))
-            }
-            RepairRequestType::Shred(block_id, slice, shred_index) => {
-                let blockstore = self.blockstore.read().await;
-                let shred = blockstore
-                    .get_shred(block_id, *slice, *shred_index)
-                    .cloned()?;
-                drop(blockstore);
-                Some(RepairResponse::Shred(
-                    request.req_type.clone(),
-                    shred.into_shred(),
-                ))
-            }
+            .is_err()
+        {
+            debug!("consensus core inbox closed, dropping repair request");
+            return Ok(());
         }
+        let Ok(response) = reply_rx.await else {
+            debug!("consensus core dropped repair reply, node shutting down");
+            return Ok(());
+        };
+        self.send_response(response, sender).await
     }
 
     #[hotpath::measure]
@@ -236,7 +277,6 @@ where
 /// This is used by the node to repair blocks that it is missing.
 /// This does not answer repair requests from other nodes, that is handled by [`RepairRequestHandler`].
 pub struct Repair<N: Network> {
-    blockstore: SharedBlockstore,
     slice_roots: BTreeMap<(BlockId, SliceIndex), SliceRoot>,
     outstanding_requests: BTreeMap<Hash, RepairRequestType>,
     /// Expiry times of outstanding requests, earliest first (min-heap via [`Reverse`]).
@@ -244,8 +284,8 @@ pub struct Repair<N: Network> {
     network: N,
     sampler: StakeWeightedSampler,
     epoch_info: Arc<ValidatorEpochInfo>,
-    /// Feeds drained blockstore events to the consensus core.
-    inputs: tokio::sync::mpsc::Sender<Input>,
+    /// Feeds repaired shreds to the consensus core.
+    inputs: mpsc::Sender<Input>,
 }
 
 impl<N> Repair<N>
@@ -254,18 +294,17 @@ where
 {
     /// Creates a new repair instance.
     ///
-    /// Given `network` will be used for sending repair requests and receiving repair responses.
-    /// Any repaired shreds will be written into the provided `blockstore`.
+    /// Given `network` will be used for sending repair requests and receiving
+    /// repair responses. Repaired shreds are fed to the consensus core via
+    /// `inputs`, which owns the blockstore they are written into.
     pub(crate) fn new(
-        blockstore: SharedBlockstore,
         network: N,
         epoch_info: Arc<ValidatorEpochInfo>,
-        inputs: tokio::sync::mpsc::Sender<Input>,
+        inputs: mpsc::Sender<Input>,
     ) -> Self {
         let validators = epoch_info.epoch_info().validators().to_vec();
         let sampler = StakeWeightedSampler::new(validators);
         Self {
-            blockstore,
             slice_roots: BTreeMap::new(),
             outstanding_requests: BTreeMap::new(),
             request_timeouts: BinaryHeap::new(),
@@ -314,16 +353,11 @@ where
     }
 
     /// Starts repair process for the block specified by `slot` and `block_hash`.
+    ///
+    /// The core suppresses repair requests for blocks it already holds (it owns
+    /// the blockstore), so this is only reached for genuinely missing blocks.
     pub async fn repair_block(&mut self, block_id: BlockId) {
         let (slot, block_hash) = &block_id;
-        if self.blockstore.read().await.get_block(&block_id).is_some() {
-            trace!(
-                "ignoring repair for block {} in slot {slot}, already have the block",
-                block_hash.short_hex()
-            );
-            return;
-        }
-
         debug!("repairing block {} in slot {slot}", block_hash.short_hex());
         let req = RepairRequestType::LastSliceRoot(block_id);
         if let Err(err) = self.send_request(req).await {
@@ -438,31 +472,14 @@ where
                     return;
                 };
 
-                // Store the shred, then feed the buffered events to the
-                // consensus core off the write lock. The core registers the
-                // completed block with the pool itself.
-                let (res, events) = {
-                    let mut blockstore = self.blockstore.write().await;
-                    let res = blockstore.add_shred_from_repair(block_hash.clone(), validated);
-                    (res, blockstore.take_events())
+                // Feed the repaired shred to the consensus core, which owns the
+                // blockstore and registers any completed block with the pool.
+                let input = Input::RepairedShred {
+                    block_hash: block_hash.clone(),
+                    shred: validated,
                 };
-                for event in events {
-                    if self
-                        .inputs
-                        .send(Input::BlockstoreEvent(event))
-                        .await
-                        .is_err()
-                    {
-                        debug!("consensus core inbox closed, dropping input");
-                    }
-                }
-                if let Ok(Some(block_info)) = res {
-                    assert_eq!(block_info.hash, *block_hash);
-                    debug!(
-                        "successfully repaired block {} in slot {}",
-                        block_hash.short_hex(),
-                        slot
-                    );
+                if self.inputs.send(input).await.is_err() {
+                    debug!("consensus core inbox closed, dropping repaired shred");
                 }
             }
         }
@@ -507,13 +524,15 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::time::Instant;
 
-    use tokio::sync::RwLock;
+    use tokio::sync::Mutex;
     use tokio::sync::mpsc::Sender;
 
     use super::*;
     use crate::ValidatorIndex;
-    use crate::consensus::{BlockstoreImpl, EpochInfo};
+    use crate::consensus::EpochInfo;
+    use crate::consensus::core::ConsensusCore;
     use crate::crypto::merkle::GENESIS_BLOCK_HASH;
     use crate::crypto::signature::SecretKey;
     use crate::network::simulated::SimulatedNetworkCore;
@@ -523,6 +542,13 @@ mod tests {
     use crate::types::Slot;
     use crate::types::slice_index::MAX_SLICES_PER_BLOCK;
 
+    /// Shared handle to the consensus core driven by the repair-test harness.
+    ///
+    /// Stands in for production's [`crate::consensus`] driver: a background task
+    /// feeds it inputs from the repair loop and request handler, and the test
+    /// injects disseminated shreds or queries the blockstore through it.
+    type SharedCore = Arc<Mutex<ConsensusCore>>;
+
     /// Test context for repair tests.
     ///
     /// Sets up a small network of 2 validators:
@@ -530,7 +556,10 @@ mod tests {
     /// - Validator 1: has repair set up, is not the leader.
     struct TestContext {
         repair_tx: Sender<BlockId>,
-        blockstore: SharedBlockstore,
+        /// Direct handle to the core's inbox, for injecting disseminated shreds.
+        input_tx: Sender<Input>,
+        /// The consensus core owning the blockstore, for assertions.
+        core: SharedCore,
         /// Validator 0's network endpoint for handling repair requests
         /// (receives [`RepairRequest`] messages, sends [`RepairResponse`] messages).
         v0_request_net: SimulatedNetwork<RepairResponse, RepairRequest>,
@@ -551,42 +580,55 @@ mod tests {
         validators[1].repair_requester_address = localhost_ip_sockaddr(2);
         validators[1].repair_responder_address = localhost_ip_sockaddr(3);
 
-        let core = Arc::new(SimulatedNetworkCore::new(1, 0.0, 0.0));
-        let v0_repair_requester_network = core.join_unlimited(ValidatorIndex::new(0)).await;
-        let v0_repair_responder_network = core.join_unlimited(ValidatorIndex::new(1)).await;
-        let v1_repair_requester_network = core.join_unlimited(ValidatorIndex::new(2)).await;
-        let v1_repair_responder_network = core.join_unlimited(ValidatorIndex::new(3)).await;
+        let net_core = Arc::new(SimulatedNetworkCore::new(1, 0.0, 0.0));
+        let v0_repair_requester_network = net_core.join_unlimited(ValidatorIndex::new(0)).await;
+        let v0_repair_responder_network = net_core.join_unlimited(ValidatorIndex::new(1)).await;
+        let v1_repair_requester_network = net_core.join_unlimited(ValidatorIndex::new(2)).await;
+        let v1_repair_responder_network = net_core.join_unlimited(ValidatorIndex::new(3)).await;
 
         let epoch_info = EpochInfo::new(validators);
         let epoch_info = Arc::new(ValidatorEpochInfo::new(ValidatorIndex::new(1), epoch_info));
 
-        // set up blockstore
-        let blockstore: SharedBlockstore = Arc::new(RwLock::new(BlockstoreImpl::new()));
-
-        // set up channels standing in for the driver
-        let (input_tx, input_rx) = tokio::sync::mpsc::channel(100);
+        // set up the consensus core (owns the blockstore) and a task that feeds
+        // it inputs from the repair loop / request handler, mirroring the driver
+        let voting_key = crate::crypto::aggsig::SecretKey::new(&mut rand::rng());
+        let core: SharedCore = Arc::new(Mutex::new(ConsensusCore::new(
+            epoch_info.clone(),
+            voting_key,
+            Instant::now(),
+        )));
+        let (input_tx, mut input_rx) = tokio::sync::mpsc::channel::<Input>(100);
         let (repair_tx, repair_rx) = tokio::sync::mpsc::channel(100);
+        {
+            let core = Arc::clone(&core);
+            tokio::spawn(async move {
+                while let Some(input) = input_rx.recv().await {
+                    // outputs (repair requests, broadcasts, ...) are not needed
+                    // by these tests, which drive the repair protocol directly
+                    let mut out = Vec::new();
+                    core.lock().await.handle(input, Instant::now(), &mut out);
+                }
+            });
+        }
 
         // create and start Repair instance
         let mut repair = Repair::new(
-            Arc::clone(&blockstore),
             v1_repair_requester_network,
             epoch_info.clone(),
-            input_tx,
+            input_tx.clone(),
         );
         tokio::spawn(async move {
             repair.repair_loop(repair_rx).await;
-            // keep the input receiver alive so sends from the repair loop don't fail
-            drop(input_rx);
         });
         let repair_request_handler =
-            RepairRequestHandler::new(epoch_info, blockstore.clone(), v1_repair_responder_network);
+            RepairRequestHandler::new(epoch_info, input_tx.clone(), v1_repair_responder_network);
         tokio::spawn(async move {
             repair_request_handler.run().await;
         });
         TestContext {
             repair_tx,
-            blockstore,
+            input_tx,
+            core,
             v0_request_net: v0_repair_responder_network,
             v0_reply_net: v0_repair_requester_network,
             leader_sk: leader_key,
@@ -690,9 +732,10 @@ mod tests {
         // relying on a fixed sleep, which is racy under CI load
         let repaired = tokio::time::timeout(Duration::from_secs(10), async {
             while ctx
-                .blockstore
-                .read()
+                .core
+                .lock()
                 .await
+                .blockstore()
                 .get_block(&block_to_repair)
                 .is_none()
             {
@@ -764,24 +807,37 @@ mod tests {
         let (block_hash, _, shreds) = create_random_shredded_block(slot, SLICES, &ctx.leader_sk);
         let block_to_repair = (slot, block_hash.clone());
 
-        // ingest the block into blockstore
-        let mut b = ctx.blockstore.write().await;
+        // ingest the block into the core's blockstore via the dissemination path
         for slice_shreds in shreds.clone() {
             for shred in slice_shreds {
-                let _ = b.add_shred_from_dissemination(shred);
+                ctx.input_tx
+                    .send(Input::DisseminatedShred(shred))
+                    .await
+                    .unwrap();
             }
         }
-        drop(b);
-        assert_eq!(
-            ctx.blockstore.read().await.disseminated_block_hash(slot),
-            Some(&block_hash)
-        );
-        assert!(
-            ctx.blockstore
-                .read()
+        // wait until the core has reconstructed the block (inputs are async)
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while ctx
+                .core
+                .lock()
                 .await
+                .blockstore()
                 .get_block(&block_to_repair)
-                .is_some()
+                .is_none()
+            {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("block should reconstruct from disseminated shreds");
+        assert_eq!(
+            ctx.core
+                .lock()
+                .await
+                .blockstore()
+                .disseminated_block_hash(slot),
+            Some(&block_hash)
         );
 
         // request last slice root to learn how many slices there are
@@ -802,9 +858,10 @@ mod tests {
         assert_eq!(last_slice.inner(), SLICES - 1);
         assert_eq!(&root, shreds[last_slice.inner()][0].slice_root());
         let correct_proof = ctx
-            .blockstore
-            .read()
+            .core
+            .lock()
             .await
+            .blockstore()
             .create_double_merkle_proof(&block_to_repair, last_slice)
             .unwrap();
         assert_eq!(proof, correct_proof);
@@ -825,9 +882,10 @@ mod tests {
             assert_eq!(req_type, request.req_type);
             assert_eq!(&root, shreds[slice.inner()][0].slice_root());
             let correct_proof = ctx
-                .blockstore
-                .read()
+                .core
+                .lock()
                 .await
+                .blockstore()
                 .create_double_merkle_proof(&block_to_repair, slice)
                 .unwrap();
             assert_eq!(proof, correct_proof);


### PR DESCRIPTION
The blockstore was the last piece of consensus state living behind a shared lock (SharedBlockstore = Arc<RwLock<dyn Blockstore>>). Move it inside ConsensusCore so the core owns all consensus state outright, and dissolve the Blockstore trait / mock into inherent methods on the sync BlockstoreImpl.

Shreds and repair now flow as core inputs and outputs:
- Dissemination ingest validates a shred at the edge (message loop) and feeds Input::DisseminatedShred; the core ingests it and emits Output::BlockDisseminated / Output::SliceCommitment.
- The repair loop feeds Input::RepairedShred instead of writing a shared blockstore; the core suppresses repair requests for blocks it already holds (the check that used to live in Repair::repair_block).
- The repair *request handler* forwards Input::RepairRequest with a oneshot reply and writes the core's response back to the peer, so the responder socket stays owned by its task (no network split). This does serialize repair-serving with consensus on the core's inbox — acceptable for a network-bound, non-latency-critical path; noted for a future priority lane.
- Own block production sends Input::OwnSlice and awaits the reconstructed BlockInfo on a oneshot, replacing the direct add_own_slice write.

Two edge caches replace the reads that used to hit the shared blockstore:
- CommitmentCache (driver-written, ingest-read) lets shred validation skip signature re-verification, fed by Output::SliceCommitment.
- A disseminated-blocks watch lets the block producer detect a block in the previous slot without polling the blockstore.

get_pool()/SharedPool are already gone; SharedBlockstore now follows. The full multi-node liveness suite passes.

Step 4 of the sans-IO consensus core migration.