### PR TITLE
fix(data): point ping dataset download at renamed S3 bucket

### DIFF
--- a/download_data.sh
+++ b/download_data.sh
@@ -3,7 +3,7 @@
 cd data
 if [ ! -f ./pings-2020-07-19-2020-07-20.csv ]; then
     echo "Downloading ping dataset..."
-    wget https://wp-public.s3.amazonaws.com/pings/pings-2020-07-19-2020-07-20.csv.gz
+    wget https://wp-public-data.s3.amazonaws.com/pings/pings-2020-07-19-2020-07-20.csv.gz
     gzip -d pings-2020-07-19-2020-07-20.csv.gz
 else
     echo "data/pings-2020-07-19-2020-07-20.csv already exists"


### PR DESCRIPTION
WonderProxy renamed the bucket from `wp-public` to `wp-public-data`, so the old URL now 404s and `./download_data.sh` silently leaves `data/` empty. The latency simulations then panic on the missing CSV. Path within the bucket is unchanged; this is the same dataset, not a replacement.

Verified: downloads 50.9 MB gz -> 217 MB CSV (2.94M rows), schema still matches `PingMeasurement` (source,destination,timestamp,min,avg,max,mdev), max server id 295 < MAX_PING_SERVERS, and `ping_data` tests pass in release.