### PR TITLE
refactor(tests): replace catch-all match arms with named variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,8 @@ todo = "warn"
 undocumented_unsafe_blocks = "warn"
 allow_attributes = "warn"
 ignore_without_reason = "warn"
+# exhaustiveness: a `_` arm covering one variant silently absorbs new ones
+match_wildcard_for_single_variants = "warn"
 # async / perf
 large_futures = "warn"
 redundant_clone = "warn"

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -896,7 +896,9 @@ mod tests {
                     assert_eq!(block_info.hash, expected_hash);
                     blocks += 1;
                 }
-                other => panic!("unexpected event: {other:?}"),
+                other @ BlockstoreEvent::InvalidBlock(_) => {
+                    panic!("unexpected event: {other:?}")
+                }
             }
         }
         assert_eq!(first_shreds, 1, "expected exactly one FirstShred event");

--- a/src/consensus/blockstore.rs
+++ b/src/consensus/blockstore.rs
@@ -896,8 +896,8 @@ mod tests {
                     assert_eq!(block_info.hash, expected_hash);
                     blocks += 1;
                 }
-                other @ BlockstoreEvent::InvalidBlock(_) => {
-                    panic!("unexpected event: {other:?}")
+                BlockstoreEvent::InvalidBlock(_) => {
+                    panic!("unexpected event: {event:?}")
                 }
             }
         }

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -520,7 +520,7 @@ mod tests {
                     assert_eq!(v.slot(), slot);
                     v
                 }
-                m => panic!("other msg: {m:?}"),
+                m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
             }
         }
     }
@@ -580,7 +580,7 @@ mod tests {
                         assert!(matches!(v, Vote::Skip(_)));
                         skipped_slots.push(v.slot());
                     }
-                    m => panic!("other msg: {m:?}"),
+                    m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
                 }
             }
         }
@@ -610,7 +610,7 @@ mod tests {
                 assert!(matches!(v, Vote::Final(_)));
                 assert_eq!(v.slot(), slot);
             }
-            m => panic!("other msg: {m:?}"),
+            m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
         }
     }
 
@@ -668,7 +668,7 @@ mod tests {
                     assert!(matches!(vote, Vote::Notar(_)));
                     assert!(vote.slot() == slot1 || vote.slot() == slot2);
                 }
-                m => panic!("other msg: {m:?}"),
+                m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
             };
         }
     }
@@ -735,7 +735,7 @@ mod tests {
             if let Ok(msg) = ctx.other_a2a.receive().await {
                 match msg {
                     ConsensusMessage::Vote(v) => assert!(matches!(v, Vote::Skip(_))),
-                    m => panic!("other msg: {m:?}"),
+                    m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
                 }
             }
         }
@@ -752,7 +752,7 @@ mod tests {
                 assert_eq!(v.slot(), block.0);
                 assert_eq!(v.block_hash(), Some(&block.1));
             }
-            m => panic!("other msg: {m:?}"),
+            m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
         }
     }
 
@@ -772,7 +772,7 @@ mod tests {
                 assert!(matches!(v, Vote::SkipFallback(_)));
                 assert_eq!(v.slot(), slot);
             }
-            m => panic!("other msg: {m:?}"),
+            m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
         }
     }
 

--- a/src/consensus/votor.rs
+++ b/src/consensus/votor.rs
@@ -520,7 +520,7 @@ mod tests {
                     assert_eq!(v.slot(), slot);
                     v
                 }
-                m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
+                msg @ ConsensusMessage::Cert(_) => panic!("other msg: {msg:?}"),
             }
         }
     }
@@ -580,7 +580,7 @@ mod tests {
                         assert!(matches!(v, Vote::Skip(_)));
                         skipped_slots.push(v.slot());
                     }
-                    m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
+                    msg @ ConsensusMessage::Cert(_) => panic!("other msg: {msg:?}"),
                 }
             }
         }
@@ -610,7 +610,7 @@ mod tests {
                 assert!(matches!(v, Vote::Final(_)));
                 assert_eq!(v.slot(), slot);
             }
-            m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
+            msg @ ConsensusMessage::Cert(_) => panic!("other msg: {msg:?}"),
         }
     }
 
@@ -668,7 +668,7 @@ mod tests {
                     assert!(matches!(vote, Vote::Notar(_)));
                     assert!(vote.slot() == slot1 || vote.slot() == slot2);
                 }
-                m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
+                msg @ ConsensusMessage::Cert(_) => panic!("other msg: {msg:?}"),
             };
         }
     }
@@ -735,7 +735,7 @@ mod tests {
             if let Ok(msg) = ctx.other_a2a.receive().await {
                 match msg {
                     ConsensusMessage::Vote(v) => assert!(matches!(v, Vote::Skip(_))),
-                    m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
+                    msg @ ConsensusMessage::Cert(_) => panic!("other msg: {msg:?}"),
                 }
             }
         }
@@ -752,7 +752,7 @@ mod tests {
                 assert_eq!(v.slot(), block.0);
                 assert_eq!(v.block_hash(), Some(&block.1));
             }
-            m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
+            msg @ ConsensusMessage::Cert(_) => panic!("other msg: {msg:?}"),
         }
     }
 
@@ -772,7 +772,7 @@ mod tests {
                 assert!(matches!(v, Vote::SkipFallback(_)));
                 assert_eq!(v.slot(), slot);
             }
-            m @ ConsensusMessage::Cert(_) => panic!("other msg: {m:?}"),
+            msg @ ConsensusMessage::Cert(_) => panic!("other msg: {msg:?}"),
         }
     }
 


### PR DESCRIPTION
Eight `_` arms matched exactly one remaining variant: seven `ConsensusMessage::Cert(_)` in votor tests and one `BlockstoreEvent::InvalidBlock(_)` in blockstore tests. Adding a variant to either enum would have been silently absorbed by the catch-all instead of failing to compile, so a new consensus message would have been asserted against as if it were a cert.

Bind the variant explicitly (`m @ ConsensusMessage::Cert(_)`) to keep the panic messages byte-identical, and enable
`clippy::match_wildcard_for_single_variants` so the pattern can't return.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved consensus test diagnostics by reporting unexpected blockstore events and certificate messages more specifically.
  * Existing vote handling and assertions remain unchanged.

* **Chores**
  * Added a Clippy warning to flag wildcard matching on single enum variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->